### PR TITLE
Bump package-lock and switch to nodenext for typings generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n2words",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n2words",
-      "version": "1.18.0",
+      "version": "1.19.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.23.9",
@@ -21,7 +21,7 @@
         "eslint": "^8.56.0",
         "eslint-plugin-ava": "^14.0.0",
         "eslint-plugin-import": "^2.29.1",
-        "eslint-plugin-jsdoc": "^46.10.1",
+        "eslint-plugin-jsdoc": "^48.0.6",
         "eslint-plugin-node": "^11.1.0",
         "microtime": "^3.1.1",
         "selenium-webdriver": "^4.17.0",
@@ -1836,9 +1836,9 @@
       }
     },
     "node_modules/@es-joy/jsdoccomment": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.41.0.tgz",
-      "integrity": "sha512-aKUhyn1QI5Ksbqcr3fFJj16p99QdjUxXAEuFst1Z47DRyoiMwivIH9MV/ARcJOCXVjPfjITciej8ZD2O/6qUmw==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.42.0.tgz",
+      "integrity": "sha512-R1w57YlVA6+YE01wch3GPYn6bCsrOV3YW/5oGGE2tmX6JcL9Nr+b5IikrjMPF+v9CV3ay+obImEdsDhovhJrzw==",
       "dev": true,
       "dependencies": {
         "comment-parser": "1.4.1",
@@ -2208,9 +2208,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.11.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
-      "integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
+      "version": "20.11.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.17.tgz",
+      "integrity": "sha512-QmgQZGWu1Yw9TDyAP9ZzpFJKynYNeOvwMJmaxABfieQoVoiVOS6MN1WSpqpRcbeA5+RW82kraAVxCCJg+780Qw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -3672,9 +3672,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.661",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.661.tgz",
-      "integrity": "sha512-AFg4wDHSOk5F+zA8aR+SVIOabu7m0e7BiJnigCvPXzIGy731XENw/lmNxTySpVFtkFEy+eyt4oHhh5FF3NjQNw==",
+      "version": "1.4.665",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.665.tgz",
+      "integrity": "sha512-UpyCWObBoD+nSZgOC2ToaIdZB0r9GhqT2WahPKiSki6ckkSuKhQNso8V2PrFcHBMleI/eqbKgVQgVC4Wni4ilw==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -4095,23 +4095,23 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "46.10.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-46.10.1.tgz",
-      "integrity": "sha512-x8wxIpv00Y50NyweDUpa+58ffgSAI5sqe+zcZh33xphD0AVh+1kqr1ombaTRb7Fhpove1zfUuujlX9DWWBP5ag==",
+      "version": "48.0.6",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-48.0.6.tgz",
+      "integrity": "sha512-LgwXOX6TWxxFYcbdVe+BJ94Kl/pgjSPYHLzqEdAMXTA1BH9WDx7iJ+9/iDajPF64LtzWX8C1mCfpbMZjJGhAOw==",
       "dev": true,
       "dependencies": {
-        "@es-joy/jsdoccomment": "~0.41.0",
+        "@es-joy/jsdoccomment": "~0.42.0",
         "are-docs-informative": "^0.0.2",
         "comment-parser": "1.4.1",
         "debug": "^4.3.4",
         "escape-string-regexp": "^4.0.0",
         "esquery": "^1.5.0",
         "is-builtin-module": "^3.2.1",
-        "semver": "^7.5.4",
+        "semver": "^7.6.0",
         "spdx-expression-parse": "^4.0.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0"
@@ -7449,9 +7449,9 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.16",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.16.tgz",
-      "integrity": "sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.17.tgz",
+      "integrity": "sha512-sh8PWc/ftMqAAdFiBu6Fy6JUOYjqDJBJvIhpfDMyHrr0Rbp5liZqd4TjtQ/RgfLjKFZb+LMx5hpml5qOWy0qvg==",
       "dev": true
     },
     "node_modules/sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "bench": "node bench.js",
     "build": "webpack --config webpack.config.js --progress",
-    "build:types": "npx -p typescript tsc lib/n2words.js dist/n2words.js --target es6 --module esnext --allowJs --declaration --emitDeclarationOnly",
+    "build:types": "npx -p typescript tsc lib/n2words.js dist/n2words.js --target es6 --module nodenext --allowJs --declaration --emitDeclarationOnly",
     "coverage": "c8 ava",
     "lint": "eslint --config .eslintrc.json lib/ test/ examples/ bench.js",
     "test": "ava --verbose",
@@ -103,7 +103,7 @@
     "eslint": "^8.56.0",
     "eslint-plugin-ava": "^14.0.0",
     "eslint-plugin-import": "^2.29.1",
-    "eslint-plugin-jsdoc": "^46.10.1",
+    "eslint-plugin-jsdoc": "^48.0.6",
     "eslint-plugin-node": "^11.1.0",
     "microtime": "^3.1.1",
     "selenium-webdriver": "^4.17.0",


### PR DESCRIPTION
- Bump package-lock.json to include version change
- Switch TypeScript typings generation from `esnext` to `nodenext` as the `moduleResolution`