### PR TITLE
ci(core): harden release pipeline and add workflow lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,24 +100,26 @@ jobs:
         if: ${{ matrix.coverage }}
         continue-on-error: true
         run: |
-          echo "## 📊 Coverage Report" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## 📊 Coverage Report"
+            echo ""
 
-          if [ -f coverage/coverage-summary.json ] && command -v jq &> /dev/null; then
-            TOTAL=$(jq -r '.total.lines.pct' coverage/coverage-summary.json)
-            STATEMENTS=$(jq -r '.total.statements.pct' coverage/coverage-summary.json)
-            BRANCHES=$(jq -r '.total.branches.pct' coverage/coverage-summary.json)
-            FUNCTIONS=$(jq -r '.total.functions.pct' coverage/coverage-summary.json)
+            if [ -f coverage/coverage-summary.json ] && command -v jq &> /dev/null; then
+              TOTAL=$(jq -r '.total.lines.pct' coverage/coverage-summary.json)
+              STATEMENTS=$(jq -r '.total.statements.pct' coverage/coverage-summary.json)
+              BRANCHES=$(jq -r '.total.branches.pct' coverage/coverage-summary.json)
+              FUNCTIONS=$(jq -r '.total.functions.pct' coverage/coverage-summary.json)
 
-            echo "| Metric | Coverage |" >> $GITHUB_STEP_SUMMARY
-            echo "|--------|----------|" >> $GITHUB_STEP_SUMMARY
-            echo "| **Lines** | ${TOTAL}% |" >> $GITHUB_STEP_SUMMARY
-            echo "| Statements | ${STATEMENTS}% |" >> $GITHUB_STEP_SUMMARY
-            echo "| Branches | ${BRANCHES}% |" >> $GITHUB_STEP_SUMMARY
-            echo "| Functions | ${FUNCTIONS}% |" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "### ℹ️ Coverage data not available" >> $GITHUB_STEP_SUMMARY
-          fi
+              echo "| Metric | Coverage |"
+              echo "|--------|----------|"
+              echo "| **Lines** | ${TOTAL}% |"
+              echo "| Statements | ${STATEMENTS}% |"
+              echo "| Branches | ${BRANCHES}% |"
+              echo "| Functions | ${FUNCTIONS}% |"
+            else
+              echo "### ℹ️ Coverage data not available"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload coverage to Coveralls
         if: ${{ matrix.coverage }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,16 @@ jobs:
         with:
           persist-credentials: false
 
+      # actionlint runs before npm-dependent steps so a workflow-YAML
+      # bug fails fast without paying the ~30s `npm ci` cost.
+      # Installer URL and binary version are pinned to the same tag —
+      # `main` is mutable and would defeat supply-chain immutability
+      # even if the binary itself is pinned.
+      - name: Run actionlint
+        run: |
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.6/scripts/download-actionlint.bash) 1.7.6
+          ./actionlint -color
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -2,7 +2,9 @@ name: PR Title
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    # `synchronize` re-runs on every push so a fixed title goes green
+    # without forcing a fresh PR open/close cycle.
+    types: [opened, edited, synchronize, reopened]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -21,16 +23,24 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          # Shallow clone — commitlint only reads the piped title, not history.
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
+          cache: 'npm'
 
-      # Skip `npm ci` — only commitlint is needed and `npx --package` fetches
-      # it on demand. Major versions pinned to match package.json's caret
-      # range so behavior matches local dev.
+      # `npm ci --ignore-scripts` installs commitlint from package.json's
+      # caret range, so this workflow uses the same major as local dev
+      # and the husky hook with no separate pin to drift. Skipping scripts
+      # avoids husky's prepare (no git hooks needed in CI) and any other
+      # postinstall noise.
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --prefer-offline
+
       - name: Validate PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx --yes --package=@commitlint/cli@21 --package=@commitlint/config-conventional@21 commitlint --config .commitlintrc.mjs
+        run: echo "$PR_TITLE" | npx --no-install commitlint --config .commitlintrc.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,23 +209,27 @@ jobs:
 
       - name: Generate job summary
         if: always()
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+          SKIP: ${{ steps.version.outputs.skip }}
+          BUMP: ${{ inputs.bump }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          TAG=${{ steps.version.outputs.tag }}
-          SKIP=${{ steps.version.outputs.skip }}
           PKG_NAME=$(node -p "require('./package.json').name")
-          echo "## Release Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          if [ "$SKIP" = "true" ]; then
-            echo "> **Skipped** — no version change detected (already at v${VERSION})" >> $GITHUB_STEP_SUMMARY
-          else
-            echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
-            echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
-            echo "| **Version** | v${VERSION} |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Tag** | \`${TAG}\` |" >> $GITHUB_STEP_SUMMARY
-            echo "| **Bump** | ${{ inputs.bump || 'auto-detected' }} |" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "- **npm**: https://www.npmjs.com/package/${PKG_NAME}/v/${VERSION}" >> $GITHUB_STEP_SUMMARY
-            echo "- **unpkg**: https://unpkg.com/${PKG_NAME}@${VERSION}/" >> $GITHUB_STEP_SUMMARY
-            echo "- **jsDelivr**: https://cdn.jsdelivr.net/npm/${PKG_NAME}@${VERSION}/" >> $GITHUB_STEP_SUMMARY
-          fi
+          {
+            echo "## Release Summary"
+            echo ""
+            if [ "$SKIP" = "true" ]; then
+              echo "> **Skipped** — no version change detected (already at v${VERSION})"
+            else
+              echo "| Item | Value |"
+              echo "|------|-------|"
+              echo "| **Version** | v${VERSION} |"
+              echo "| **Tag** | \`${TAG}\` |"
+              echo "| **Bump** | ${BUMP} |"
+              echo ""
+              echo "- **npm**: https://www.npmjs.com/package/${PKG_NAME}/v/${VERSION}"
+              echo "- **unpkg**: https://unpkg.com/${PKG_NAME}@${VERSION}/"
+              echo "- **jsDelivr**: https://cdn.jsdelivr.net/npm/${PKG_NAME}@${VERSION}/"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,11 +9,11 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Version bump (leave empty to auto-detect from commits)"
+        description: "Version bump (use 'auto' to detect from commits)"
         required: false
         type: choice
-        options: ["", "major", "minor", "patch"]
-        default: ""
+        options: ["auto", "major", "minor", "patch"]
+        default: "auto"
 
 concurrency:
   group: release
@@ -91,10 +91,10 @@ jobs:
         id: version
         run: |
           CURRENT=$(node -p "require('./package.json').version")
-          if [ -n "${{ inputs.bump }}" ]; then
-            TAG=$(git-cliff --bump ${{ inputs.bump }} --bumped-version)
-          else
+          if [ "${{ inputs.bump }}" = "auto" ]; then
             TAG=$(git-cliff --bumped-version)
+          else
+            TAG=$(git-cliff --bump ${{ inputs.bump }} --bumped-version)
           fi
           BARE="${TAG#v}"
           if [ "$BARE" = "$CURRENT" ]; then
@@ -139,23 +139,54 @@ jobs:
       - name: Generate changelog
         if: steps.version.outputs.skip != 'true'
         run: |
-          BUMP_ARG="${{ inputs.bump }}"
-          git-cliff --bump ${BUMP_ARG:+$BUMP_ARG} --output CHANGELOG.md
-          git-cliff --bump ${BUMP_ARG:+$BUMP_ARG} --unreleased --strip header --output RELEASE_NOTES.md
+          if [ "${{ inputs.bump }}" = "auto" ]; then
+            git-cliff --bump --output CHANGELOG.md
+            git-cliff --bump --unreleased --strip header --output RELEASE_NOTES.md
+          else
+            git-cliff --bump ${{ inputs.bump }} --output CHANGELOG.md
+            git-cliff --bump ${{ inputs.bump }} --unreleased --strip header --output RELEASE_NOTES.md
+          fi
 
-      - name: Commit, tag and push
+      # Commit locally only — defer the push until AFTER `npm publish`
+      # succeeds (see "Tag and push to origin" below). `[skip ci]` keeps
+      # the eventual push from re-triggering ci.yml on main, which would
+      # waste a billing minute re-running checks that already passed on
+      # the parent PR. The bump commit goes onto whatever the runner
+      # checked out; origin only learns about it after the artifact is
+      # durable on npm.
+      - name: Commit chore(release) locally
         if: steps.version.outputs.skip != 'true'
         run: |
           git add package.json package-lock.json CHANGELOG.md
-          git commit -m "chore(release): ${{ steps.version.outputs.tag }}"
-          git tag ${{ steps.version.outputs.tag }}
-          git push origin main --follow-tags
+          git commit -m "chore(release): ${{ steps.version.outputs.tag }} [skip ci]"
 
       - name: Publish to npm
         if: steps.version.outputs.skip != 'true'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish --provenance
+
+      # Tag + push deferred until AFTER `npm publish` lands the
+      # artifact. Prior shape pushed first; an npm-publish failure (OIDC
+      # expiry, registry hiccup, etc.) left the tag on origin pointing
+      # at a version that wasn't on npm, and the next run tripped the
+      # "tag exists" guard. Now: tag on origin ⇒ artifact on npm.
+      #
+      # Annotated tag (`-a`) — `--follow-tags` only pushes annotated
+      # tags; lightweight ones are silently skipped. `--atomic` makes
+      # the main + tag advance server-side all-or-nothing, closing the
+      # narrower "commit lands but tag doesn't" anomaly.
+      #
+      # `git pull --rebase --autostash` defends against a human commit
+      # arriving on main between the bump and this push. Without the
+      # rebase the push is rejected as non-fast-forward and the release
+      # is stuck with the package on npm but no commit on main.
+      - name: Tag and push to origin
+        if: steps.version.outputs.skip != 'true'
+        run: |
+          git pull --rebase --autostash origin main
+          git tag -a ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
+          git push origin main --atomic --follow-tags
 
       - name: Create release archive
         if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
## Summary

Three release-pipeline hardenings + workflow YAML linting.

### 1. Single-source commitlint version (`pr-title.yml`)

The PR-title workflow used to pin commitlint majors separately via `npx --package=@commitlint/cli@N --package=@commitlint/config-conventional@N`. That duplicated pin drifted on the v20 → v21 bump in #302 — Copilot flagged it mid-review. This switches the workflow to `npm ci --ignore-scripts` + `npx --no-install commitlint`, so package.json's caret range is the only source of truth.

### 2. Defer the tag push until after `npm publish` succeeds (`release.yml`)

Prior shape: `git push --follow-tags` → `npm publish`. If publish failed (OIDC expiry, registry hiccup), the tag landed on origin pointing at a version that wasn't on npm, and the next run would trip the "tag exists" guard. New shape: bump and commit locally, **publish to npm**, *then* tag and push. Now `tag on origin ⇒ artifact on npm`.

Three smaller hardenings landed in the same commit:

- **Annotated tag** (`git tag -a`) instead of lightweight — `--follow-tags` only pushes annotated tags. v4.0.0 happens to be on origin as a lightweight tag, presumably via implementation slop.
- **`--atomic`** push so main and the tag advance server-side all-or-nothing.
- **`git pull --rebase --autostash origin main`** before the push, so a human commit landing on main during release doesn't reject the push as non-fast-forward.

The `chore(release)` commit now carries `[skip ci]` so the push doesn't re-trigger `ci.yml` on main.

### 3. actionlint in the Lint & Security job (`ci.yml`)

Static workflow YAML linting: bad `${{ }}` expressions, deprecated action versions, `needs:` typos, invalid runner labels, shellcheck on `run:` blocks. Running it locally on this branch caught one real pre-existing issue (an empty-string entry in `workflow_dispatch.inputs.bump.options` in release.yml), fixed in the same release.yml commit by switching that option to `"auto"`. Installer URL and binary version pinned to the same tag for supply-chain integrity. Runs before `npm ci` so workflow-YAML bugs fail fast.

## Test plan

- [x] `npm test` (264 tests)
- [x] `npm run lint`
- [x] `actionlint .github/workflows/*.yml` clean
- [x] Local simulation of the new pr-title shape: `npm ci --ignore-scripts` then `echo "<title>" | npx --no-install commitlint --config .commitlintrc.mjs`
- [x] CI green on this PR
- [ ] Next release exercises the deferred-tag-push path
