### PR TITLE
build: add prepack hook to build dist + types before packing

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "lint:fix": "eslint --fix && markdownlint-cli2 --fix",
     "lint:js": "eslint",
     "lint:md": "markdownlint-cli2",
+    "prepack": "node --run build",
     "prepare:husky": "husky",
     "test": "node --run test:unit && node --run build:types",
     "test:unit": "ava \"test/*.test.js\" \"test/utils/*.test.js\""


### PR DESCRIPTION
## What

Adds `"prepack": "node --run build"` to the npm scripts.

## Why

`dist/**` and `src/**/*.d.ts` are **gitignored build artifacts**, the `files` field promises to ship them, yet there was **no `prepack`/`prepublishOnly`/`prepare` hook to produce them**. The published package was correct only because `release.yml` happened to build in the right order before publishing — types as a *side effect* of the `npm test` step, dist via an explicit `build:dist` step. Nothing in the package itself guaranteed it, and:

- `npm pack` on a clean checkout silently produced an **incomplete tarball** (78 source `.js` + meta — **no dist, no types**).
- The release `Verify build artifacts` step only *prints* `find … *.d.ts`; it never asserts they exist. A typeless/distless publish would pass `npm publish --dry-run` unnoticed.

`prepack` moves that guarantee into the package: any `npm pack`/`npm publish` (local or CI) builds first and self-corrects.

### Why `prepack`, not `prepare`

`prepack` fires on pack/publish (and git-dependency installs) but **not** on plain local `npm install`, so it won't slow dev installs — and it avoids re-introducing the auto-on-install behavior this repo deliberately sidesteps by naming the husky script `prepare:husky` rather than `prepare`.

## Verification

Simulated a fresh checkout and packed:

```
$ node --run clean        # dist: 0 files, .d.ts: 0 files
$ npm pack                # > n2words@5.0.0 prepack  → full build runs
tarball: 304 files { meta: 4, dist: 144, 'src .js': 78, 'src .d.ts': 78 }
```

Without the hook the same clean-state pack ships only 82 files.

## Notes / follow-up

This makes the explicit build steps in `release.yml` (and the `npm pack --dry-run` in `ci.yml`'s build job) redundant — they'll now build via `prepack` too. Harmless (a redundant rebuild), but a future cleanup could slim those workflows now that the package is self-sufficient. Left out of this PR to keep it to the packaging guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)