### PR TITLE
fix(scripts): make lang:add output lint-clean and canonicalize the code

### DIFF
--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -203,7 +203,8 @@ function generateCardinalFunction (code) {
  * @returns {string} The number in words
  */
 function toCardinal (value) {
-  // parseCardinalValue(value) -> { isNegative, integerPart: bigint, decimalPart }
+  // parseCardinalValue(value) -> { isNegative, integerPart: bigint, decimalPart? }
+  // (decimalPart is present only for decimal inputs)
   parseCardinalValue(value)
 
   // TODO: build the words from integerPart, applying isNegative and decimalPart

--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -203,9 +203,10 @@ function generateCardinalFunction (code) {
  * @returns {string} The number in words
  */
 function toCardinal (value) {
-  const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // parseCardinalValue(value) -> { isNegative, integerPart: bigint, decimalPart }
+  parseCardinalValue(value)
 
-  // TODO: Implement conversion logic
+  // TODO: build the words from integerPart, applying isNegative and decimalPart
   throw new Error('${code} cardinal not yet implemented')
 }`
 }
@@ -225,9 +226,10 @@ function generateOrdinalFunction (code) {
  * @throws {RangeError} If value is not a positive integer
  */
 function toOrdinal (value) {
-  const integerPart = parseOrdinalValue(value)
+  // parseOrdinalValue(value) -> integerPart (bigint, positive integers only)
+  parseOrdinalValue(value)
 
-  // TODO: Implement conversion logic
+  // TODO: build and return the ordinal words
   throw new Error('${code} ordinal not yet implemented')
 }`
 }
@@ -248,10 +250,11 @@ function generateCurrencyFunction (code) {
  */
 function toCurrency (value, options) {
   options = validateOptions(options)
-  const { isNegative, dollars, cents } = parseCurrencyValue(value)
+  // parseCurrencyValue(value) -> { isNegative, dollars: bigint, cents: bigint }
+  parseCurrencyValue(value)
 
-  // TODO: Implement conversion logic
-  // TODO: Define currency vocabulary (e.g., dollar/dollars, cent/cents)
+  // TODO: build the words from dollars and cents, applying isNegative
+  // TODO: define this locale's currency vocabulary (major/minor unit names)
   throw new Error('${code} currency not yet implemented')
 }`
 }
@@ -579,10 +582,13 @@ async function main () {
     process.exit(1)
   }
 
-  // Warn if using non-canonical form
+  // Canonicalize the code (e.g. cy-gb -> cy-GB) so the filename, export
+  // name, and import path all follow the project's BCP 47 convention.
+  // Everything downstream uses `code`, so reassign it here.
   const canonical = getCanonicalCode(code)
   if (canonical && canonical !== code) {
-    console.log(chalk.yellow(`Warning: "${code}" will be canonicalized to "${canonical}"`))
+    console.log(chalk.yellow(`Note: canonicalized "${code}" -> "${canonical}"`))
+    code = canonical
   }
 
   const normalized = normalizeCode(code)


### PR DESCRIPTION
## What does this do?

Fixes two bugs that left a freshly scaffolded language failing the project's own gates before the contributor writes anything.

**1. Generated stubs failed `npm run lint`.** The stubs destructured parser results they never used (the body just `throw`s), so `standard` reported **7 `no-unused-vars` errors** on a brand-new file. Stubs now call the parser (keeping the import used and the input validated) and document the returned shape in a comment, instead of binding unused locals.

**2. Non-canonical codes weren't canonicalized.** `npm run lang:add -- cy-gb` printed *"will be canonicalized to cy-GB"* but then created `src/cy-gb.js` with export `cyGb` and an `n2words/cy-gb` import path — the notice never took effect ([add-language.js:586](scripts/add-language.js#L586) computed the canonical form but downstream kept using the raw input). The code is now reassigned to its canonical form, so filename, export name, and import path all follow the BCP 47 convention and the message is accurate.

Combined with the empty-fixture test failure, a fresh scaffold previously failed **both** lint and test; #1 makes lint pass out of the box.

## How was this tested?

- `npx standard scripts/add-language.js` — clean
- Scaffolded `cy-gb` end-to-end: created `src/cy-GB.js` (export `cyGB`), and `npx standard src/cy-GB.js` passed with 0 errors
- Reverted the throwaway scaffold (files + LANGUAGES.md)

## Related Issue

<!-- none; found during the lang:add audit alongside #310 -->


📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).
