### PR TITLE
ci(core): generate a canonical, PR-linked changelog with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,14 +136,21 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         run: npm publish --dry-run
 
+      # `--unreleased --prepend` adds ONLY the new version's section to
+      # the top of the existing CHANGELOG.md. The old `--output`
+      # regenerated the whole file from git history, which (with this
+      # cliff.toml) would flatten every prior release — including the
+      # hand-written 3.0.0 migration tables — into tool-generated text.
+      # RELEASE_NOTES.md is the same new section with the title stripped,
+      # for the GitHub Release body.
       - name: Generate changelog
         if: steps.version.outputs.skip != 'true'
         run: |
           if [ "${{ inputs.bump }}" = "auto" ]; then
-            git-cliff --bump --output CHANGELOG.md
+            git-cliff --bump --unreleased --prepend CHANGELOG.md
             git-cliff --bump --unreleased --strip header --output RELEASE_NOTES.md
           else
-            git-cliff --bump ${{ inputs.bump }} --output CHANGELOG.md
+            git-cliff --bump ${{ inputs.bump }} --unreleased --prepend CHANGELOG.md
             git-cliff --bump ${{ inputs.bump }} --unreleased --strip header --output RELEASE_NOTES.md
           fi
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,12 +1,43 @@
+# git-cliff configuration
+#
+# Emits the canonical Conventional-Changelog / "Keep a Changelog"
+# format: newest release on top, a compare link + date in each version
+# header, changes grouped by type with a leading BREAKING CHANGES
+# block, and every entry ending in its PR (#NN) and commit links — the
+# PR is the full story behind the one-line hook.
+#
+# Links are derived offline from the squash-merge "(#NN)" suffix and
+# the commit hash; no GitHub API/token needed. The release workflow
+# prepends ONLY the new version's section (`--unreleased --prepend`),
+# so historical entries — including the hand-written 3.0.0 migration
+# tables — are preserved verbatim.
+
 [changelog]
-header = ""
+header = "# Changelog\n\n"
 body = """
-{% for group, commits in commits | group_by(attribute="group") %}
-### {{ group }}
-{% for commit in commits %}
-- {{ commit.message | upper_first }}\
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}](https://github.com/forzagreen/n2words/compare/{{ previous.version }}...{{ version }}) ({{ timestamp | date(format="%Y-%m-%d") }})
+{% else %}\
+## [Unreleased]
+{% endif %}
+{% set breaking = commits | filter(attribute="breaking", value=true) %}\
+{% if breaking | length > 0 %}
+### ⚠ BREAKING CHANGES
+
+{% for commit in breaking %}\
+* {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.breaking_description }}
+{% endfor %}\
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}\
+{% if "skip" not in group %}
+### {{ group | split(pat=">") | last }}
+
+{% for commit in commits %}\
+* {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message }} ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/forzagreen/n2words/commit/{{ commit.id }}))
+{% endfor %}\
+{% endif %}\
 {% endfor %}
-{% endfor %}
+
 """
 trim = true
 footer = ""
@@ -15,18 +46,28 @@ footer = ""
 conventional_commits = true
 filter_unconventional = true
 split_commits = false
+commit_preprocessors = [
+  # Link the squash-merge "(#123)" PR reference inline in the subject.
+  { pattern = '\(#([0-9]+)\)', replace = "([#${1}](https://github.com/forzagreen/n2words/issues/${1}))" },
+]
+# Group names carry an order prefix (<N>) the template strips, so
+# sections render in this order regardless of git-cliff's grouping
+# sort. Hidden types share a "<9>skip" group: the template skips any
+# group containing "skip", but they stay in the commit set so a
+# breaking change typed as chore!/ci!/etc. still surfaces in the
+# BREAKING CHANGES block above (rather than being dropped entirely).
 commit_parsers = [
-  { message = "^feat", group = "Features" },
-  { message = "^fix", group = "Bug Fixes" },
-  { message = "^perf", group = "Performance Improvements" },
-  { message = "^revert", group = "Reverts" },
-  { message = "^refactor", group = "Code Refactoring", skip = true },
-  { message = "^docs", skip = true },
-  { message = "^style", skip = true },
-  { message = "^chore", skip = true },
-  { message = "^test", skip = true },
-  { message = "^build", skip = true },
-  { message = "^ci", skip = true },
+  { message = "^feat", group = "<1>Features" },
+  { message = "^fix", group = "<2>Bug Fixes" },
+  { message = "^perf", group = "<3>Performance Improvements" },
+  { message = "^revert", group = "<4>Reverts" },
+  { message = "^refactor", group = "<9>skip" },
+  { message = "^docs", group = "<9>skip" },
+  { message = "^style", group = "<9>skip" },
+  { message = "^chore", group = "<9>skip" },
+  { message = "^test", group = "<9>skip" },
+  { message = "^build", group = "<9>skip" },
+  { message = "^ci", group = "<9>skip" },
 ]
 filter_commits = true
 tag_pattern = "v[0-9].*"


### PR DESCRIPTION
## Why

The current `cliff.toml` emits a header-less list — no version sections, dates, or links — and the release workflow runs it with `--output`, which **regenerates the whole file from git history on every release**. With this minimal template that would flatten the existing release-please history (version headers, compare links, and the hand-written 3.0.0 migration tables) into tool-generated text. This is the latent bug flagged during the 5.0.0 rectification (#307).

## What

Adopt the canonical **Conventional-Changelog / Keep a Changelog** shape — the OSS standard (semantic-release / standard-version / release-please all emit it) and the format already in `CHANGELOG.md`:

- per-version `## [x.y.z](compare-link) (date)` header, newest first
- leading `### ⚠ BREAKING CHANGES`, then changes grouped by type in a fixed order (Features → Bug Fixes → Performance Improvements → Reverts)
- **every entry ends in its `(#PR)` and commit links** — the PR is the full story behind the one-line hook
- PR/commit links are derived **offline** from the squash-merge subject and commit hash; no GitHub API or token needed
- internal types (chore/ci/docs/style/test/build/refactor) are hidden, but a breaking change typed as one (e.g. `chore!`) still surfaces in BREAKING CHANGES

The workflow now generates with `--unreleased --prepend`, so each release adds only its own section to the top and **all prior entries are preserved verbatim**.

### Rendered sample (the 5.0.0 window)

```
## [5.0.0](https://github.com/forzagreen/n2words/compare/v4.0.0...v5.0.0) (2026-05-30)


### ⚠ BREAKING CHANGES

* **core:** bump Node engine to >=22, drop EOL Node 20 ([#287](https://github.com/forzagreen/n2words/issues/287))

### Bug Fixes

* **types:** add typesVersions to support CommonJS imports in TypeScript ([#301](...)) ([3a381d2](...))
```

## Notes

- `CHANGELOG.md` is **not** modified here — the 5.0.0 entry and history are already correct; this only changes generation for future releases.
- Correct compare links depend on the `v5.0.0` git tag existing (still pending from the #307 rectification). Until that tag is created, the next release's `previous.version` would resolve to `v4.0.0`.
- Verified locally (git-cliff 2.13.1): rendered output matches the existing format, and `--prepend` inserts the new section below the `# Changelog` header with a blank-line separator while leaving history untouched.

## Test plan

- [x] `actionlint` clean across all workflows
- [x] Local render of the 5.0.0 window matches the canonical format
- [x] Local `--prepend` against the real CHANGELOG.md preserves history + header placement
- [ ] CI green