### PR TITLE
use the correct Arabic negative word

### DIFF
--- a/lib/i18n/AR.mjs
+++ b/lib/i18n/AR.mjs
@@ -3,7 +3,7 @@ import AbstractLanguage from '../classes/AbstractLanguage.mjs';
 export class Arabic extends AbstractLanguage {
   constructor() {
     super({
-      negativeWord: 'ناقص',
+      negativeWord: 'سالب',
       separatorWord: 'فاصلة',
       zero: 'صفر'
     });


### PR DESCRIPTION
The Arabic word 'ناقص' is translated to the word minus in English while it is correct when talking about subtraction it's incorrect when talking about negative numbers, the better word to use is 'سالب' which means negative in Arabic