### PR TITLE
fix(types): add typesVersions to support CommonJS imports in TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,12 @@
     "./utils/*": null,
     "./package.json": "./package.json"
   },
+  "typesVersions": {
+    "*": {
+      "utils/*": [],
+      "*": ["./src/*.d.ts"]
+    }
+  },
   "files": [
     "src/**/*.js",
     "src/**/*.d.ts",


### PR DESCRIPTION
# Pull Request

## What does this do?

Add typesVersions field to package.json to map type definitions, enabling proper CommonJS module resolution in TypeScript projects such as NestJS v10.

Without this, TypeScript fails to resolve types when importing n2words via require() or with moduleResolution set to Node.

## Related Issue

<!-- Optional: Fixes #123 -->

## Checklist

- [x] Tests pass (`npm test`)
- [x] Linting passes (`npm run lint`)

<!-- That's it for most PRs! The sections below are optional. -->

---

<details>
<summary><b>Adding a new language?</b> (click to expand)</summary>

**Recommended:** Use the scaffolding tool to generate all files automatically:

```bash
npm run lang:add -- <code>
```

**Manual setup:** If not using the scaffolding tool, ensure you have:

- [ ] Language module in `src/<code>.js` exporting `toCardinal()`, `toOrdinal()`, and/or `toCurrency()`
- [ ] Test fixture in `test/fixtures/<code>.js` with matching exports
- [ ] Tests pass (`npm test`)

</details>

<details>
<summary><b>Breaking change?</b> (click to expand)</summary>

Describe what breaks and how users should update:

</details>
