### PR TITLE
Drop Node v14 from testing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['14', '16', '18', '19', '20']
+        node: ['16', '18', '19', '20']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
-    - run: npm install
+    - run: npm ci
     - run: npm run lint
     - run: npm run build
     - run: npm run coverage


### PR DESCRIPTION
Node v14 is EOL is soon (2023-04-30) and causing issues so we've dropped slightly early. I've also reverted the CI temporary fix as it's no longer needed.