### PR TITLE
chore(deps): bump commitlint to 21 and actions/cache to v5

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -33,4 +33,4 @@ jobs:
       - name: Validate PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx --yes --package=@commitlint/cli@20 --package=@commitlint/config-conventional@20 commitlint --config .commitlintrc.mjs
+        run: echo "$PR_TITLE" | npx --yes --package=@commitlint/cli@21 --package=@commitlint/config-conventional@21 commitlint --config .commitlintrc.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           HASH=$(jq -S '{dependencies,devDependencies,optionalDependencies,peerDependencies}' package.json | sha256sum | cut -c1-16)
           echo "key=npm-${{ runner.os }}-node${{ env.NODE_VERSION }}-${HASH}" >> "$GITHUB_OUTPUT"
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: ~/.npm
           key: ${{ steps.cache-key.outputs.key }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,9 @@
       "devDependencies": {
         "@babel/core": "^7.29.0",
         "@babel/preset-env": "^7.29.5",
-        "@commitlint/cli": "^20.5.3",
-        "@commitlint/config-conventional": "^20.5.3",
-        "@commitlint/format": "^20.5.0",
+        "@commitlint/cli": "^21.0.1",
+        "@commitlint/config-conventional": "^21.0.1",
+        "@commitlint/format": "^21.0.1",
         "@rollup/plugin-babel": "^7.0.0",
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
@@ -1582,111 +1582,190 @@
       }
     },
     "node_modules/@commitlint/cli": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-20.5.3.tgz",
-      "integrity": "sha512-OJdL0EXWD5y9LPa0nr/geOwzaS8BsdaybKkcloB0JgsguGxNv2R+hC2FTPqrAcprg35zF33KOQerY0x8W1aesA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-21.0.1.tgz",
+      "integrity": "sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/format": "^20.5.0",
-        "@commitlint/lint": "^20.5.3",
-        "@commitlint/load": "^20.5.3",
-        "@commitlint/read": "^20.5.0",
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/format": "^21.0.1",
+        "@commitlint/lint": "^21.0.1",
+        "@commitlint/load": "^21.0.1",
+        "@commitlint/read": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
         "tinyexec": "^1.0.0",
-        "yargs": "^17.0.0"
+        "yargs": "^18.0.0"
       },
       "bin": {
         "commitlint": "cli.js"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/@commitlint/config-conventional": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-20.5.3.tgz",
-      "integrity": "sha512-j34Qqeaa152chJgz2ysyk0BCpHenJn1lV0Rx0VXf8k3ccQcED+48EZrzMvo9jLmJUyBrrBwvu89I+2er4gW7QQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-21.0.1.tgz",
+      "integrity": "sha512-gRorrkfWOh/+V5X8GYWWbQvrzPczopGMS4CCNrQdHkK4xWElv82BDvIsDhJZWTlI7TazOlYea6VATufCsFs+sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.0.1",
         "conventional-changelog-conventionalcommits": "^9.2.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/config-validator": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
-      "integrity": "sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.0.1.tgz",
+      "integrity": "sha512-Zd2UFdndeMMaW2O96HK0tdfT4gOImUvidMpAd/pws2zZ4m1nrAZ/9b/v2JYuE8fs86GpXv9F7LNaIuCIWhY+pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.0.1",
         "ajv": "^8.11.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/ensure": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-20.5.3.tgz",
-      "integrity": "sha512-4i4AgNvH62owG9MwSiWKrle7HGNpBHHdLnWFIp5fTsHUYe5kRuh15t08L/0pdbbrRk8JKXQxxN4hZQcn+szkrw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-21.0.1.tgz",
+      "integrity": "sha512-jJ1037967wU7YN/xkv+iRlOBlmaOXPhPO5KQSqya6GyXzBlwuLzELBFao16DVg9dZyqmNrhewzwZ3SAibetHBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.0.1",
         "es-toolkit": "^1.46.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/execute-rule": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-20.0.0.tgz",
-      "integrity": "sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-21.0.1.tgz",
+      "integrity": "sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/format": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-20.5.0.tgz",
-      "integrity": "sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-21.0.1.tgz",
+      "integrity": "sha512-ksmG2+cHGtuDPQQbhBbC4unwm444+6TiPw0d1bKf67hntgZqZ8E0g1MuYKUuyT5IH4IMmXZhKq22/Z3jBvtQIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.0.1",
         "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/is-ignored": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-20.5.0.tgz",
-      "integrity": "sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-21.0.1.tgz",
+      "integrity": "sha512-iNDP8SFdw8JEkM0CHZ2XFnhTN4Zg5jKUY2d8kBOSFrI2aA+3YJI7fcqVpfgbpJ9xtxFVYpi+DBATU5AvhoTq8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.0.1",
         "semver": "^7.6.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/is-ignored/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1697,32 +1776,32 @@
       }
     },
     "node_modules/@commitlint/lint": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-20.5.3.tgz",
-      "integrity": "sha512-M7JbWBNr2gXKaPc4i/KipsuW1gkDHpj35KPjWtKy3Z+2AQw5wu1gBi1LIO0uoaij67CqY4K8PxPZSGens4evCw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-21.0.1.tgz",
+      "integrity": "sha512-gF+iYtUw1gBG3HUH9z3VxwUjGg2R2G5j+nmvPs8aIeYkiB7TtneBu3wO85I0bUl93bYNsvsCNI9Nte2fmDUMww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/is-ignored": "^20.5.0",
-        "@commitlint/parse": "^20.5.0",
-        "@commitlint/rules": "^20.5.3",
-        "@commitlint/types": "^20.5.0"
+        "@commitlint/is-ignored": "^21.0.1",
+        "@commitlint/parse": "^21.0.1",
+        "@commitlint/rules": "^21.0.1",
+        "@commitlint/types": "^21.0.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/load": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-20.5.3.tgz",
-      "integrity": "sha512-1FDZWuKyu98Myb8i7Tp31jPU2rZpOwAdYRyJcy2KoGg7Xk2A+bgHN8smhMaaNSNkmE8fwt53BokywZq8Gv/5XQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-21.0.1.tgz",
+      "integrity": "sha512-Btg1q1mKmiihN4W3x0EsPDrJMOQfMa9NIqlzlJyXAfxvsOGdGXOW5p3R3RcSxDCaY7JabY9flIl+Om1af3PSrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.5.0",
-        "@commitlint/execute-rule": "^20.0.0",
-        "@commitlint/resolve-extends": "^20.5.3",
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/execute-rule": "^21.0.1",
+        "@commitlint/resolve-extends": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
         "cosmiconfig": "^9.0.1",
         "cosmiconfig-typescript-loader": "^6.1.0",
         "es-toolkit": "^1.46.0",
@@ -1730,112 +1809,110 @@
         "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/message": {
-      "version": "20.4.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-20.4.3.tgz",
-      "integrity": "sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-21.0.1.tgz",
+      "integrity": "sha512-R3dVQeJQ0B6yqrZEjkUHD4r7UJYLV9Lvk2xs3PTOmtWk2G3mI6Xgc+YdRxL1PwcDfBiUjv2SkIkW4AUc976w1w==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/parse": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-20.5.0.tgz",
-      "integrity": "sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-21.0.1.tgz",
+      "integrity": "sha512-oh/nCSOqdoeQNA1tO8aAmxkq5EBo8/NzcFQRvv66AWc9HpED28sL2iSicCKU6hPintWuscL6BJEWi77Wq1LPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/types": "^21.0.1",
         "conventional-changelog-angular": "^8.2.0",
         "conventional-commits-parser": "^6.3.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/read": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-20.5.0.tgz",
-      "integrity": "sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-21.0.1.tgz",
+      "integrity": "sha512-pMEu4lbpC8W0ZgKJj2U6WaobXIZWdFlULpIEewYhkPXx+WZcnoO53YrVPc7QErQuNolq2Me8dP58Wu7YAVXVOA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/top-level": "^20.4.3",
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/top-level": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
         "git-raw-commits": "^5.0.0",
-        "minimist": "^1.2.8",
         "tinyexec": "^1.0.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/resolve-extends": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-20.5.3.tgz",
-      "integrity": "sha512-+ogW9v/u9JqpvAgTrLra/YTFo0KkjU6iNblF89pPsj4NebNc+DAWctsludwezI8YnsjBmfHpApSwcXprN/f/ew==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-21.0.1.tgz",
+      "integrity": "sha512-0DhjYWL6uYrY16Efa032fYk3woGJDU4AGWiG1XXltT9AMUNYKyb5cIZU2ivbaMZ3+kKFqUjikD2cjh66Sbh/Sg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/config-validator": "^20.5.0",
-        "@commitlint/types": "^20.5.0",
+        "@commitlint/config-validator": "^21.0.1",
+        "@commitlint/types": "^21.0.1",
         "es-toolkit": "^1.46.0",
         "global-directory": "^5.0.0",
-        "import-meta-resolve": "^4.0.0",
         "resolve-from": "^5.0.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/rules": {
-      "version": "20.5.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-20.5.3.tgz",
-      "integrity": "sha512-MPlMnb9D3wbszYMp+1hPtuhtPJndRo6I6yfkZVA4+jR8w7Kqp0u2u/Y+gzbaItx5Lltq5rw7FSZQWJMoXUC4NQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-21.0.1.tgz",
+      "integrity": "sha512-VMooYpz4nJg7xlaUso6CCOWEz8D/ChkvsvZUMARcoJ1ZpfKPyFCGrHNha2tbsETNAb6ErgiRuCr2DvghrvPDYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@commitlint/ensure": "^20.5.3",
-        "@commitlint/message": "^20.4.3",
-        "@commitlint/to-lines": "^20.0.0",
-        "@commitlint/types": "^20.5.0"
+        "@commitlint/ensure": "^21.0.1",
+        "@commitlint/message": "^21.0.1",
+        "@commitlint/to-lines": "^21.0.1",
+        "@commitlint/types": "^21.0.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/to-lines": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-20.0.0.tgz",
-      "integrity": "sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-21.0.1.tgz",
+      "integrity": "sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/top-level": {
-      "version": "20.4.3",
-      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-20.4.3.tgz",
-      "integrity": "sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-21.0.1.tgz",
+      "integrity": "sha512-4esUYqzY7K0FCgcJ/1xWEZekV7Ch4yZT1+xjEb7KzqbJ05XEkxHVsTfC8ADKNNtlCE2pj98KEbPGZWw9WwEnVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@commitlint/types": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-20.5.0.tgz",
-      "integrity": "sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==",
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/@commitlint/types/-/types-21.0.1.tgz",
+      "integrity": "sha512-4u7w8jcoCUFWhjWnASYzZHAP34OqOtuFBN87nQmFvqda03YU0T6z+yB4w0gSAMpekiRqqGk5rt+qSlW+a2vSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1843,7 +1920,7 @@
         "picocolors": "^1.1.1"
       },
       "engines": {
-        "node": ">=v18"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@conventional-changelog/git-client": {
@@ -1874,9 +1951,9 @@
       }
     },
     "node_modules/@conventional-changelog/git-client/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -2811,14 +2888,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.2.tgz",
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "undici-types": "~7.19.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/resolve": {
@@ -6280,17 +6357,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/imurmurhash": {
@@ -10282,9 +10348,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.19.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
       "license": "MIT",
       "peer": true

--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
   "typesVersions": {
     "*": {
       "utils/*": [],
-      "*": ["./src/*.d.ts"]
+      "*": [
+        "./src/*.d.ts"
+      ]
     }
   },
   "files": [
@@ -125,9 +127,9 @@
   "devDependencies": {
     "@babel/core": "^7.29.0",
     "@babel/preset-env": "^7.29.5",
-    "@commitlint/cli": "^20.5.3",
-    "@commitlint/config-conventional": "^20.5.3",
-    "@commitlint/format": "^20.5.0",
+    "@commitlint/cli": "^21.0.1",
+    "@commitlint/config-conventional": "^21.0.1",
+    "@commitlint/format": "^21.0.1",
     "@rollup/plugin-babel": "^7.0.0",
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",


### PR DESCRIPTION
## Summary

- Bumps `@commitlint/cli`, `@commitlint/config-conventional`, and `@commitlint/format` from 20.5.x → 21.0.1.
- Bumps `actions/cache` GitHub Action from v4 → v5 in the release workflow.

## Notes

**commitlint v21** raises the minimum Node version to 22 (already matches our `engines.node`) and renders input on a new line by default (a `--legacy-output` escape hatch is available). The existing `.commitlintrc.mjs` continues to load and validate messages without changes — verified locally with `npx commitlint --print-config` and round-trip tests against valid/invalid messages.

**actions/cache v5** runs on the Node.js 24 runtime. We only use GitHub-hosted runners (`ubuntu-latest`) in the release workflow, so the v5 self-hosted-runner minimum (`2.327.1`) is not a constraint here.

## Test plan

- [x] `npm test` passes (264 tests)
- [x] `npm run lint` passes
- [x] `npx commitlint --print-config` loads cleanly
- [x] Valid commit message accepted; invalid rejected
- [ ] CI green
- [ ] Release workflow exercises actions/cache@v5 on next release (lower-stakes — restore-keys fall back to v4 misses gracefully)

## Supersedes

- Closes #296
- Closes #297
- Closes #298
- Closes #299