### PR TITLE
Catch empty string inputs

### DIFF
--- a/lib/classes/N2WordsAbs.mjs
+++ b/lib/classes/N2WordsAbs.mjs
@@ -38,9 +38,9 @@ export default class {
 
   /**
    *
-   * @param {number|string} value Number to be converted.
+   * @param {number|string} value Number to be convert.
    * @throws {Error} Value must be a valid number.
-   * @returns {string|undefined} Value in written format.
+   * @returns {string} Value in written format.
    */
   floatToCardinal(value) {
     if (typeof value == 'number') {
@@ -48,7 +48,7 @@ export default class {
         throw new Error('NaN is not an accepted number.');
       }
     } else if (typeof value == 'string') {
-      if (Number.isNaN(value = Number(value.trim()))) {
+      if (value.length == 0 || Number.isNaN(value = Number(value.trim()))) {
         throw new Error('"' + value + '" is not a valid number.');
       }
     } else {

--- a/lib/classes/N2WordsAbs.mjs
+++ b/lib/classes/N2WordsAbs.mjs
@@ -48,7 +48,8 @@ export default class {
         throw new Error('NaN is not an accepted number.');
       }
     } else if (typeof value == 'string') {
-      if (value.length == 0 || Number.isNaN(value = Number(value.trim()))) {
+      value = value.trim();
+      if (value.length == 0 || Number.isNaN(value = Number(value))) {
         throw new Error('"' + value + '" is not a valid number.');
       }
     } else {

--- a/lib/n2words.mjs
+++ b/lib/n2words.mjs
@@ -29,9 +29,9 @@ import n2wordsZH from './i18n/ZH.mjs';
 
 /**
  * Converts a number to written form.
- * @param {number} value The number to convert.
+ * @param {number|string} value The number to convert.
  * @param {object} [options={lang: "en"}] User options.
- * @returns {string} Resulting text value.
+ * @returns {string} Value in written format.
  */
 export default function(value, options = {lang: 'en'}) {
   switch (options.lang) {

--- a/test/tests.mjs
+++ b/test/tests.mjs
@@ -88,6 +88,11 @@ test('error on unsupported languages', t => {
   t.throws(
     () => {
       n2words(2, { lang: 'aaa' });
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
       n2words(2, 'en');
     },
     { instanceOf: Error }
@@ -98,10 +103,30 @@ test('error on invalid numbers', t => {
   t.throws(
     () => {
       n2words('foobar');
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
       n2words(false);
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
       n2words('3px');
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
       n2words(NaN);
-      n2words(' ');
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
+      n2words('');
     },
     { instanceOf: Error }
   );

--- a/test/tests.mjs
+++ b/test/tests.mjs
@@ -130,4 +130,10 @@ test('error on invalid numbers', t => {
     },
     { instanceOf: Error }
   );
+  t.throws(
+    () => {
+      n2words(' ');
+    },
+    { instanceOf: Error }
+  );
 });


### PR DESCRIPTION
As brought up in https://github.com/forzagreen/n2words/pull/84#issuecomment-1523096939 we should catch empty strings. This PR addresses that, as well as a significant testing issue.