### PR TITLE
fix(core): declare @types/node devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@rollup/plugin-node-resolve": "^16.0.3",
         "@rollup/plugin-terser": "^1.0.0",
         "@rollup/plugin-virtual": "^3.0.2",
+        "@types/node": "^24.12.4",
         "ava": "^8.0.1",
         "benchmark": "^2.1.4",
         "browserslist": "^4.28.2",
@@ -2848,14 +2849,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
-        "undici-types": ">=7.24.0 <7.24.7"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/resolve": {
@@ -10319,12 +10319,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "@rollup/plugin-node-resolve": "^16.0.3",
     "@rollup/plugin-terser": "^1.0.0",
     "@rollup/plugin-virtual": "^3.0.2",
+    "@types/node": "^24.12.4",
     "ava": "^8.0.1",
     "benchmark": "^2.1.4",
     "browserslist": "^4.28.2",


### PR DESCRIPTION
## What does this do?

Declares `@types/node` as an explicit devDependency. `tsconfig.json` sets `"types": ["node"]`, but `@types/node` was never declared — it only resolved because `@commitlint/cli` pulls it transitively and **npm hoists it** (a phantom dependency).

Surfaced while checking pnpm/bun support: under **pnpm's strict `node_modules`** layout, `tsc` can't find the node types, so `pnpm run test` and `pnpm run build` fail with `Cannot find type definition file for 'node'`. It's also fragile under npm — if commitlint ever drops that transitive `@types/node`, the build breaks with no local change.

Pinned to the `.nvmrc` major (24).

## How was this tested?

- **npm:** `npm test` (264) + `npm run build` still pass, output unchanged
- **pnpm:** in a throwaway clone of this branch, `pnpm install` + `pnpm run test` (264) + `pnpm run build` now **pass** (they failed before this change)
- `npm ci` clean, 0 vulnerabilities

## Related Issue

<!-- part of bun/pnpm compatibility work -->

📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).