### PR TITLE
docs(core): refresh stale figures in README

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -9,7 +9,8 @@
 # "defaults" = > 0.5% usage, last 2 versions, Firefox ESR, not dead
 # Filtering by "supports bigint" excludes KaiOS 2.5 and Opera Mini (can't run BigInt)
 #
-# This query targets ~87% of global users (all in-use browsers with BigInt support).
+# This query targets all in-use browsers with BigInt support. Run
+# `npx browserslist --coverage` to see the current global-coverage percentage.
 # See: https://github.com/browserslist/browserslist#queries
 
 # Target all in-use browsers that can run BigInt (non-polyfillable)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 - **Pure Functions** — Each language exports standalone functions. No classes, no configuration, no side effects.
 - **Tree-Shakeable** — Import only what you need. Unused exports are eliminated by modern bundlers.
-- **Tiny Bundles** — ~2.4 KB gzipped per language (with all forms). No bloat.
+- **Tiny Bundles** — ~2 KB gzipped per language (with all forms). No bloat.
 - **Multiple Forms** — Cardinal ("forty-two"), ordinal ("forty-second"), and currency ("forty-two dollars")
 - **70+ Languages** — European, Asian, Middle Eastern, African, and regional variants
 - **Zero Dependencies** — Works everywhere: Node.js, browsers, Deno, Bun
@@ -93,7 +93,7 @@ Highlights: Arabic, Chinese (Simplified/Traditional), English, French, German, H
 ## Compatibility
 
 - **Node.js**: 22+
-- **Browsers**: Chrome 67+, Firefox 68+, Safari 14+, Edge 79+ (~87% global coverage)
+- **Browsers**: Chrome 67+, Firefox 68+, Safari 14+, Edge 79+ — any browser with BigInt support
 - **Runtimes**: Deno, Bun, Cloudflare Workers
 
 Requires BigInt support (cannot be polyfilled).
@@ -102,7 +102,7 @@ Requires BigInt support (cannot be polyfilled).
 
 n2words is optimized for both size and speed:
 
-- ~2.4 KB gzipped per language (includes all forms)
+- ~2 KB gzipped per language (includes all forms)
 - Individual language imports enable tree-shaking
 - No runtime dependencies
 - BigInt modulo operations (no string manipulation)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -55,7 +55,7 @@ const currencyLanguages = getCurrencyLanguages()
  * 1. Source (src/): Modern ES2022+ code with BigInt, optional chaining
  * 2. Babel: Transpiles ES2022+ features down while preserving BigInt support
  * 3. Terser: Minifies using ES2020 syntax (safe for BigInt-supporting browsers)
- * 4. Target: ~85.9% global coverage via .browserslistrc ("defaults and supports bigint")
+ * 4. Target: in-use browsers with BigInt support, via .browserslistrc ("defaults and supports bigint")
  *
  * Generates:
  * - Individual ESM bundles (dist/{langCode}.js): One per language, for browsers


### PR DESCRIPTION
## Summary

Three places carried stale or mismatched figures for the same underlying metric:

| File | Was | Now |
|---|---|---|
| `README.md` | "~2.4 KB gzipped per language" (×2) | "~2 KB" |
| `README.md` | "~87% global coverage" | "any browser with BigInt support" |
| `.browserslistrc:12` | "~87% of global users" | prose pointing at `npx browserslist --coverage` |
| `rollup.config.js:58` | "~85.9% global coverage" | prose, no number |

Reality check: average gzipped per-language ESM bundle is 2.2 KB across the 72 languages (range 1.7–2.9 KB), and the current caniuse coverage for `defaults and supports bigint` is ~85.5%. The three files all cited *different* numbers (87 / 87 / 85.9), so even before the caniuse drift they weren't internally consistent.

Replacing the precise figures with rough phrasing means the next caniuse market-share shift doesn't restale anything.

Spot-checks confirmed the rest of the README is accurate: 72 language files (matches "70+"), every language exports all three forms, UMD shape (`n2words.enUS`, `.ordinal.enUS`, `.currency.enUS`) matches `rollup.config.js`, browser version baselines (Chrome 67+ / FF 68+ / Safari 14+ / Edge 79+) are correct for BigInt support, Node.js 22+ matches `engines.node`.

## Test plan

- [x] `markdownlint-cli2 README.md` passes
- [x] `npx browserslist --coverage` still resolves correctly (config unchanged, only comment edited)
- [x] No links broken