### PR TITLE
docs: slim the PR template to what CI can't verify

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,41 +2,17 @@
 
 ## What does this do?
 
-<!-- A brief description of your changes -->
+<!-- What changed, and why -->
+
+## How was this tested?
+
+<!-- Commands run / scenarios checked.
+     CI already runs `npm test` + `npm run lint`. -->
 
 ## Related Issue
 
 <!-- Optional: Fixes #123 -->
 
-## Checklist
-
-- [ ] Tests pass (`npm test`)
-- [ ] Linting passes (`npm run lint`)
-
-<!-- That's it for most PRs! The sections below are optional. -->
-
 ---
 
-<details>
-<summary><b>Adding a new language?</b> (click to expand)</summary>
-
-**Recommended:** Use the scaffolding tool to generate all files automatically:
-
-```bash
-npm run lang:add -- <code>
-```
-
-**Manual setup:** If not using the scaffolding tool, ensure you have:
-
-- [ ] Language module in `src/<code>.js` exporting `toCardinal()`, `toOrdinal()`, and/or `toCurrency()`
-- [ ] Test fixture in `test/fixtures/<code>.js` with matching exports
-- [ ] Tests pass (`npm test`)
-
-</details>
-
-<details>
-<summary><b>Breaking change?</b> (click to expand)</summary>
-
-Describe what breaks and how users should update:
-
-</details>
+📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## What does this do?

Replaces the PR template with a shorter, unconditional one. Recent PRs showed the old template's conditional sections weren't working:

- **The language section reached nobody it targeted** — the one language PR (#275) discarded the template entirely and wrote a custom body.
- **Everyone else carried it as noise** — a types PR (#301) shipped the whole "Adding a new language?" `<details>` block plus its inapplicable checkboxes (`<details>` renders as a visible collapsible on every PR).
- **The checklist restated CI** — `tests pass` / `lint passes` are already enforced by CI, while the "how was this tested?" prose that maintainer PRs actually write wasn't prompted.

New template: `What does this do?` + `How was this tested?` + `Related Issue`, and a single link to CONTRIBUTING.md (where the language / breaking-change flows already live) in place of the two `<details>` blocks.

## How was this tested?

- `npm run lint:md` clean (the template is covered by the markdown lint glob)
- Confirmed the CONTRIBUTING link uses a full URL so it resolves from the rendered PR body (relative `.github/`-anchored links would 404)
- This PR's own description follows the new template shape

## Related Issue

<!-- none -->

---

📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).