### PR TITLE
Bump to v1.16.3

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Setup Node.js v19
+    - name: Setup Node.js v20
       uses: actions/setup-node@v3
       with:
-        node-version: 19
+        node-version: 20
         registry-url: 'https://registry.npmjs.org'
 
     - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    tags-ignore:
+      - v*
+  pull_request:
 
 jobs:
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n2words",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n2words",
-      "version": "1.16.2",
+      "version": "1.16.3",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.22.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n2words",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "description": "n2words converts a numerical number into a written one, supports 27 languages and has zero dependencies.",
   "keywords": [
     "n2words",


### PR DESCRIPTION
## Changes

- Bump to `v1.16.3`
- Update _NPM Publish_ workflow from Node `v19` to `v20`
- Ignore testing on tag `v*` pushes