### PR TITLE
build: clarify terser mangle-safety rationale in rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,7 +38,7 @@ const languageCodes = getLanguageCodes()
 // Individual bundle terser config — aggressive because each bundle is a
 // self-contained leaf artifact: nothing external imports its internals, so
 // every non-exported top-level name is safe to mangle. Terser still preserves
-// the public exports (toCardinal/toOrdinal/toCurrency) regardless of toplevel.
+// each bundle's public export names regardless of toplevel.
 const individualTerserConfig = terser({
   compress: {
     passes: 3, // Extra pass for better compression

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -35,7 +35,10 @@ const languageCodes = getLanguageCodes()
  * multiple languages to be loaded together without conflicts.
  */
 
-// Individual bundle terser config - aggressive since only one function is exported
+// Individual bundle terser config — aggressive because each bundle is a
+// self-contained leaf artifact: nothing external imports its internals, so
+// every non-exported top-level name is safe to mangle. Terser still preserves
+// the public exports (toCardinal/toOrdinal/toCurrency) regardless of toplevel.
 const individualTerserConfig = terser({
   compress: {
     passes: 3, // Extra pass for better compression


### PR DESCRIPTION
## What

Corrects a stale comment on `individualTerserConfig` in `rollup.config.js`.

## Why

The comment claimed the aggressive `toplevel` mangling was safe *"since only one function is exported"*. That hasn't been true since languages gained ordinal/currency forms — **every** language now exports three functions (`toCardinal`, `toOrdinal`, `toCurrency`), verified across all 72 `src/*.js` files.

The minifier settings are correct and unchanged — the *reasoning* was just wrong. Aggressive top-level mangling is safe because each bundle is a **self-contained leaf artifact**: nothing external imports its internals, so every non-exported top-level name is free to rename. Terser preserves the public export names regardless (confirmed in the built output: `export{N as toCardinal,I as toCurrency,y as toOrdinal}`).

## Scope

- Comment-only. No change to `compress`/`mangle` options.
- Empirically confirmed beforehand that the current minifier config is already at its size floor (`module: true` / higher `ecma` move zero bytes), so no tuning was warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)