### PR TITLE
ci(core): correct release tag/push ordering and harden workflow scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       # even if the binary itself is pinned.
       - name: Run actionlint
         run: |
-          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.6/scripts/download-actionlint.bash) 1.7.6
+          bash <(curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
           ./actionlint -color
 
       - name: Setup Node.js

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -43,4 +43,8 @@ jobs:
       - name: Validate PR title
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
-        run: echo "$PR_TITLE" | npx --no-install commitlint --config .commitlintrc.mjs
+        # `printf '%s\n'`, not `echo` — a title starting with `-n`/`-e`
+        # is otherwise swallowed by echo as a flag (POSIX echo is
+        # underspecified on flag handling), so commitlint would see a
+        # truncated title and could pass or fail misleadingly.
+        run: printf '%s\n' "$PR_TITLE" | npx --no-install commitlint --config .commitlintrc.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,14 +177,21 @@ jobs:
       # the main + tag advance server-side all-or-nothing, closing the
       # narrower "commit lands but tag doesn't" anomaly.
       #
-      # `git pull --rebase --autostash` defends against a human commit
-      # arriving on main between the bump and this push. Without the
-      # rebase the push is rejected as non-fast-forward and the release
-      # is stuck with the package on npm but no commit on main.
+      # Do NOT rebase onto origin/main before pushing. The npm package
+      # was already published from THIS chore(release) commit's tree.
+      # A rebase would replay that commit onto any PR that merged during
+      # the build, so the tag's tree would include source the published
+      # package was never built from (tag/artifact mismatch), and the
+      # merged PR would sink below the tag where the next
+      # `git-cliff --bumped-version` walk skips it — silently dropped
+      # from the changelog. Let the race fail loud instead: a PR landing
+      # on origin/main mid-build makes this a non-fast-forward push and
+      # `--atomic` rejects both main and the tag. That is recoverable —
+      # the package is already on npm; once main is stable, re-run the
+      # release or push the chore(release) commit + tag by hand.
       - name: Tag and push to origin
         if: steps.version.outputs.skip != 'true'
         run: |
-          git pull --rebase --autostash origin main
           git tag -a ${{ steps.version.outputs.tag }} -m "Release ${{ steps.version.outputs.tag }}"
           git push origin main --atomic --follow-tags
 


### PR DESCRIPTION
## Summary

Three CI fixes, the first a correctness issue in the release pipeline introduced by #303.

### 1. Don't rebase before pushing the release tag (`release.yml`)

The release job publishes to npm **before** it tags and pushes, and the package is built from the `chore(release)` commit's working tree — so that commit's tree is the artifact of record.

The pre-push `git pull --rebase --autostash origin main` added in #303 breaks that guarantee under a race: if any PR merges to main while a release runs, the rebase replays the `chore(release)` commit onto the new main. The tag then points at a tree containing source the **published npm package was never built from** (tag/artifact mismatch), and the merged PR sinks below the tag where the next `git-cliff --bumped-version` walk skips it — silently dropping it from the changelog.

Fix: drop the rebase and let the race fail loud. A concurrent merge makes the push a non-fast-forward and `--atomic` rejects both main and the tag. That state is recoverable (package already on npm; re-run the release or push the commit + tag by hand once main is stable) and strictly safer than a silent mismatch.

### 2. `printf` instead of `echo` for the PR title pipe (`pr-title.yml`)

`echo "$PR_TITLE"` interprets a title that is exactly a flag token (`-n`, `-e`, `-ne`, …) as an echo option rather than text, and the behavior is shell-dependent (POSIX echo is underspecified; `xpg_echo` changes it). commitlint would then validate an altered title. `printf '%s\n'` emits the title verbatim regardless of leading characters or shell.

### 3. Bump actionlint pin `v1.7.6` → `v1.7.12` (`ci.yml`)

Installer URL and binary pin move together to the same newer tag.

## Test plan

- [x] `actionlint .github/workflows/*.yml` clean (locally, v1.7.12)
- [x] Confirmed commitlint receives the full literal title via the `printf` path
- [ ] CI green