### PR TITLE
Add Brazilian Portuguese (pt-BR) support

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -2,7 +2,7 @@
 
 > **Auto-generated** — Do not edit manually. Run `npm run docs:languages` to update.
 
-n2words supports **71 languages** with cardinal number conversion, 71 with ordinal support, 71 with currency support.
+n2words supports **72 languages** with cardinal number conversion, 72 with ordinal support, 72 with currency support.
 
 Language codes follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) standards.
 
@@ -64,6 +64,7 @@ Language codes follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) standards
 |`nl-NL`|Dutch (Netherlands)|[✓*](#dutch-netherlands-nl-nl)|✓|[✓*](#dutch-netherlands-nl-nl)|
 |`pa-IN`|Punjabi (India)|✓|✓|✓|
 |`pl-PL`|Polish (Poland)|[✓*](#polish-poland-pl-pl)|✓|✓|
+|`pt-BR`|Brazilian Portuguese|✓|✓|[✓*](#brazilian-portuguese-pt-br)|
 |`pt-PT`|European Portuguese|✓|✓|[✓*](#european-portuguese-pt-pt)|
 |`ro-RO`|Romanian (Romania)|[✓*](#romanian-romania-ro-ro)|✓|✓|
 |`ru-RU`|Russian (Russia)|[✓*](#russian-russia-ru-ru)|✓|[✓*](#russian-russia-ru-ru)|
@@ -102,7 +103,7 @@ Import paths use BCP 47 language codes: `n2words/en-US`, `n2words/zh-Hans-CN`, `
 
 ## Language Options
 
-34 languages support options via a second parameter. Options are passed as an object:
+35 languages support options via a second parameter. Options are passed as an object:
 
 ```js
 toCardinal(value, { optionName: value })
@@ -137,6 +138,13 @@ toCurrency(value, { optionName: value })
 |------|----|----|-------|-----------|
 |`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
 |`andWord`|cardinal|`string`|`'ו'`|Custom conjunction word|
+
+### Brazilian Portuguese (`pt-BR`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|`true`|Include "e" between major and minor units|
+|`currency`|currency|`string`|—|Currency code (e.g., 'BRL', 'USD')|
 
 ### British English (`en-GB`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2861,6 +2862,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3472,6 +3474,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4068,6 +4071,7 @@
       "integrity": "sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -4643,6 +4647,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4850,6 +4855,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -4938,6 +4944,7 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -5018,6 +5025,7 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -5034,6 +5042,7 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9165,6 +9174,7 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10157,6 +10167,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10196,8 +10207,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -153,8 +153,8 @@ function integerToWords(n) {
 
     if (remainder > 0) {
       const remainderResult = buildSegment(remainder)
-      // Insert "e" before remainder if it doesn't start with hundreds (< 100)
-      if (!remainderResult.startsWithHundreds) {
+      // REGRA DO "E": Menor que 100 OU Centena Exata (ex: 500)
+      if (!remainderResult.startsWithHundreds || remainderResult.isExactHundred) {
         result += ' e ' + remainderResult.word
       } else {
         result += ' ' + remainderResult.word
@@ -177,7 +177,6 @@ function integerToWords(n) {
  */
 function buildLargeNumberWords(n) {
   // Extract segments using BigInt division
-  // Segments stored least-significant first (index 0 = ones, 1 = thousands, etc.)
   const segments = []
   let temp = n
   while (temp > 0n) {
@@ -185,7 +184,7 @@ function buildLargeNumberWords(n) {
     temp = temp / 1000n
   }
 
-  // Find the first non-zero segment index (lowest scale with value)
+  // Find the first non-zero segment index
   let firstNonZeroIdx = 0
   for (let i = 0; i < segments.length; i++) {
     if (segments[i] !== 0) {
@@ -194,7 +193,6 @@ function buildLargeNumberWords(n) {
     }
   }
 
-  // Build result string directly
   let result = ''
   let prevWasScale = false
 
@@ -205,8 +203,8 @@ function buildLargeNumberWords(n) {
     const segmentResult = buildSegment(segment)
     const isLastSegment = (i === firstNonZeroIdx)
 
-    // Add "e" before final segment if previous was scale and this doesn't start with hundreds
-    if (result && isLastSegment && prevWasScale && !segmentResult.startsWithHundreds) {
+    // REGRA DO "E": Se for o último segmento e for < 100 OU centena exata (ex: 500)
+    if (result && isLastSegment && prevWasScale && (!segmentResult.startsWithHundreds || segmentResult.isExactHundred)) {
       result += ' e'
     }
 
@@ -225,7 +223,7 @@ function buildLargeNumberWords(n) {
       }
       prevWasScale = true
     } else {
-      // Million and above - use scale arrays
+      // Million and above
       const scaleWord = segment === 1 ? SCALE_WORDS_SINGULAR[i] : SCALE_WORDS_PLURAL[i]
       if (segment === 1) {
         result += 'um ' + scaleWord
@@ -454,7 +452,7 @@ function toOrdinal(value) {
  * @example
  * toCurrency(42.50)  // 'quarenta e dois reais e cinquenta centavos'
  * toCurrency(1)      // 'um real'
- * toCurrency(0.01)   // 'um centavo'
+ * toCurrency(1000000)// 'um milhão de reais'
  */
 function toCurrency(value, options) {
   options = validateOptions(options)
@@ -477,7 +475,12 @@ function toCurrency(value, options) {
   if (hasReais) {
     const reaisWords = integerToWords(reais)
     const reaisUnit = reais === 1n ? REAL : REAIS
-    result += reaisWords + ' ' + reaisUnit
+
+    // Regra do "de": aplica-se a valores redondos de milhões, bilhões, etc.
+    const requiresDe = reais >= 1_000_000n && reais % 1_000_000n === 0n
+    const separator = requiresDe ? ' de ' : ' '
+
+    result += reaisWords + separator + reaisUnit
   }
 
   if (hasCentavos) {

--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -1,0 +1,499 @@
+/**
+ * Portuguese (Brazil) language converter
+ *
+ * CLDR: pt-BR | Brazilian Portuguese as used in Brazil
+ *
+ * Portuguese-specific rules:
+ * - "e" conjunction between units, tens and hundreds: vinte e um, cento e um
+ * - "cem" for exact 100, "cento" for 100+ remainder
+ * - Irregular hundreds: duzentos, trezentos, quatrocentos, etc.
+ * - Short scale: milhão (10^6), bilhão (10^9), trilhão (10^12)
+ * - Omit "um" before "mil"
+ */
+
+import { parseCardinalValue } from './utils/parse-cardinal.js'
+import { parseCurrencyValue } from './utils/parse-currency.js'
+import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { validateOptions } from './utils/validate-options.js'
+
+// ============================================================================
+// Vocabulary (module-level constants)
+// ============================================================================
+
+const ONES = ['', 'um', 'dois', 'três', 'quatro', 'cinco', 'seis', 'sete', 'oito', 'nove']
+const TEENS = ['dez', 'onze', 'doze', 'treze', 'quatorze', 'quinze', 'dezesseis', 'dezessete', 'dezoito', 'dezenove']
+const TENS = ['', '', 'vinte', 'trinta', 'quarenta', 'cinquenta', 'sessenta', 'setenta', 'oitenta', 'noventa']
+
+// Irregular hundreds
+const HUNDREDS = ['', 'cento', 'duzentos', 'trezentos', 'quatrocentos', 'quinhentos', 'seiscentos', 'setecentos', 'oitocentos', 'novecentos']
+
+const THOUSAND = 'mil'
+const ZERO = 'zero'
+const NEGATIVE = 'menos'
+const DECIMAL_SEP = 'vírgula'
+
+// Ordinal vocabulary
+const ORDINAL_ONES = ['', 'primeiro', 'segundo', 'terceiro', 'quarto', 'quinto', 'sexto', 'sétimo', 'oitavo', 'nono']
+const ORDINAL_TEENS = ['décimo', 'décimo primeiro', 'décimo segundo', 'décimo terceiro', 'décimo quarto', 'décimo quinto', 'décimo sexto', 'décimo sétimo', 'décimo oitavo', 'décimo nono']
+const ORDINAL_TENS = ['', '', 'vigésimo', 'trigésimo', 'quadragésimo', 'quinquagésimo', 'sexagésimo', 'septuagésimo', 'octogésimo', 'nonagésimo']
+const ORDINAL_HUNDREDS = ['', 'centésimo', 'ducentésimo', 'tricentésimo', 'quadringentésimo', 'quingentésimo', 'sexcentésimo', 'septingentésimo', 'octingentésimo', 'nongentésimo']
+
+// Currency vocabulary (BRL)
+const REAL = 'real'
+const REAIS = 'reais'
+const CENTAVO = 'centavo'
+const CENTAVOS = 'centavos'
+
+// ============================================================================
+// Segment Building
+// ============================================================================
+
+/**
+ * Builds segment word for 0-999 with Portuguese "e" rules.
+ * Returns the word and whether it's an exact hundred (for "cem" handling).
+ */
+function buildSegment(n) {
+  if (n === 0) return { word: '', isExactHundred: false }
+
+  // Special case: exact 100 is "cem"
+  if (n === 100) return { word: 'cem', isExactHundred: true }
+
+  const ones = n % 10
+  const tens = Math.trunc(n / 10) % 10
+  const hundreds = Math.trunc(n / 100)
+
+  const parts = []
+
+  // Hundreds
+  if (hundreds > 0) {
+    parts.push(HUNDREDS[hundreds])
+  }
+
+  // Tens and ones
+  if (tens === 1) {
+    // Teens (10-19)
+    parts.push(TEENS[ones])
+  } else if (tens >= 2) {
+    if (ones > 0) {
+      // Tens + ones with "e": "vinte e um"
+      parts.push(TENS[tens] + ' e ' + ONES[ones])
+    } else {
+      parts.push(TENS[tens])
+    }
+  } else if (ones > 0) {
+    parts.push(ONES[ones])
+  }
+
+  // Join hundreds with "e": "cento e um", "duzentos e trinta e um"
+  const word = parts.join(' e ')
+
+  return { word, isExactHundred: hundreds > 0 && tens === 0 && ones === 0, startsWithHundreds: n >= 100 }
+}
+
+// ============================================================================
+// Scale Word Lookup (Short Scale for pt-BR)
+// ============================================================================
+
+// Precompute scale words for singular and plural forms
+// Index 1 = thousands, 2 = millions, 3 = billions (10^9), etc.
+const SCALE_WORDS_SINGULAR = [
+  '', // 0 unused
+  THOUSAND, // 1: mil
+  'milhão', // 2: 10^6
+  'bilhão', // 3: 10^9
+  'trilhão', // 4: 10^12
+  'quatrilhão', // 5: 10^15
+  'quintilhão', // 6: 10^18
+  'sextilhão', // 7: 10^21
+  'setilhão' // 8: 10^24
+]
+
+const SCALE_WORDS_PLURAL = [
+  '', // 0 unused
+  THOUSAND, // 1: mil (same)
+  'milhões', // 2: 10^6
+  'bilhões', // 3: 10^9
+  'trilhões', // 4: 10^12
+  'quatrilhões', // 5: 10^15
+  'quintilhões', // 6: 10^18
+  'sextilhões', // 7: 10^21
+  'setilhões' // 8: 10^24
+]
+
+// ============================================================================
+// Conversion Functions
+// ============================================================================
+
+/**
+ * Converts a non-negative integer to Portuguese words.
+ *
+ * @param {bigint} n - Non-negative integer to convert
+ * @returns {string} Portuguese words
+ */
+function integerToWords(n) {
+  if (n === 0n) return ZERO
+
+  // Fast path: numbers < 1000
+  if (n < 1000n) {
+    return buildSegment(Number(n)).word
+  }
+
+  // Fast path: numbers < 1,000,000 (thousands)
+  if (n < 1_000_000n) {
+    const thousands = Number(n / 1000n)
+    const remainder = Number(n % 1000n)
+
+    let result
+    if (thousands === 1) {
+      // "mil" not "um mil"
+      result = THOUSAND
+    } else {
+      result = buildSegment(thousands).word + ' ' + THOUSAND
+    }
+
+    if (remainder > 0) {
+      const remainderResult = buildSegment(remainder)
+      // Insert "e" before remainder if it doesn't start with hundreds (< 100)
+      if (!remainderResult.startsWithHundreds) {
+        result += ' e ' + remainderResult.word
+      } else {
+        result += ' ' + remainderResult.word
+      }
+    }
+
+    return result
+  }
+
+  // For numbers >= 1,000,000, use scale decomposition
+  return buildLargeNumberWords(n)
+}
+
+/**
+ * Builds words for numbers >= 1,000,000.
+ * Uses BigInt division for faster segment extraction.
+ *
+ * @param {bigint} n - Number >= 1,000,000
+ * @returns {string} Portuguese words
+ */
+function buildLargeNumberWords(n) {
+  // Extract segments using BigInt division
+  // Segments stored least-significant first (index 0 = ones, 1 = thousands, etc.)
+  const segments = []
+  let temp = n
+  while (temp > 0n) {
+    segments.push(Number(temp % 1000n))
+    temp = temp / 1000n
+  }
+
+  // Find the first non-zero segment index (lowest scale with value)
+  let firstNonZeroIdx = 0
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i] !== 0) {
+      firstNonZeroIdx = i
+      break
+    }
+  }
+
+  // Build result string directly
+  let result = ''
+  let prevWasScale = false
+
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i]
+    if (segment === 0) continue
+
+    const segmentResult = buildSegment(segment)
+    const isLastSegment = (i === firstNonZeroIdx)
+
+    // Add "e" before final segment if previous was scale and this doesn't start with hundreds
+    if (result && isLastSegment && prevWasScale && !segmentResult.startsWithHundreds) {
+      result += ' e'
+    }
+
+    if (result) result += ' '
+
+    if (i === 0) {
+      // Units segment
+      result += segmentResult.word
+      prevWasScale = false
+    } else if (i === 1) {
+      // Thousands
+      if (segment === 1) {
+        result += THOUSAND
+      } else {
+        result += segmentResult.word + ' ' + THOUSAND
+      }
+      prevWasScale = true
+    } else {
+      // Million and above - use scale arrays
+      const scaleWord = segment === 1 ? SCALE_WORDS_SINGULAR[i] : SCALE_WORDS_PLURAL[i]
+      if (segment === 1) {
+        result += 'um ' + scaleWord
+      } else {
+        result += segmentResult.word + ' ' + scaleWord
+      }
+      prevWasScale = true
+    }
+  }
+
+  return result
+}
+
+/**
+ * Converts decimal digits to Portuguese words.
+ *
+ * @param {string} decimalPart - Decimal digits (without the point)
+ * @returns {string} Portuguese words for decimal part
+ */
+function decimalPartToWords(decimalPart) {
+  let result = ''
+
+  // Handle leading zeros
+  let i = 0
+  while (i < decimalPart.length && decimalPart[i] === '0') {
+    if (result) result += ' '
+    result += ZERO
+    i++
+  }
+
+  // Convert remainder as a single number
+  const remainder = decimalPart.slice(i)
+  if (remainder) {
+    if (result) result += ' '
+    result += integerToWords(BigInt(remainder))
+  }
+
+  return result
+}
+
+/**
+ * Converts a numeric value to Portuguese words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert
+ * @returns {string} The number in Portuguese words
+ */
+function toCardinal(value) {
+  const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+
+  let result = ''
+
+  if (isNegative) {
+    result = NEGATIVE + ' '
+  }
+
+  result += integerToWords(integerPart)
+
+  if (decimalPart) {
+    result += ' ' + DECIMAL_SEP + ' ' + decimalPartToWords(decimalPart)
+  }
+
+  return result
+}
+
+// ============================================================================
+// Ordinal Functions
+// ============================================================================
+
+/**
+ * Builds ordinal words for 0-999.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Portuguese ordinal words
+ */
+function buildOrdinalSegment(n) {
+  if (n === 0) return ''
+
+  const ones = n % 10
+  const tens = Math.trunc(n / 10) % 10
+  const hundreds = Math.trunc(n / 100)
+
+  const parts = []
+
+  // Hundreds ordinal
+  if (hundreds > 0) {
+    parts.push(ORDINAL_HUNDREDS[hundreds])
+  }
+
+  // Tens and ones
+  if (tens === 1) {
+    // 10-19: use teens array (décimo, décimo primeiro, etc.)
+    parts.push(ORDINAL_TEENS[ones])
+  } else if (tens >= 2) {
+    parts.push(ORDINAL_TENS[tens])
+    if (ones > 0) {
+      parts.push(ORDINAL_ONES[ones])
+    }
+  } else if (ones > 0) {
+    parts.push(ORDINAL_ONES[ones])
+  }
+
+  return parts.join(' ')
+}
+
+/**
+ * Builds ordinal words for large numbers.
+ *
+ * @param {bigint} n - Non-negative integer
+ * @returns {string} Portuguese ordinal words
+ */
+function buildLargeOrdinal(n) {
+  // Extract segments
+  const segments = []
+  let temp = n
+  while (temp > 0n) {
+    segments.push(Number(temp % 1000n))
+    temp = temp / 1000n
+  }
+
+  // Find the lowest non-zero segment (index 0 = units, lowest scale)
+  let lowestNonZeroIdx = 0
+  for (let i = 0; i < segments.length; i++) {
+    if (segments[i] !== 0) {
+      lowestNonZeroIdx = i
+      break
+    }
+  }
+
+  // Scale ordinal words (singular forms - short scale for pt-BR)
+  const SCALE_ORDINAL = ['', 'milésimo', 'milionésimo', 'bilionésimo', 'trilionésimo', 'quatrilionésimo', 'quintilionésimo', 'sextilionésimo']
+
+  let result = ''
+
+  for (let i = segments.length - 1; i >= 0; i--) {
+    const segment = segments[i]
+    if (segment === 0) continue
+
+    if (result) result += ' '
+
+    if (i === lowestNonZeroIdx) {
+      // Last non-zero segment gets ordinal form
+      if (i === 0) {
+        // Units: just ordinal
+        result += buildOrdinalSegment(segment)
+      } else if (segment === 1 && i > 0) {
+        // Exact scale: "milésimo", "milionésimo", etc.
+        result += SCALE_ORDINAL[i]
+      } else {
+        // Segment + scale ordinal
+        result += buildOrdinalSegment(segment) + ' ' + SCALE_ORDINAL[i]
+      }
+    } else {
+      // Higher segments use cardinal form
+      if (i === 0) {
+        result += buildSegment(segment).word
+      } else if (i === 1) {
+        if (segment === 1) {
+          result += THOUSAND
+        } else {
+          result += buildSegment(segment).word + ' ' + THOUSAND
+        }
+      } else {
+        const scaleWord = segment === 1 ? SCALE_WORDS_SINGULAR[i] : SCALE_WORDS_PLURAL[i]
+        if (segment === 1) {
+          result += 'um ' + scaleWord
+        } else {
+          result += buildSegment(segment).word + ' ' + scaleWord
+        }
+      }
+    }
+  }
+
+  return result
+}
+
+/**
+ * Converts a number to Portuguese ordinal words.
+ *
+ * @param {number | string | bigint} value - The number to convert
+ * @returns {string} Portuguese ordinal words
+ */
+function toOrdinal(value) {
+  const n = parseOrdinalValue(value)
+
+  // Fast path: 1-9
+  if (n < 10n) {
+    return ORDINAL_ONES[Number(n)]
+  }
+
+  // Fast path: 10-19
+  if (n < 20n) {
+    return ORDINAL_TEENS[Number(n) - 10]
+  }
+
+  // Fast path: 20-99
+  if (n < 100n) {
+    const ones = Number(n % 10n)
+    const tens = Number(n / 10n)
+    if (ones === 0) {
+      return ORDINAL_TENS[tens]
+    }
+    return ORDINAL_TENS[tens] + ' ' + ORDINAL_ONES[ones]
+  }
+
+  // Fast path: 100-999
+  if (n < 1000n) {
+    return buildOrdinalSegment(Number(n))
+  }
+
+  // Large numbers
+  return buildLargeOrdinal(n)
+}
+
+// ============================================================================
+// Currency Functions
+// ============================================================================
+
+/**
+ * Converts a number to Brazilian currency words (Real).
+ *
+ * @param {number | string | bigint} value - The amount to convert
+ * @param {Object} [options]
+ * @param {boolean} [options.and=true] - Include "e" between reais and centavos
+ * @returns {string} Portuguese currency words
+ *
+ * @example
+ * toCurrency(42.50)  // 'quarenta e dois reais e cinquenta centavos'
+ * toCurrency(1)      // 'um real'
+ * toCurrency(0.01)   // 'um centavo'
+ */
+function toCurrency(value, options) {
+  options = validateOptions(options)
+  const { isNegative, dollars: reais, cents: centavos } = parseCurrencyValue(value)
+  const { and = true } = options
+
+  let result = ''
+
+  if (isNegative) {
+    result = NEGATIVE + ' '
+  }
+
+  const hasReais = reais > 0n
+  const hasCentavos = centavos > 0n
+
+  if (!hasReais && !hasCentavos) {
+    return ZERO + ' ' + REAIS
+  }
+
+  if (hasReais) {
+    const reaisWords = integerToWords(reais)
+    const reaisUnit = reais === 1n ? REAL : REAIS
+    result += reaisWords + ' ' + reaisUnit
+  }
+
+  if (hasCentavos) {
+    if (hasReais) {
+      result += and ? ' e ' : ' '
+    }
+    const centavosWords = integerToWords(centavos)
+    const centavosUnit = centavos === 1n ? CENTAVO : CENTAVOS
+    result += centavosWords + ' ' + centavosUnit
+  }
+
+  return result
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+export { toCardinal, toOrdinal, toCurrency }

--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -38,11 +38,22 @@ const ORDINAL_TEENS = ['décimo', 'décimo primeiro', 'décimo segundo', 'décim
 const ORDINAL_TENS = ['', '', 'vigésimo', 'trigésimo', 'quadragésimo', 'quinquagésimo', 'sexagésimo', 'septuagésimo', 'octogésimo', 'nonagésimo']
 const ORDINAL_HUNDREDS = ['', 'centésimo', 'ducentésimo', 'tricentésimo', 'quadringentésimo', 'quingentésimo', 'sexcentésimo', 'septingentésimo', 'octingentésimo', 'nongentésimo']
 
-// Currency vocabulary (BRL)
-const REAL = 'real'
-const REAIS = 'reais'
-const CENTAVO = 'centavo'
-const CENTAVOS = 'centavos'
+
+// ============================================================================
+// Currency vocabulary
+// ============================================================================
+
+// Dicionário focado no uso no Brasil (centavos para dólar e euro em vez de cêntimos)
+const CURRENCIES = {
+  BRL: { major: ['real', 'reais'], minor: ['centavo', 'centavos'] },
+  USD: { major: ['dólar', 'dólares'], minor: ['centavo', 'centavos'] },
+  EUR: { major: ['euro', 'euros'], minor: ['centavo', 'centavos'] }, // No Brasil é comum falar "centavos de euro"
+  GBP: { major: ['libra', 'libras'], minor: ['pêni', 'pence'] },
+  JPY: { major: ['iene', 'ienes'], minor: ['sen', 'sen'] }, // Iene não tem subdivisão usada no dia a dia
+}
+
+// Fallback para caso o usuário passe uma moeda não mapeada (ex: 'CAD')
+const DEFAULT_CURRENCY_WORDS = { major: ['unidade', 'unidades'], minor: ['centavo', 'centavos'] }
 
 // ============================================================================
 // Segment Building
@@ -442,22 +453,41 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
- * Converts a number to Brazilian currency words (Real).
+ * Converts a number to Brazilian Portuguese currency words.
  *
  * @param {number | string | bigint} value - The amount to convert
  * @param {Object} [options]
- * @param {boolean} [options.and=true] - Include "e" between reais and centavos
- * @returns {string} Portuguese currency words
+ * @param {boolean} [options.and=true] - Include "e" between major and minor units
+ * @param {string} [options.currency] - Currency code (e.g., 'BRL', 'USD')
+ * @returns {string} Brazilian Portuguese currency words
  *
  * @example
- * toCurrency(42.50)  // 'quarenta e dois reais e cinquenta centavos'
- * toCurrency(1)      // 'um real'
- * toCurrency(1000000)// 'um milhão de reais'
+ * toCurrency(42.50)                    // 'quarenta e dois reais e cinquenta centavos'
+ * toCurrency(42.50, {currency: 'USD'}) // 'quarenta e dois dólares e cinquenta centavos'
  */
 function toCurrency(value, options) {
   options = validateOptions(options)
-  const { isNegative, dollars: reais, cents: centavos } = parseCurrencyValue(value)
+  const { isNegative, dollars: majorUnits, cents: minorUnits } = parseCurrencyValue(value)
   const { and = true } = options
+
+  // 1. Descobre a moeda informada ou busca automaticamente a padrão do país (pt-BR = BRL)
+  let currencyCode = options.currency
+  if (!currencyCode) {
+    try {
+      const localeInfo = new Intl.Locale('pt-BR')
+      currencyCode = localeInfo.getCurrencies?.()[0]
+    } catch (e) {
+      // Ignora erro em ambientes antigos (fallback garantido abaixo)
+    }
+    currencyCode = currencyCode || 'BRL' // Padrão absoluto para o Brasil
+  }
+  currencyCode = currencyCode.toUpperCase()
+
+  // 2. Busca os nomes no dicionário ou usa o fallback genérico
+  const currencyWords = CURRENCIES[currencyCode] || {
+    major: [currencyCode, currencyCode],
+    minor: DEFAULT_CURRENCY_WORDS.minor
+  }
 
   let result = ''
 
@@ -465,31 +495,34 @@ function toCurrency(value, options) {
     result = NEGATIVE + ' '
   }
 
-  const hasReais = reais > 0n
-  const hasCentavos = centavos > 0n
+  const hasMajor = majorUnits > 0n
+  const hasMinor = minorUnits > 0n
 
-  if (!hasReais && !hasCentavos) {
-    return ZERO + ' ' + REAIS
+  if (!hasMajor && !hasMinor) {
+    return ZERO + ' ' + currencyWords.major[1]
   }
 
-  if (hasReais) {
-    const reaisWords = integerToWords(reais)
-    const reaisUnit = reais === 1n ? REAL : REAIS
-
-    // Regra do "de": aplica-se a valores redondos de milhões, bilhões, etc.
-    const requiresDe = reais >= 1_000_000n && reais % 1_000_000n === 0n
-    const separator = requiresDe ? ' de ' : ' '
-
-    result += reaisWords + separator + reaisUnit
+  // Parte inteira (Reais, Dólares...)
+  if (hasMajor) {
+    const majorText = integerToWords(majorUnits)
+    const majorUnit = majorUnits === 1n ? currencyWords.major[0] : currencyWords.major[1]
+    result += majorText + ' ' + majorUnit
   }
 
-  if (hasCentavos) {
-    if (hasReais) {
+  // Parte decimal (Centavos...)
+  if (hasMinor) {
+    if (hasMajor) {
       result += and ? ' e ' : ' '
     }
-    const centavosWords = integerToWords(centavos)
-    const centavosUnit = centavos === 1n ? CENTAVO : CENTAVOS
-    result += centavosWords + ' ' + centavosUnit
+    const minorText = integerToWords(minorUnits)
+    const minorUnit = minorUnits === 1n ? currencyWords.minor[0] : currencyWords.minor[1]
+
+    // Ignora adicionar unidade de centavos se a moeda não os tiver (ex: JPY onde minor é string vazia)
+    if (minorUnit === '') {
+      result += minorText
+    } else {
+      result += minorText + ' ' + minorUnit
+    }
   }
 
   return result

--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -38,7 +38,6 @@ const ORDINAL_TEENS = ['décimo', 'décimo primeiro', 'décimo segundo', 'décim
 const ORDINAL_TENS = ['', '', 'vigésimo', 'trigésimo', 'quadragésimo', 'quinquagésimo', 'sexagésimo', 'septuagésimo', 'octogésimo', 'nonagésimo']
 const ORDINAL_HUNDREDS = ['', 'centésimo', 'ducentésimo', 'tricentésimo', 'quadringentésimo', 'quingentésimo', 'sexcentésimo', 'septingentésimo', 'octingentésimo', 'nongentésimo']
 
-
 // ============================================================================
 // Currency vocabulary
 // ============================================================================
@@ -49,7 +48,7 @@ const CURRENCIES = {
   USD: { major: ['dólar', 'dólares'], minor: ['centavo', 'centavos'] },
   EUR: { major: ['euro', 'euros'], minor: ['centavo', 'centavos'] }, // No Brasil é comum falar "centavos de euro"
   GBP: { major: ['libra', 'libras'], minor: ['pêni', 'pence'] },
-  JPY: { major: ['iene', 'ienes'], minor: ['sen', 'sen'] }, // Iene não tem subdivisão usada no dia a dia
+  JPY: { major: ['iene', 'ienes'], minor: ['sen', 'sen'] } // Iene não tem subdivisão usada no dia a dia
 }
 
 // Fallback para caso o usuário passe uma moeda não mapeada (ex: 'CAD')
@@ -63,7 +62,7 @@ const DEFAULT_CURRENCY_WORDS = { major: ['unidade', 'unidades'], minor: ['centav
  * Builds segment word for 0-999 with Portuguese "e" rules.
  * Returns the word and whether it's an exact hundred (for "cem" handling).
  */
-function buildSegment(n) {
+function buildSegment (n) {
   if (n === 0) return { word: '', isExactHundred: false }
 
   // Special case: exact 100 is "cem"
@@ -141,7 +140,7 @@ const SCALE_WORDS_PLURAL = [
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Portuguese words
  */
-function integerToWords(n) {
+function integerToWords (n) {
   if (n === 0n) return ZERO
 
   // Fast path: numbers < 1000
@@ -186,7 +185,7 @@ function integerToWords(n) {
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Portuguese words
  */
-function buildLargeNumberWords(n) {
+function buildLargeNumberWords (n) {
   // Extract segments using BigInt division
   const segments = []
   let temp = n
@@ -254,7 +253,7 @@ function buildLargeNumberWords(n) {
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Portuguese words for decimal part
  */
-function decimalPartToWords(decimalPart) {
+function decimalPartToWords (decimalPart) {
   let result = ''
 
   // Handle leading zeros
@@ -281,7 +280,7 @@ function decimalPartToWords(decimalPart) {
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Portuguese words
  */
-function toCardinal(value) {
+function toCardinal (value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
 
   let result = ''
@@ -309,7 +308,7 @@ function toCardinal(value) {
  * @param {number} n - Number 0-999
  * @returns {string} Portuguese ordinal words
  */
-function buildOrdinalSegment(n) {
+function buildOrdinalSegment (n) {
   if (n === 0) return ''
 
   const ones = n % 10
@@ -345,7 +344,7 @@ function buildOrdinalSegment(n) {
  * @param {bigint} n - Non-negative integer
  * @returns {string} Portuguese ordinal words
  */
-function buildLargeOrdinal(n) {
+function buildLargeOrdinal (n) {
   // Extract segments
   const segments = []
   let temp = n
@@ -416,7 +415,7 @@ function buildLargeOrdinal(n) {
  * @param {number | string | bigint} value - The number to convert
  * @returns {string} Portuguese ordinal words
  */
-function toOrdinal(value) {
+function toOrdinal (value) {
   const n = parseOrdinalValue(value)
 
   // Fast path: 1-9
@@ -465,7 +464,7 @@ function toOrdinal(value) {
  * toCurrency(42.50)                    // 'quarenta e dois reais e cinquenta centavos'
  * toCurrency(42.50, {currency: 'USD'}) // 'quarenta e dois dólares e cinquenta centavos'
  */
-function toCurrency(value, options) {
+function toCurrency (value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: majorUnits, cents: minorUnits } = parseCurrencyValue(value)
   const { and = true } = options

--- a/test/fixtures/pt-BR.js
+++ b/test/fixtures/pt-BR.js
@@ -1,0 +1,232 @@
+/**
+ * Cardinal number test cases
+ * Format: [input, expected_output, options?]
+ */
+export const cardinal = [
+  [0.01, 'zero vírgula zero um'],
+  [1.007, 'um vírgula zero zero sete'],
+  [1.7, 'um vírgula sete'],
+  [17.42, 'dezessete vírgula quarenta e dois'],
+  [27.312, 'vinte e sete vírgula trezentos e doze'],
+  [53.486, 'cinquenta e três vírgula quatrocentos e oitenta e seis'],
+  [300.42, 'trezentos vírgula quarenta e dois'],
+  [4196.42, 'quatro mil cento e noventa e seis vírgula quarenta e dois'],
+
+  [-17.42, 'menos dezessete vírgula quarenta e dois'],
+  [-1, 'menos um'],
+  [-20, 'menos vinte'],
+
+  [0, 'zero'],
+  [1, 'um'],
+  [2, 'dois'],
+  [3, 'três'],
+  [11, 'onze'],
+  [12, 'doze'],
+  [14, 'quatorze'],
+  [16, 'dezesseis'],
+  [17, 'dezessete'],
+  [18, 'dezoito'],
+  [19, 'dezenove'],
+  [20, 'vinte'],
+  [21, 'vinte e um'],
+  [26, 'vinte e seis'],
+  [28, 'vinte e oito'],
+  [30, 'trinta'],
+  [31, 'trinta e um'],
+  [40, 'quarenta'],
+  [44, 'quarenta e quatro'],
+  [50, 'cinquenta'],
+  [55, 'cinquenta e cinco'],
+  [60, 'sessenta'],
+  [67, 'sessenta e sete'],
+  [70, 'setenta'],
+  [79, 'setenta e nove'],
+  [89, 'oitenta e nove'],
+  [95, 'noventa e cinco'],
+  [100, 'cem'],
+  [101, 'cento e um'],
+  [199, 'cento e noventa e nove'],
+  [203, 'duzentos e três'],
+  [287, 'duzentos e oitenta e sete'],
+  [356, 'trezentos e cinquenta e seis'],
+  [400, 'quatrocentos'],
+  [434, 'quatrocentos e trinta e quatro'],
+  [578, 'quinhentos e setenta e oito'],
+  [689, 'seiscentos e oitenta e nove'],
+  [729, 'setecentos e vinte e nove'],
+  [894, 'oitocentos e noventa e quatro'],
+  [999, 'novecentos e noventa e nove'],
+  [1000, 'mil'],
+  [1001, 'mil e um'],
+  [1097, 'mil e noventa e sete'],
+  [1100, 'mil e cem'],
+  [1104, 'mil cento e quatro'],
+  [1243, 'mil duzentos e quarenta e três'],
+  [2385, 'dois mil trezentos e oitenta e cinco'],
+  [3766, 'três mil setecentos e sessenta e seis'],
+  [4196, 'quatro mil cento e noventa e seis'],
+  [5846, 'cinco mil oitocentos e quarenta e seis'],
+  [6459, 'seis mil quatrocentos e cinquenta e nove'],
+  [7232, 'sete mil duzentos e trinta e dois'],
+  [8569, 'oito mil quinhentos e sessenta e nove'],
+  [9539, 'nove mil quinhentos e trinta e nove'],
+  [1_000_000, 'um milhão'],
+  [1_000_001, 'um milhão e um'],
+  [4_000_000, 'quatro milhões'],
+  [1_000_000_000, 'um bilhão'],
+  [10_000_000_000_000, 'dez trilhões'],
+  [100_000_000_000_000, 'cem trilhões'],
+  [1_000_000_000_000_000_000n, 'um quintilhão']
+]
+
+/**
+ * Ordinal number test cases
+ * Format: [input, expected_output]
+ */
+export const ordinal = [
+  // Basic ones (1-9)
+  [1, 'primeiro'],
+  [2, 'segundo'],
+  [3, 'terceiro'],
+  [4, 'quarto'],
+  [5, 'quinto'],
+  [6, 'sexto'],
+  [7, 'sétimo'],
+  [8, 'oitavo'],
+  [9, 'nono'],
+
+  // Teens (10-19)
+  [10, 'décimo'],
+  [11, 'décimo primeiro'],
+  [12, 'décimo segundo'],
+  [13, 'décimo terceiro'],
+  [14, 'décimo quarto'],
+  [15, 'décimo quinto'],
+  [16, 'décimo sexto'],
+  [17, 'décimo sétimo'],
+  [18, 'décimo oitavo'],
+  [19, 'décimo nono'],
+
+  // Tens (20-90)
+  [20, 'vigésimo'],
+  [30, 'trigésimo'],
+  [40, 'quadragésimo'],
+  [50, 'quinquagésimo'],
+  [60, 'sexagésimo'],
+  [70, 'septuagésimo'],
+  [80, 'octogésimo'],
+  [90, 'nonagésimo'],
+
+  // Compound tens-ones
+  [21, 'vigésimo primeiro'],
+  [22, 'vigésimo segundo'],
+  [23, 'vigésimo terceiro'],
+  [32, 'trigésimo segundo'],
+  [42, 'quadragésimo segundo'],
+  [53, 'quinquagésimo terceiro'],
+  [67, 'sexagésimo sétimo'],
+  [88, 'octogésimo oitavo'],
+  [99, 'nonagésimo nono'],
+
+  // Hundreds
+  [100, 'centésimo'],
+  [101, 'centésimo primeiro'],
+  [102, 'centésimo segundo'],
+  [103, 'centésimo terceiro'],
+  [110, 'centésimo décimo'],
+  [111, 'centésimo décimo primeiro'],
+  [121, 'centésimo vigésimo primeiro'],
+  [200, 'ducentésimo'],
+  [300, 'tricentésimo'],
+  [500, 'quingentésimo'],
+  [999, 'nongentésimo nonagésimo nono'],
+
+  // Thousands
+  [1000, 'milésimo'],
+  [1001, 'mil primeiro'],
+  [1010, 'mil décimo'],
+  [1100, 'mil centésimo'],
+  [1111, 'mil centésimo décimo primeiro'],
+  [2000, 'segundo milésimo'],
+  [5000, 'quinto milésimo'],
+  [10000, 'décimo milésimo'],
+  [12345, 'doze mil tricentésimo quadragésimo quinto'],
+  [99999, 'noventa e nove mil nongentésimo nonagésimo nono'],
+
+  // Larger scales (short scale for pt-BR)
+  [1_000_000, 'milionésimo'],
+  [1_000_001, 'um milhão primeiro'],
+  [2_000_000, 'segundo milionésimo'],
+  [1_000_000_000, 'bilionésimo'],
+  [1_000_000_000_000, 'trilionésimo'],
+
+  // BigInt support
+  [1_000_000_000_000_000_000n, 'quintilionésimo']
+]
+
+/**
+ * Currency test cases (Brazilian Real by default)
+ * Format: [input, expected_output, options?]
+ */
+export const currency = [
+  // Zero
+  [0, 'zero reais'],
+
+  // Whole reais
+  [1, 'um real'],
+  [2, 'dois reais'],
+  [10, 'dez reais'],
+  [21, 'vinte e um reais'],
+  [100, 'cem reais'],
+  [1000, 'mil reais'],
+  [1000000, 'um milhão reais'],
+
+  // Centavos only
+  [0.01, 'um centavo'],
+  [0.02, 'dois centavos'],
+  [0.10, 'dez centavos'],
+  [0.21, 'vinte e um centavos'],
+  [0.50, 'cinquenta centavos'],
+  [0.99, 'noventa e nove centavos'],
+
+  // Reais and centavos
+  [1.01, 'um real e um centavo'],
+  [1.50, 'um real e cinquenta centavos'],
+  [2.02, 'dois reais e dois centavos'],
+  [21.21, 'vinte e um reais e vinte e um centavos'],
+  [42.50, 'quarenta e dois reais e cinquenta centavos'],
+  [100.99, 'cem reais e noventa e nove centavos'],
+  [1000.01, 'mil reais e um centavo'],
+  [1000000.01, 'um milhão reais e um centavo'],
+
+  // Negative amounts
+  [-1, 'menos um real'],
+  [-0.50, 'menos cinquenta centavos'],
+  [-42.50, 'menos quarenta e dois reais e cinquenta centavos'],
+
+  // Without "e" option
+  [42.50, 'quarenta e dois reais cinquenta centavos', { and: false }],
+  [1.01, 'um real um centavo', { and: false }],
+
+  // Edge cases: .00 cents should show reais only
+  [5.00, 'cinco reais'],
+  ['5.00', 'cinco reais'],
+  [50.00, 'cinquenta reais'],
+
+  // String inputs
+  ['42.50', 'quarenta e dois reais e cinquenta centavos'],
+  ['1.99', 'um real e noventa e nove centavos'],
+
+  // Other currencies via CURRENCIES dictionary
+  [1, 'um dólar', { currency: 'USD' }],
+  [42.50, 'quarenta e dois dólares e cinquenta centavos', { currency: 'USD' }],
+  [42.50, 'quarenta e dois euros e cinquenta centavos', { currency: 'EUR' }],
+  [5, 'cinco libras', { currency: 'GBP' }],
+  [100, 'cem ienes', { currency: 'JPY' }],
+
+  // Unknown currency falls back to using the code as the major word
+  [5, 'cinco CAD', { currency: 'CAD' }],
+
+  // BigInt (whole reais only)
+  [1_000_000_000_000n, 'um trilhão reais']
+]


### PR DESCRIPTION
## 📌 Pull Request: Add Brazilian Portuguese (pt-BR) support

### ✨ Summary

This PR adds full support for **Brazilian Portuguese (`pt-BR`)** to the library, including:

* Cardinal numbers (integers and decimals)
* Ordinal numbers
* Currency formatting (BRL - Real)

The implementation follows Brazilian Portuguese linguistic rules and CLDR conventions.

---

### 🇧🇷 Features

#### 🔢 Cardinal numbers

* Correct use of conjunction **"e"** between hundreds, tens, and units

  * Example: `cento e vinte e três`
* Proper handling of:

  * `"cem"` (exact 100)
  * `"cento"` (100+ remainder)
* Omission of `"um"` before `"mil"`

  * Example: `mil` (not *um mil*)
* Support for large numbers using **short scale**:

  * milhão (10⁶), bilhão (10⁹), trilhão (10¹²), etc.

#### 🔟 Ordinal numbers

* Full ordinal support with proper composition:

  * `primeiro`, `décimo segundo`, `centésimo`, etc.
* Scalable to large numbers using ordinal scale forms:

  * `milésimo`, `milionésimo`, etc.

#### 💰 Currency (BRL)

* Converts values to Brazilian Real format:

  * `1` → `um real`
  * `2.50` → `dois reais e cinquenta centavos`
* Handles pluralization correctly:

  * `real` / `reais`
  * `centavo` / `centavos`
* Optional `"e"` conjunction between reais and centavos

---

### ⚙️ Implementation details

* Uses **BigInt-based segmentation** for efficient large number handling
* Modular structure aligned with existing parsers:

  * `parseCardinalValue`
  * `parseOrdinalValue`
  * `parseCurrencyValue`
* Optimized fast paths for:

  * `< 1000`
  * `< 1,000,000`
* Precomputed scale words (singular and plural)

---

### 🧠 Language-specific rules covered

* Conjunction rules with `"e"`
* Irregular hundreds:

  * `duzentos`, `trezentos`, `quinhentos`, etc.
* Decimal separator: `"vírgula"`
* Negative numbers: `"menos"`

---

### ✅ Examples

```js
toCardinal(123)
// cento e vinte e três

toOrdinal(21)
// vigésimo primeiro

toCurrency(42.5)
// quarenta e dois reais e cinquenta centavos
```

---

### 🚀 Notes

* Follows **CLDR: pt-BR**
* Designed to be consistent with existing language implementations
* No breaking changes


