### PR TITLE
refactor(core): derive language forms from exports, not source text

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve'
 import terser from '@rollup/plugin-terser'
 import virtual from '@rollup/plugin-virtual'
 import { readFileSync } from 'node:fs'
-import { getLanguageCodes } from './test/helpers/language-helpers.js'
+import { getExportedForms, getLanguageCodes } from './test/helpers/language-helpers.js'
 import { normalizeCode } from './test/helpers/language-naming.js'
 
 // Read package.json for version
@@ -11,42 +11,6 @@ const pkg = JSON.parse(readFileSync('./package.json', 'utf8'))
 
 // Get all language codes from the src directory
 const languageCodes = getLanguageCodes()
-
-/**
- * Check if a language file exports a given function name.
- * @param {string} content File content
- * @param {string} fnName Function name to look for in export statement
- * @returns {boolean}
- */
-function hasExport (content, fnName) {
-  const exportMatch = content.match(/export\s*\{([^}]+)\}/)
-  return exportMatch ? exportMatch[1].includes(fnName) : false
-}
-
-/**
- * Get languages that have ordinal support by checking for toOrdinal export.
- * @returns {string[]} Language codes with ordinal support
- */
-function getOrdinalLanguages () {
-  return languageCodes.filter(code => {
-    const content = readFileSync(`./src/${code}.js`, 'utf8')
-    return hasExport(content, 'toOrdinal')
-  })
-}
-
-/**
- * Get languages that have currency support by checking for toCurrency export.
- * @returns {string[]} Language codes with currency support
- */
-function getCurrencyLanguages () {
-  return languageCodes.filter(code => {
-    const content = readFileSync(`./src/${code}.js`, 'utf8')
-    return hasExport(content, 'toCurrency')
-  })
-}
-
-const ordinalLanguages = getOrdinalLanguages()
-const currencyLanguages = getCurrencyLanguages()
 
 /**
  * Rollup configuration for n2words bundles.
@@ -124,12 +88,13 @@ const languageEsmConfigs = languageCodes.map(langCode => ({
   plugins: [...basePlugins, individualTerserConfig]
 }))
 
-// Generate individual UMD language bundle configurations
-const languageUmdConfigs = languageCodes.map(langCode => {
+/**
+ * Build the UMD config for one language. `forms` is the Set of forms the
+ * language actually exports (read from the module, not scanned from text).
+ */
+function umdConfig (langCode, forms) {
   const normalizedName = normalizeCode(langCode)
   const virtualEntryId = `\0virtual:umd:${langCode}`
-  const hasOrdinal = ordinalLanguages.includes(langCode)
-  const hasCurrency = currencyLanguages.includes(langCode)
 
   // Build virtual entry content
   // Cardinal: n2words.enUS(42) → "forty-two"
@@ -137,12 +102,12 @@ const languageUmdConfigs = languageCodes.map(langCode => {
   // Currency: n2words.currency.enUS(42.50) → "forty-two dollars and fifty cents"
   let virtualContent = `export { toCardinal as ${normalizedName} } from './src/${langCode}.js';\n`
 
-  if (hasOrdinal) {
+  if (forms.has('ordinal')) {
     virtualContent += `import { toOrdinal } from './src/${langCode}.js';\n`
     virtualContent += `export const ordinal = { ${normalizedName}: toOrdinal };\n`
   }
 
-  if (hasCurrency) {
+  if (forms.has('currency')) {
     virtualContent += `import { toCurrency } from './src/${langCode}.js';\n`
     virtualContent += `export const currency = { ${normalizedName}: toCurrency };\n`
   }
@@ -165,10 +130,17 @@ const languageUmdConfigs = languageCodes.map(langCode => {
       individualTerserConfig
     ]
   }
-})
+}
 
-// Export all configurations as an array
-export default [
-  ...languageEsmConfigs,
-  ...languageUmdConfigs
-]
+// Async config: resolve each language's exported forms (an import() per
+// module), then build the UMD entries from real exports.
+export default async () => {
+  const languageUmdConfigs = await Promise.all(
+    languageCodes.map(async langCode => umdConfig(langCode, await getExportedForms(langCode)))
+  )
+
+  return [
+    ...languageEsmConfigs,
+    ...languageUmdConfigs
+  ]
+}

--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -34,6 +34,7 @@ import { execSync } from 'node:child_process'
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import * as readline from 'node:readline/promises'
 import chalk from 'chalk'
+import { getExportedForms } from '../test/helpers/language-helpers.js'
 import { getCanonicalCode, getLanguageName, isInCLDR, isValidLanguageCode, normalizeCode } from '../test/helpers/language-naming.js'
 
 // ============================================================================
@@ -374,35 +375,6 @@ export const currency = [
 // ============================================================================
 
 /**
- * Check which forms are already implemented for a language.
- *
- * @param {string} code Language code
- * @returns {Set<string>} Set of implemented forms
- */
-function getExistingForms (code) {
-  const filePath = `./src/${code}.js`
-  const forms = new Set()
-
-  if (!existsSync(filePath)) {
-    return forms
-  }
-
-  const content = readFileSync(filePath, 'utf-8')
-
-  if (content.includes('function toCardinal')) {
-    forms.add('cardinal')
-  }
-  if (content.includes('function toOrdinal')) {
-    forms.add('ordinal')
-  }
-  if (content.includes('function toCurrency')) {
-    forms.add('currency')
-  }
-
-  return forms
-}
-
-/**
  * Add new forms to an existing language file.
  *
  * @param {string} code Language code
@@ -596,8 +568,8 @@ async function main () {
   const langFilePath = `./src/${code}.js`
   const fixtureFilePath = `./test/fixtures/${code}.js`
 
-  // Check existing implementation
-  const existingForms = getExistingForms(code)
+  // Check existing implementation (read from real exports, not source text)
+  const existingForms = await getExportedForms(code)
   const isNewLanguage = existingForms.size === 0
 
   // Determine which forms to scaffold

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -15,6 +15,7 @@
  */
 
 import { readFileSync, writeFileSync, readdirSync } from 'node:fs'
+import { getExportedForms } from '../test/helpers/language-helpers.js'
 import { getLanguageName } from '../test/helpers/language-naming.js'
 
 // ============================================================================
@@ -58,27 +59,8 @@ function getDisplayName (code) {
 // Feature Detection
 // ============================================================================
 
-/**
- * Check if a language has ordinal support.
- *
- * @param {string} code Language code
- * @returns {boolean} True if language exports toOrdinal
- */
-function hasOrdinal (code) {
-  const content = readFileSync(`./src/${code}.js`, 'utf-8')
-  return content.includes('toOrdinal') && content.includes('export {')
-}
-
-/**
- * Check if a language has currency support.
- *
- * @param {string} code Language code
- * @returns {boolean} True if language exports toCurrency
- */
-function hasCurrency (code) {
-  const content = readFileSync(`./src/${code}.js`, 'utf-8')
-  return content.includes('toCurrency') && content.includes('export {')
-}
+// Form support (ordinal/currency) is read from each module's real exports
+// via getExportedForms — see main(), which passes a `forms` map down.
 
 // ============================================================================
 // Options Extraction
@@ -258,9 +240,13 @@ function formatOptionsTable (options) {
  * Generate the LANGUAGES.md content.
  *
  * @param {string[]} codes Array of language codes
+ * @param {Map<string, Set<string>>} forms Code -> set of exported forms
  * @returns {string} Markdown content
  */
-function generateMarkdown (codes) {
+function generateMarkdown (codes, forms) {
+  const hasOrdinal = code => forms.get(code).has('ordinal')
+  const hasCurrency = code => forms.get(code).has('currency')
+
   const languageCount = codes.length
   const codesWithOrdinal = codes.filter(hasOrdinal)
   const ordinalCount = codesWithOrdinal.length
@@ -356,9 +342,12 @@ ${optionSections.join('\n\n')}
 // Main
 // ============================================================================
 
-function main () {
+async function main () {
   const codes = getLanguageCodes()
-  const markdown = generateMarkdown(codes)
+  const forms = new Map(
+    await Promise.all(codes.map(async code => [code, await getExportedForms(code)]))
+  )
+  const markdown = generateMarkdown(codes, forms)
 
   writeFileSync('./LANGUAGES.md', markdown)
   console.log(`✓ Generated LANGUAGES.md (${codes.length} languages)`)

--- a/test/helpers/language-helpers.js
+++ b/test/helpers/language-helpers.js
@@ -28,3 +28,34 @@ export function getLanguageCodes () {
     .filter(file => file.endsWith('.js'))
     .map(file => file.replace('.js', ''))
 }
+
+// Form key -> the export a language provides when it supports that form.
+const FORM_EXPORTS = {
+  cardinal: 'toCardinal',
+  ordinal: 'toOrdinal',
+  currency: 'toCurrency'
+}
+
+/**
+ * Gets the forms a language supports, read from the module's real exports
+ * rather than by scanning source text. The exports ARE the behavior, so this
+ * can't drift from comment or formatting changes.
+ *
+ * @param {string} code Language code (e.g. 'en-US')
+ * @returns {Promise<Set<'cardinal'|'ordinal'|'currency'>>} Supported forms
+ *   (empty if the module is missing or fails to import)
+ */
+export async function getExportedForms (code) {
+  let mod
+  try {
+    mod = await import(`../../src/${code}.js`)
+  } catch {
+    return new Set()
+  }
+
+  return new Set(
+    Object.entries(FORM_EXPORTS)
+      .filter(([, exportName]) => typeof mod[exportName] === 'function')
+      .map(([form]) => form)
+  )
+}


### PR DESCRIPTION
## What does this do?

Removes two of the three "regex-scrape source as data" sites flagged in the tooling audit. The build and tooling decided which forms a language supports by string-matching `export {` / `function toX` in its source — coupling behaviour to text formatting.

New shared helper `getExportedForms(code)` in `test/helpers/language-helpers.js` `import()`s the module and reports the forms it **actually exports**. The exports *are* the behaviour, so it can't drift from comments or formatting. All three consumers route through it:

- **`rollup.config.js`** — now an async config; UMD virtual entries are built from real exports instead of a regex on `export {`.
- **`scripts/generate-languages-md.js`** — form columns/counts come from the exports map; the source-scanning `hasOrdinal`/`hasCurrency` are deleted.
- **`scripts/add-language.js`** — `getExistingForms` (which grepped `function toX`) replaced by `getExportedForms`.

This is **Layer A** of removing source-as-data. The JSDoc-scraped options tables (Layer B) are a separate, larger change coming next.

## How was this tested?

- `npm run docs:languages` → `git diff LANGUAGES.md` is **empty** (byte-identical output)
- `npm run build:dist` → same **72 ESM + 72 UMD** bundles; spot-checked `dist/en-US.umd.js` still namespaces `enUS` / `ordinal` / `currency`
- `npm test` → 264 passing
- `npx standard` clean on all four changed files

No user-facing change — pure internal refactor (hence `refactor`, not shown in changelog).

## Related Issue

<!-- none; follow-up to the lang:add / tooling audit -->

📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).