### PR TITLE
ci(core): push release commits as a GitHub App (ruleset bypass actor)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,31 @@ jobs:
     environment: npm
 
     steps:
+      # Mint a short-lived installation token from the release-bot
+      # GitHub App. The App is a bypass actor on the `main` branch
+      # ruleset, so the chore(release) commit pushed below is exempt
+      # from the "require a pull request" rule. The default
+      # GITHUB_TOKEN / github-actions[bot] is NOT a bypass actor —
+      # pushing with it is what the ruleset rejected, leaving a
+      # published npm version with no tag or commit on main.
+      - name: Mint release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          # `app-id` (the App's numeric ID), not `client-id`: both work
+          # in v3, but actionlint's bundled action metadata doesn't know
+          # `client-id` yet and fails the lint gate on it. Switch when
+          # the pinned actionlint recognizes it.
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Persisted as the push credential for "Tag and push to
+          # origin" below — that push then authenticates as the App
+          # (the bypass actor), not github-actions[bot].
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Verify NODE_VERSION satisfies engines.node
         # engines.node is a floor (e.g. ">=22"). The runner's Node major
@@ -208,7 +229,7 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         uses: softprops/action-gh-release@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}
           body_path: RELEASE_NOTES.md


### PR DESCRIPTION
## Why

The release job commits `chore(release): vX.Y.Z` to `main`, then tags and pushes. The `main` ruleset enforces a `pull_request` rule with **no bypass actors**, so that push is rejected for `github-actions[bot]` (the identity behind the default `GITHUB_TOKEN`). Because the push runs *after* `npm publish`, the package ships but no tag/commit lands — exactly what left `5.0.0` on npm with nothing in git ([failed run](https://github.com/forzagreen/n2words/actions/runs/26670443898)).

## What

Mint a short-lived installation token from a dedicated GitHub App and use it for `checkout` (which persists it as the push credential) and the GitHub Release step. The App is a **bypass actor** on the ruleset, so its push to `main` is allowed while the rule keeps blocking everyone else. Token is ~1h-lived and repo-scoped.

## ⚠️ Required setup before merging

This PR will **break the release workflow** (missing-secret error at the token step) until all of the following are done:

1. **Create a GitHub App** (your account → Settings → Developer settings → GitHub Apps → New).
   - Repository permission: **Contents: Read and write** (enough to push commits/tags and create releases). No webhook needed.
   - Note the **App ID** (numeric).
   - Generate a **private key** (.pem) and download it.
2. **Install the App** on `forzagreen/n2words` (App settings → Install App → select this repo only).
3. **Add repo secrets** (Settings → Secrets and variables → Actions):
   - `RELEASE_BOT_APP_ID` = the numeric App ID
   - `RELEASE_BOT_PRIVATE_KEY` = the full contents of the .pem
4. **Add the App as a bypass actor** on the `main` ruleset (Settings → Rules → Rulesets → `main` → Bypass list → Add → your App). Without this, the push is still rejected.

Once 1–4 are in place, merge this PR. The next `workflow_dispatch` release will commit, tag, and publish end-to-end.

## Notes

- Kept `id-token: write` (npm provenance OIDC) and the `contents: write` permission block; the App token now does the git/release work, but those don't hurt.
- `app-id` is used rather than the now-preferred `client-id`: both work in the v3 action, but the pinned actionlint's bundled metadata doesn't recognize `client-id` yet and fails the lint gate. Comment in the file flags the switch for later.
- The `chore(release)` commit keeps its `[skip ci]` marker — App-token pushes *do* trigger workflows (unlike `GITHUB_TOKEN`), so the marker prevents a redundant `ci.yml` run on `main` after release.

## Test plan

- [x] `actionlint` clean across all workflows (locally, v1.7.12)
- [ ] CI green on this PR
- [ ] First real release after setup completes commit + tag + Release (validates the bypass end-to-end)