### PR TITLE
chore: document pnpm/bun dev support and gitignore bun.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ bench/results.json
 # Alternative lock files (keep only package-lock.json)
 pnpm-lock.yaml
 yarn.lock
+bun.lock
 bun.lockb
 
 # AI assistants

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,8 @@ npm test
 
 **Requirements:** Node.js >=22, Git
 
+**Package manager:** examples use npm, but **pnpm** and **bun** work too — scripts run through `node --run`, so `pnpm run <script>` / `bun run <script>` behave the same. The committed lockfile is npm's; please don't commit `pnpm-lock.yaml` or `bun.lock`.
+
 ## Pull Request Process
 
 1. Create a feature branch: `git checkout -b feat/add-pt-BR`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ npm test
 
 **Requirements:** Node.js >=22, Git
 
-**Package manager:** examples use npm, but **pnpm** and **bun** work too — scripts run through `node --run`, so `pnpm run <script>` / `bun run <script>` behave the same. The committed lockfile is npm's; please don't commit `pnpm-lock.yaml` or `bun.lock`.
+**Package manager:** examples use npm, but **pnpm** and **bun** work too — scripts run through `node --run`, so `pnpm run <script>` / `bun run <script>` behave the same. `package-lock.json` is the committed lockfile; pnpm/bun/yarn lockfiles are gitignored.
 
 ## Pull Request Process
 


### PR DESCRIPTION
## What does this do?

Completes the bun/pnpm support work with two small changes:

1. **`.gitignore`**: add `bun.lock`. The "alternative lock files" block already ignored `pnpm-lock.yaml`, `yarn.lock`, and `bun.lockb` — but `bun.lockb` is bun's *old binary* format. Current bun (1.2+, tested 1.3.14) writes a *text-format* **`bun.lock`** by default, which wasn't ignored and would be committed by accident. (My bun test run created exactly this file.)
2. **CONTRIBUTING.md**: note that pnpm and bun work for development (scripts run via `node --run`), and that `package-lock.json` is the committed lockfile while the others are gitignored.

Scripts being PM-agnostic plus `@types/node` now declared (#317) is what makes pnpm/bun work; this PR makes that discoverable and guards against stray lockfiles.

## How was this tested?

- `git check-ignore` confirms all four lockfiles (`bun.lock`, `bun.lockb`, `pnpm-lock.yaml`, `yarn.lock`) are ignored
- `npm run lint:md` clean
- Underlying compat verified empirically (with #317): pnpm + bun each do `install` / `run test` (264) / `build` / `lint`; and a real `npm pack` tarball imports + runs under the bun runtime

## Related

Supersedes #306 (closed). Pairs with #317 (`@types/node`).

📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).