### PR TITLE
build(core): enable @babel/preset-env bugfixes

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -42,6 +42,7 @@ const babelConfig = {
     [
       '@babel/preset-env',
       {
+        bugfixes: true, // Narrower, smaller transforms (the default in Babel 8)
         modules: false // Preserve ES modules for Rollup's tree-shaking
       }
     ]


### PR DESCRIPTION
## What does this do?

Adds `bugfixes: true` to the `@babel/preset-env` config. It lets preset-env emit narrower, more-targeted workarounds instead of broad transforms — the recommended setting on Babel 7, and the default in Babel 8.

## How was this tested?

- `npm run build:dist` → same 72 ESM + 72 UMD bundles
- **dist is byte-identical** with and without the flag (verified by hashing all bundles both ways) — no current transforms fire for these targets, so this is purely future-proofing + Babel-8 alignment
- `npx standard rollup.config.js` clean

## Note

This is the minimal "make the config optimal" change. Separately worth discussing whether babel earns its place at all for this project's targets — see the conversation; happy to pivot to removing it if preferred.

📚 Adding a language or a breaking change? See [CONTRIBUTING.md](https://github.com/forzagreen/n2words/blob/main/CONTRIBUTING.md).