### PR TITLE
fix(core): sync package.json version to v4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n2words",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n2words",
-      "version": "3.1.0",
+      "version": "4.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n2words",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Convert numbers to words in 71 languages with zero dependencies. Supports BigInt, decimals, and browser/Node.js environments.",
   "keywords": [
     "number-to-words",


### PR DESCRIPTION
## Summary

- `package.json` was stuck at `3.1.0` while the latest release is `v4.0.0`
- The old release-please setup created the tag/release but never committed the version bump back to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)