### PR TITLE
Fix issue with extra leading zeros if decimal portion had zeros in value

### DIFF
--- a/lib/classes/AbstractLanguage.js
+++ b/lib/classes/AbstractLanguage.js
@@ -68,30 +68,29 @@ export default class {
   }
 
   /**
-   * Convert decimal number to a string array of cardinal numbers.
+   * Convert decimal number (processing leading zeros) to a string array of cardinal numbers.
    * @param {string} decimal Decimal string to convert.
    * @returns {string} Value in written format.
    */
   decimalToCardinal(decimal) {
     const words = [];
-    let allZero = true;
 
     // Split decimal portion into an array of characters
     const chars = decimal.split('');
 
-    // Loop through characters adding zeros to output array
-    chars.forEach(char => {
-      if (char === '0') {
-        words.push(this.zero);
-      } else {
-        allZero = false;
-      }
-    });
+    // Loop through characters adding leading zeros to words array
+    let i = 0;
+    while (i < chars.length && chars[i] === '0') {
+      words.push(this.zero);
+      i++;
+    }
 
-    if (allZero) {
+    // Prevent further processing if entire string was zeros
+    if (i === chars.length) {
       return words;
     }
 
+    // Convert remaining, combining with leading zeros, and return words array
     return words.concat(this.toCardinal(BigInt(decimal)));
   }
 

--- a/test/core.js
+++ b/test/core.js
@@ -20,6 +20,7 @@ test('accept valid string numbers', t => {
   t.is(n2words('0012'), 'twelve');
   t.is(n2words('.1'), 'zero point one');
   t.is(n2words(' -12.6 '), 'minus twelve point six');
+  t.is(n2words(' -12.606'), 'minus twelve point six hundred and six');
 });
 
 test('error on unsupported languages', t => {


### PR DESCRIPTION
As mentioned in #133, this fixes decimal values that include zeros that are not leading. I also added a test since this case had none. Please take a look below for an example of the fix.

```js
// Before
n2words(' -12.606') === 'minus twelve point zero six hundred and six'
// After
n2words(' -12.606') === 'minus twelve point six hundred and six'
```