### PR TITLE
ci: include src/utils tree in release archive zip

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,8 @@ jobs:
           mkdir -p n2words-${VERSION}/{src,dist}
           # Recursive copy so the zip mirrors the npm package's src/ tree —
           # a flat `src/*.js src/*.d.ts` glob silently drops src/utils/ (its
-          # .js + .d.ts), which the package's `files: ["src/**/*"]` globs ship.
+          # .js + .d.ts), which the package's `src/**/*.js` + `src/**/*.d.ts`
+          # files globs ship.
           cp -r src/. n2words-${VERSION}/src/
           cp dist/*.js n2words-${VERSION}/dist/
           zip -r n2words-${VERSION}.zip n2words-${VERSION}/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,10 @@ jobs:
         run: |
           VERSION=${{ steps.version.outputs.version }}
           mkdir -p n2words-${VERSION}/{src,dist}
-          cp src/*.js src/*.d.ts n2words-${VERSION}/src/
+          # Recursive copy so the zip mirrors the npm package's src/ tree —
+          # a flat `src/*.js src/*.d.ts` glob silently drops src/utils/ (its
+          # .js + .d.ts), which the package's `files: ["src/**/*"]` globs ship.
+          cp -r src/. n2words-${VERSION}/src/
           cp dist/*.js n2words-${VERSION}/dist/
           zip -r n2words-${VERSION}.zip n2words-${VERSION}/
 


### PR DESCRIPTION
## What

Fixes the `Create release archive` step in `release.yml` to copy `src/` recursively, so the GitHub Release zip mirrors the npm package's `src/` tree.

```diff
-          cp src/*.js src/*.d.ts n2words-${VERSION}/src/
+          cp -r src/. n2words-${VERSION}/src/
```

## Why

The flat globs `src/*.js src/*.d.ts` match only top-level files and silently drop the entire `src/utils/` directory. The npm package ships those via its recursive `files: ["src/**/*.js", "src/**/*.d.ts"]` globs, so the supplementary Release zip was inconsistent with the published package.

It's actually worse than just missing type declarations: the zip dropped `src/utils/*.js` too — and every language file imports from `./utils/…` at runtime, so the old zip's `src/` was **non-functional** on its own.

## Verification

Built locally, then simulated both copies and compared against the package's actual shipped file list:

| | `src/*.js` `*.d.ts` (old) | `cp -r src/.` (new) | npm package ships |
|---|---|---|---|
| `.js` | 72 | **78** | 78 |
| `.d.ts` | 72 | **78** | 78 |
| `src/utils/` | ❌ absent | ✅ present (12 files) | 12 files |

The recursive copy now matches the package exactly. `actionlint` clean.

## Context

Found during the #324 adversarial review and noted as a pre-existing issue (not introduced by that diff). This is the standalone follow-up. Touches a different region of `release.yml` than #324, so the two merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)