### PR TITLE
docs: drop the redundant rule from the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,4 @@
 
 <!-- Optional: Fixes #123 -->
 
----
-
 📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## What does this do?

Removes the `---` horizontal rule before the CONTRIBUTING footer in the PR template (added in #311).

GitHub renders an underline beneath every `##` heading. Because **Related Issue** is optional and usually left empty, that heading's underline ended up directly adjacent to the `---`, rendering as a **double horizontal rule**. The heading underlines already separate sections, so the explicit rule was redundant — dropping it removes the artifact whether or not Related Issue is filled.

## How was this tested?

- `npm run lint:md` clean
- Confirmed the footer still reads cleanly with just a blank line above it

## Related Issue

<!-- none; follow-up to #311 -->

📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).