### PR TITLE
chore(release): v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [5.0.0](https://github.com/forzagreen/n2words/compare/v4.0.0...v5.0.0) (2026-05-30)
+
+
+### ⚠ BREAKING CHANGES
+
+* require Node.js >=22, drop EOL Node 20 ([#287](https://github.com/forzagreen/n2words/issues/287))
+
+### Features
+
+* add Brazilian Portuguese (pt-BR) support ([#275](https://github.com/forzagreen/n2words/issues/275))
+
+### Bug Fixes
+
+* **types:** add typesVersions to support CommonJS imports in TypeScript ([#301](https://github.com/forzagreen/n2words/issues/301))
+
 ## [4.0.0](https://github.com/forzagreen/n2words/compare/v3.1.0...v4.0.0) (2026-03-05)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n2words",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n2words",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n2words",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Convert numbers to words in 70+ languages with zero dependencies. Supports BigInt, decimals, and browser/Node.js environments.",
   "keywords": [
     "number-to-words",


### PR DESCRIPTION
## What this is

Reconciles git with npm after the failed release run ([run 26670443898](https://github.com/forzagreen/n2words/actions/runs/26670443898)).

`n2words@5.0.0` **published to npm successfully**, but the release job's `git push origin main` (the version-bump commit) was rejected by the `main` branch ruleset — the `pull_request` rule with `bypass_actors: null` blocks all direct pushes, including the Actions bot. The push was `--atomic`, so the `v5.0.0` tag was rejected alongside it.

Result before this PR: npm at 5.0.0, but `main` still at 4.0.0, no `v5.0.0` tag, no GitHub Release.

## This PR

- `package.json` + `package-lock.json` → `5.0.0`
- `CHANGELOG.md` → prepends the `5.0.0` entry

After merge, the `v5.0.0` tag + GitHub Release get created on the merge commit (tags aren't covered by the ruleset).

## Notes

- **Changelog is hand-written** in the existing release-please style. I deliberately did **not** run the current `cliff.toml` generator: it uses `git-cliff ... --output` (full regenerate) with a minimal template that emits no `## [version]` headers, which would flatten the entire historical changelog into header-less `### Group` lists. That generator config needs a separate fix before the next automated release — see the workflow follow-up.
- The auto-detected bump for this window is `4.0.1`; `5.0.0` reflects the deliberate major chosen at dispatch (the Node.js >=22 requirement in #287 is a breaking change that `chore(core)!` doesn't trip git-cliff's auto-major on).

## Test plan

- [x] `markdownlint` clean
- [ ] CI green