### PR TITLE
Ability to run language/i18n tests separately

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint --config .eslintrc.json lib/ test/",
     "test": "ava --verbose",
+    "test:en": "npm run test -- -- --lang en",
     "coverage": "c8 ava",
     "build": "webpack --config webpack.config.js --progress"
   },

--- a/test/core.mjs
+++ b/test/core.mjs
@@ -1,0 +1,70 @@
+/* eslint-disable import/no-unresolved */
+/* eslint-disable node/no-missing-import */
+import test from 'ava';
+import n2words from '../lib/n2words.mjs';
+
+test('english is default', t => {
+  t.is(n2words(12), 'twelve');
+  t.is(n2words(356), 'three hundred and fifty-six');
+});
+
+test('accept valid string numbers', t => {
+  t.is(n2words('12'), 'twelve');
+  t.is(n2words('0012'), 'twelve');
+  t.is(n2words('.1'), 'zero point one');
+  t.is(n2words(' -12.6 '), 'minus twelve point six');
+});
+
+test('error on unsupported languages', t => {
+  t.throws(
+    () => {
+      n2words(2, { lang: 'aaa' });
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
+      n2words(2, 'en');
+    },
+    { instanceOf: Error }
+  );
+});
+
+test('error on invalid numbers', t => {
+  t.throws(
+    () => {
+      n2words('foobar');
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
+      n2words(false);
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
+      n2words('3px');
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
+      n2words(NaN);
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
+      n2words('');
+    },
+    { instanceOf: Error }
+  );
+  t.throws(
+    () => {
+      n2words(' ');
+    },
+    { instanceOf: Error }
+  );
+});

--- a/test/languages.mjs
+++ b/test/languages.mjs
@@ -61,79 +61,24 @@ const i18n = {
   zh: ZH,
 };
 
-Object.keys(i18n).forEach(language => {
+const parameter = process.argv[2];
+const value = process.argv[3];
+
+if (parameter == '--language' || parameter == '--lang') {
+  testLanguage(value);
+} else {
+  Object.keys(i18n).forEach(language => {
+    testLanguage(language);
+  });
+}
+
+function testLanguage(language) {
   test(language, t => {
     i18n[language].forEach(problem => {
       t.is(
-        n2words(problem[0], Object.assign({ lang: language }, problem[2])),
+        n2words(problem[0], Object.assign({lang: language}, problem[2])),
         problem[1]
       );
     });
   });
-});
-
-test('english is default', t => {
-  t.is(n2words(12), 'twelve');
-  t.is(n2words(356), 'three hundred and fifty-six');
-});
-
-test('accept valid string numbers', t => {
-  t.is(n2words('12'), 'twelve');
-  t.is(n2words('0012'), 'twelve');
-  t.is(n2words('.1'), 'zero point one');
-  t.is(n2words(' -12.6 '), 'minus twelve point six');
-});
-
-test('error on unsupported languages', t => {
-  t.throws(
-    () => {
-      n2words(2, { lang: 'aaa' });
-    },
-    { instanceOf: Error }
-  );
-  t.throws(
-    () => {
-      n2words(2, 'en');
-    },
-    { instanceOf: Error }
-  );
-});
-
-test('error on invalid numbers', t => {
-  t.throws(
-    () => {
-      n2words('foobar');
-    },
-    { instanceOf: Error }
-  );
-  t.throws(
-    () => {
-      n2words(false);
-    },
-    { instanceOf: Error }
-  );
-  t.throws(
-    () => {
-      n2words('3px');
-    },
-    { instanceOf: Error }
-  );
-  t.throws(
-    () => {
-      n2words(NaN);
-    },
-    { instanceOf: Error }
-  );
-  t.throws(
-    () => {
-      n2words('');
-    },
-    { instanceOf: Error }
-  );
-  t.throws(
-    () => {
-      n2words(' ');
-    },
-    { instanceOf: Error }
-  );
-});
+}


### PR DESCRIPTION
Initial PR to resolve #87

- Move language tests to separate file
- Move language testing logic to function
- Language tests now accepts single language parameter