### PR TITLE
Add separator option for fr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ typings/
 
 # JSDoc
 docs/
+
+# JetBrain generated folder
+.idea

--- a/lib/i18n/fr.js
+++ b/lib/i18n/fr.js
@@ -1,12 +1,15 @@
 import BaseLanguage from '../classes/base-language.js';
 
 export class N2WordsFR extends BaseLanguage {
+  separator;
+
   constructor(options) {
     options = Object.assign({
       negativeWord: 'moins',
       separatorWord: 'virgule',
       zero: 'zéro',
-      _region: 'FR'
+      _region: 'FR',
+      separator: ' ',
     }, options);
 
     super(options, [
@@ -49,6 +52,8 @@ export class N2WordsFR extends BaseLanguage {
       [1n, 'un'],
       [0n, 'zéro']
     ]);
+
+    this.separator = options.separator;
   }
 
   merge(current, next) { // {'cent':100}, {'vingt-cinq':25}
@@ -80,14 +85,14 @@ export class N2WordsFR extends BaseLanguage {
       if (nNumber % 10n == 1 && cNumber != 80) return { [`${cText} et ${nText}`]: cNumber + nNumber };
       return { [`${cText}-${nText}`]: cNumber + nNumber };
     }
-    if (nNumber > cNumber) return { [`${cText} ${nText}`]: cNumber * nNumber };
-    return { [`${cText} ${nText}`]: cNumber + nNumber };
+    if (nNumber > cNumber) return { [`${cText}${this.separator}${nText}`]: cNumber * nNumber };
+    return { [`${cText}${this.separator}${nText}`]: cNumber + nNumber };
   }
 }
 
 /**
  * Converts a value to cardinal (written) form.
- * @param {number|string|bigint} value Number to be convert.
+ * @param {number|string|bigint} value Number to be converted.
  * @param {object} [options] Options for class.
  * @returns {string} Value in cardinal (written) format.
  * @throws {Error} Value cannot be invalid.

--- a/lib/i18n/fr.js
+++ b/lib/i18n/fr.js
@@ -82,7 +82,7 @@ export class N2WordsFR extends BaseLanguage {
       }
     }
     if (nNumber < cNumber && cNumber < 100) {
-      if (nNumber % 10n == 1 && cNumber != 80) return { [`${cText} et ${nText}`]: cNumber + nNumber };
+      if (nNumber % 10n == 1 && cNumber != 80) return { [`${cText}${this.separator}et${this.separator}${nText}`]: cNumber + nNumber };
       return { [`${cText}-${nText}`]: cNumber + nNumber };
     }
     if (nNumber > cNumber) return { [`${cText}${this.separator}${nText}`]: cNumber * nNumber };

--- a/test/core.js
+++ b/test/core.js
@@ -82,4 +82,8 @@ test('change internal params', t => {
     lang: 'ar',
     negativeWord: 'سالب'
   }), 'سالب مائة');
+  t.is(n2words(2824, {
+    lang: 'fr',
+    separator: '-'
+  }), 'deux-mille-huit-cent-vingt-quatre');
 });

--- a/test/core.js
+++ b/test/core.js
@@ -86,4 +86,12 @@ test('change internal params', t => {
     lang: 'fr',
     separator: '-'
   }), 'deux-mille-huit-cent-vingt-quatre');
+  t.is(n2words(21_602, {
+    lang: 'fr',
+    separator: '-'
+  }), 'vingt-et-un-mille-six-cent-deux');
+  t.is(n2words(142.61, {
+    lang: 'fr',
+    separator: '-'
+  }), 'cent-quarante-deux virgule soixante-et-un');
 });


### PR DESCRIPTION
In the rectified French orthography, it is recommended to [add a hyphen between each word](https://vitrinelinguistique.oqlf.gouv.qc.ca/23494/la-typographie/nombres/ecriture-des-determinants-numeraux). (See the bottom of the page for "Rectifications de l’orthographe.")

To avoid a breaking change, the default option is still a space. To opt in to the rectified orthography, the user must add the option:
```
n2words(21_602, {
  lang: 'fr',
  separator: '-'
})
```
Not wrapping the `separatorWord` with hyphens is okay, so there are no changes there.

Tests are implemented as well.

I didn't bump the version because I thought you might want to do it yourself if this is accepted. If it's requested, I can add a commit.