### PR TITLE
ci: drop redundant build steps now covered by prepack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline
 
-      # `npm pack --dry-run` runs the prepack script (npm run build), so this one
+      # `npm pack --dry-run` runs the prepack script (node --run build), so this one
       # step both builds every artifact and verifies the published file list — a
       # failing build fails the pack. No separate build step needed.
       - name: Build & verify package contents

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,8 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline
 
-      - name: Build all artifacts
-        run: npm run build
-
-      - name: Verify package contents
+      # `npm pack --dry-run` runs the prepack script (npm run build), so this one
+      # step both builds every artifact and verifies the published file list — a
+      # failing build fails the pack. No separate build step needed.
+      - name: Build & verify package contents
         run: npm pack --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,9 +140,14 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
 
-      - name: Build dist
+      # `npm publish --dry-run` runs the prepack script (npm run build), which
+      # builds dist/ + type declarations and leaves them on disk for the steps
+      # that follow (Verify below, the real Publish, Create release archive).
+      # A failing build fails the dry run, gating the release before any commit,
+      # tag, or publish happens.
+      - name: Dry-run publish
         if: steps.version.outputs.skip != 'true'
-        run: npm run build:dist
+        run: npm publish --dry-run
 
       - name: Verify build artifacts
         if: steps.version.outputs.skip != 'true'
@@ -152,10 +157,6 @@ jobs:
           echo ""
           echo "Type declarations:"
           find src -name "*.d.ts" -type f
-
-      - name: Dry-run publish
-        if: steps.version.outputs.skip != 'true'
-        run: npm publish --dry-run
 
       # `--unreleased --prepend` adds ONLY the new version's section to
       # the top of the existing CHANGELOG.md. The old `--output`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         run: npm version ${{ steps.version.outputs.version }} --no-git-tag-version
 
-      # `npm publish --dry-run` runs the prepack script (npm run build), which
+      # `npm publish --dry-run` runs the prepack script (node --run build), which
       # builds dist/ + type declarations and leaves them on disk for the steps
       # that follow (Verify below, the real Publish, Create release archive).
       # A failing build fails the dry run, gating the release before any commit,


### PR DESCRIPTION
## What

Now that `prepack` (`node --run build`) guarantees a clean build before every pack/publish (#323), the explicit build steps in the workflows are redundant. This removes them.

- **`ci.yml`** (`build` job): dropped `Build all artifacts` (`npm run build`). The remaining `npm pack --dry-run` step runs `prepack`, so it both builds every artifact and verifies the published file list — a failing build fails the pack.
- **`release.yml`**: dropped `Build dist` (`npm run build:dist`), and reordered so `Dry-run publish` (`npm publish --dry-run`, which builds via `prepack`) runs **before** `Verify build artifacts`. The dry-run's `prepack` produces the artifacts that Verify inspects, that the real `Publish to npm` (`npm publish --provenance`, also `prepack`) ships fresh, and that `Create release archive` copies.

Net: every-push CI is **faster** (one build instead of two). The release job builds twice (dry-run pre-flight + real publish) — accepted, since releases are rare/manual and the inline pre-flight is worth it.

## Why the reorder is also more correct

Previously the `.d.ts` files `Verify build artifacts` checked for were a *coincidental* leftover from the `npm test` step's `build:types` — the old `Build dist` step only ran rollup, not `tsc`. After this change, `prepack` is the single source of every artifact the later steps read.

## Verification

`actionlint` clean on both files. Beyond that, an adversarial review (3 independent lenses + synthesis) empirically confirmed all five release-contract invariants on a clean tree:

- Both `npm pack --dry-run` and `npm publish --dry-run` rebuild 144 `dist/*.js` + 78 `src/**/*.d.ts` and leave them on disk; the tarball contains all 304 files.
- A **deliberately broken build** makes both dry-runs exit 1 → the build still gates the release before any commit, tag, or publish.
- No competing lifecycle hooks (`prepare`/`prepublish`/`prepublishOnly`/`postpack` all absent); skip-path guards intact; CI build job still `needs: lint` + push-to-main guarded.

Verdict: **safe to merge**, zero blocking findings.

## Noted (out of scope — pre-existing, not from this diff)

`Create release archive` (`release.yml`) uses a non-recursive `cp src/*.js src/*.d.ts …`, which omits the 6 `src/utils/*.d.ts` from the **GitHub Release zip**. This does **not** affect the npm package (the `files: ["src/**/*.d.ts"]` glob ships all 78). Byte-identical to `main`, so not a regression here — flagging as a possible standalone follow-up (`cp -r src/. …`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)