### PR TITLE
docs(scripts): fix and standardize lang:add invocation examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ function toCardinal (value, options) {
 ## Adding a Language
 
 ```bash
-npm run lang:add <code>  # Creates stub + fixture + type tests
+npm run lang:add -- <code>  # Creates stub + fixture + type tests
 ```
 
 Then: implement all three forms (`toCardinal`, `toOrdinal`, `toCurrency`) in `src/{code}.js`, add cases to `test/fixtures/{code}.js`, run `npm test`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ Scopes use BCP 47 language codes (`en-US`, `fr-BE`, `zh-Hans-CN`) or project are
 ## Adding a New Language
 
 ```bash
-npm run lang:add <code>   # e.g., ko-KR, sr-Cyrl-RS, fr-BE
+npm run lang:add -- <code>   # e.g., ko-KR, sr-Cyrl-RS, fr-BE
 ```
 
 This scaffolds all required files. Every language implements three **forms**:

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ Run `npm run bench` to measure on your hardware.
 We welcome contributions! Add a new language or improve existing ones:
 
 ```bash
-npm run lang:add <code>    # Scaffold a new language (BCP 47 code)
-npm test                   # Run full test suite
+npm run lang:add -- <code>   # Scaffold a new language (BCP 47 code)
+npm test                     # Run full test suite
 ```
 
 Also welcome: bug reports, feature requests, and documentation improvements.

--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -7,7 +7,11 @@
  * Supports scaffolding multiple conversion forms (cardinal, ordinal, currency).
  *
  * Usage:
- *   npm run lang:add [language-code] [options]
+ *   npm run lang:add -- [language-code] [options]
+ *
+ * The `--` separates npm's own args from the script's. It is required
+ * whenever you pass a flag (--cardinal etc.); without it npm swallows
+ * the flag and warns. Use it in every invocation for consistency.
  *
  * Options:
  *   --cardinal    Scaffold cardinal number support
@@ -18,12 +22,12 @@
  * If no form options provided, prompts for form selection.
  *
  * Examples:
- *   npm run lang:add                              # Fully interactive
- *   npm run lang:add ko-KR                        # Prompts for forms
- *   npm run lang:add ko-KR --cardinal             # Cardinal only
- *   npm run lang:add ko-KR --ordinal              # Ordinal only
- *   npm run lang:add ko-KR --currency             # Currency only
- *   npm run lang:add ko-KR --cardinal --ordinal   # Multiple forms
+ *   npm run lang:add                                 # Fully interactive
+ *   npm run lang:add -- ko-KR                        # Prompts for forms
+ *   npm run lang:add -- ko-KR --cardinal             # Cardinal only
+ *   npm run lang:add -- ko-KR --ordinal              # Ordinal only
+ *   npm run lang:add -- ko-KR --currency             # Currency only
+ *   npm run lang:add -- ko-KR --cardinal --ordinal   # Multiple forms
  */
 
 import { execSync } from 'node:child_process'
@@ -536,7 +540,10 @@ async function main () {
   const { code: cliCode, forms: cliFlags, help } = parseArgs(process.argv.slice(2))
 
   if (help) {
-    console.log(chalk.cyan('Usage: npm run lang:add [language-code] [options]'))
+    console.log(chalk.cyan('Usage: npm run lang:add -- [language-code] [options]'))
+    console.log()
+    console.log(chalk.gray('The `--` separates npm args from the script. Required when passing'))
+    console.log(chalk.gray('a flag; use it always for consistency.'))
     console.log()
     console.log(chalk.gray('Options:'))
     console.log(chalk.gray('  --cardinal    Scaffold cardinal number support'))
@@ -547,12 +554,12 @@ async function main () {
     console.log(chalk.gray('If no form options provided, prompts for form selection.'))
     console.log()
     console.log(chalk.gray('Examples:'))
-    console.log(chalk.gray('  npm run lang:add                              # Fully interactive'))
-    console.log(chalk.gray('  npm run lang:add ko-KR                        # Prompts for forms'))
-    console.log(chalk.gray('  npm run lang:add ko-KR --cardinal             # Cardinal only'))
-    console.log(chalk.gray('  npm run lang:add ko-KR --ordinal              # Ordinal only'))
-    console.log(chalk.gray('  npm run lang:add ko-KR --currency             # Currency only'))
-    console.log(chalk.gray('  npm run lang:add ko-KR --cardinal --ordinal   # Multiple forms'))
+    console.log(chalk.gray('  npm run lang:add                                 # Fully interactive'))
+    console.log(chalk.gray('  npm run lang:add -- ko-KR                        # Prompts for forms'))
+    console.log(chalk.gray('  npm run lang:add -- ko-KR --cardinal             # Cardinal only'))
+    console.log(chalk.gray('  npm run lang:add -- ko-KR --ordinal              # Ordinal only'))
+    console.log(chalk.gray('  npm run lang:add -- ko-KR --currency             # Currency only'))
+    console.log(chalk.gray('  npm run lang:add -- ko-KR --cardinal --ordinal   # Multiple forms'))
     process.exit(0)
   }
 
@@ -650,10 +657,10 @@ async function main () {
   // Success message
   console.log(chalk.green(`\n✓ Successfully scaffolded ${code} ${isNewLanguage ? 'language' : 'forms'}`))
   console.log(chalk.cyan('\nNext steps:'))
-  console.log(chalk.gray(`1. Implement ${langFilePath}`))
-  console.log(chalk.gray(`2. Add test cases to ${fixtureFilePath}`))
-  console.log(chalk.gray('3. Run: npm test'))
-  console.log(chalk.gray('4. Run: npm run build:types'))
+  console.log(chalk.gray(`1. Implement ${langFilePath} (replace the \`throw\` in each form)`))
+  console.log(chalk.gray(`2. Add at least one case per form to ${fixtureFilePath}`))
+  console.log(chalk.gray('   — the suite rejects empty fixtures, so it fails until you do'))
+  console.log(chalk.gray('3. Run: npm test  (runs the suite and builds types)'))
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Why

While reviewing why contributors aren't using `npm run lang:add` (the most recent language, pt-BR #275, was hand-written, not scaffolded), three concrete usability snags turned up.

## Fixes

1. **The script's own flag examples were broken.** Docstring and `--help` showed `npm run lang:add ko-KR --cardinal`. npm intercepts the bare `--cardinal` (`npm warn Unknown cli config "--cardinal"`) and drops to interactive mode instead. Examples now use the `--` separator, with a short note on why it's required.

2. **Docs disagreed on invocation.** README / CONTRIBUTING / CLAUDE.md used `npm run lang:add <code>`; the PR template used `npm run lang:add -- <code>`. The bare code happens to forward on npm 11, but anything with a flag needs `--`. Standardized every doc on the always-safe `-- <code>` form.

3. **"Next steps" told you to run a command that fails.** A fresh scaffold writes empty fixtures, and the test harness rejects empty fixtures by design (`Empty cardinal fixture… must contain at least one test case`). The post-scaffold message now states a case per form is required first, and drops the redundant `npm run build:types` step — `npm test` already builds types.

No behavior change to the scaffolding itself; this is examples, docs, and the post-run message.

## Test plan

- [x] `npm run lint` clean (js + md)
- [x] `npm run lang:add -- --help` renders the corrected usage
- [x] End-to-end scaffold of a throwaway language shows the new next-steps, then reverted
- [ ] CI green

## Not included (deferred)

Discoverability work discussed alongside this — an "Add a language" issue template and a "don't see your language?" pointer on LANGUAGES.md — is intentionally left for a separate change.