### PR TITLE
refactor(core): annotate language files for strict checkJs (batch 1/3)

### DIFF
--- a/src/am-ET.js
+++ b/src/am-ET.js
@@ -57,6 +57,10 @@ const SCALE_WORDS = ['', THOUSAND, 'ሚሊዮን', 'ቢሊዮን']
 // Precomputed Lookup Table
 // ============================================================================
 
+/**
+ * @param {number} n
+ * @returns {string}
+ */
 function buildSegment (n) {
   if (n === 0) return ''
 
@@ -89,6 +93,10 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -99,6 +107,10 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function buildLargeNumberWords (n) {
   const numStr = n.toString()
   const len = numStr.length
@@ -139,6 +151,10 @@ function buildLargeNumberWords (n) {
   return parts.join(' ')
 }
 
+/**
+ * @param {string} decimalPart
+ * @returns {string}
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/am-Latn-ET.js
+++ b/src/am-Latn-ET.js
@@ -57,6 +57,12 @@ const SCALE_WORDS = ['', THOUSAND, 'miliyon', 'billiyon']
 // Precomputed Lookup Table
 // ============================================================================
 
+/**
+ * Builds the words for a 3-digit segment (0-999).
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} The segment in Amharic (Latin) words
+ */
 function buildSegment (n) {
   if (n === 0) return ''
 
@@ -89,6 +95,12 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Amharic (Latin script) words.
+ *
+ * @param {bigint} n - Non-negative integer to convert
+ * @returns {string} The integer in Amharic (Latin) words
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -99,6 +111,12 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * Builds the words for a number of 1000 or greater using short-scale grouping.
+ *
+ * @param {bigint} n - Integer of 1000 or greater
+ * @returns {string} The number in Amharic (Latin) words
+ */
 function buildLargeNumberWords (n) {
   const numStr = n.toString()
   const len = numStr.length
@@ -139,6 +157,12 @@ function buildLargeNumberWords (n) {
   return parts.join(' ')
 }
 
+/**
+ * Reads the decimal part digit by digit.
+ *
+ * @param {string} decimalPart - The fractional digits as a string
+ * @returns {string} The decimal digits in Amharic (Latin) words
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/ar-SA.js
+++ b/src/ar-SA.js
@@ -76,6 +76,12 @@ const HALALA_PLURAL_11 = 'هللة'
  * Convert a 3-digit group to words.
  * Returns a clean string with no leading/trailing spaces.
  * Arabic "و" (and) is attached to following word: "مائة وخمسة" not "مائة و خمسة"
+ *
+ * @param {number} groupNumber - The 3-digit group value (0-999)
+ * @param {number} groupLevel - The scale level of this group (0 = units, 1 = thousands, ...)
+ * @param {bigint} fullNumber - The full number being converted
+ * @param {string[]} ones - Gender-specific ones words (1-19)
+ * @returns {string} The group rendered as words
  */
 function segmentToWords (groupNumber, groupLevel, fullNumber, ones) {
   const tensValue = groupNumber % 100
@@ -127,6 +133,13 @@ function segmentToWords (groupNumber, groupLevel, fullNumber, ones) {
   return result
 }
 
+/**
+ * Convert a non-negative integer to Arabic words.
+ *
+ * @param {bigint} n - The non-negative integer to convert
+ * @param {string} gender - 'masculine' or 'feminine'
+ * @returns {string} The number rendered as words
+ */
 function integerToWords (n, gender) {
   if (n === 0n) return ZERO
 
@@ -177,6 +190,13 @@ function integerToWords (n, gender) {
   return result
 }
 
+/**
+ * Convert the fractional digits of a number to Arabic words.
+ *
+ * @param {string} decimalPart - The decimal digits (after the separator)
+ * @param {string} gender - 'masculine' or 'feminine'
+ * @returns {string} The decimal part rendered as words
+ */
 function decimalPartToWords (decimalPart, gender) {
   const parts = []
   let i = 0
@@ -293,6 +313,9 @@ function toOrdinal (value, options) {
  * - 2: dual
  * - 3-10: plural form 1
  * - 11+: plural form 2 (different ending)
+ *
+ * @param {bigint} n - The riyal count
+ * @returns {string} The appropriate riyal word form
  */
 function getRiyalForm (n) {
   if (n === 1n) return RIYAL_SINGULAR
@@ -301,6 +324,12 @@ function getRiyalForm (n) {
   return RIYAL_PLURAL_11
 }
 
+/**
+ * Gets the appropriate halala word form based on number.
+ *
+ * @param {bigint} n - The halala count
+ * @returns {string} The appropriate halala word form
+ */
 function getHalalaForm (n) {
   if (n === 1n) return HALALA_SINGULAR
   if (n === 2n) return HALALA_DUAL

--- a/src/az-AZ.js
+++ b/src/az-AZ.js
@@ -37,6 +37,7 @@ const SCALE_WORDS = ['', THOUSAND, 'milyon', 'milyar', 'trilyon', 'katrilyon', '
 
 // Azerbaijani ordinals use -(i/ı/u/ü)nci/ncı/ncu/ncü suffix with vowel harmony
 // Special forms for 1-10
+/** @type {Record<number, string>} */
 const ORDINAL_SPECIAL = {
   1: 'birinci',
   2: 'ikinci',
@@ -61,6 +62,11 @@ const QEPIK = 'qəpik' // subunit (100 qəpik = 1 manat)
 // Precomputed Lookup Table
 // ============================================================================
 
+/**
+ * Builds the Azerbaijani words for a 3-digit segment (0-999).
+ * @param {number} n - The segment value
+ * @returns {string} The segment in words
+ */
 function buildSegment (n) {
   if (n === 0) return ''
 
@@ -96,6 +102,11 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Azerbaijani words.
+ * @param {bigint} n - The integer value
+ * @returns {string} The integer in words
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -106,6 +117,11 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * Builds Azerbaijani words for numbers >= 1000 using scale words.
+ * @param {bigint} n - The integer value
+ * @returns {string} The number in words
+ */
 function buildLargeNumberWords (n) {
   const numStr = n.toString()
   const len = numStr.length
@@ -149,6 +165,11 @@ function buildLargeNumberWords (n) {
   return parts.join(' ')
 }
 
+/**
+ * Converts the decimal-part digit string to Azerbaijani words.
+ * @param {string} decimalPart - The decimal digits as a string
+ * @returns {string} The decimal part in words
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/bn-BD.js
+++ b/src/bn-BD.js
@@ -65,6 +65,9 @@ const SCALE_WORDS = ['', 'হাজার', 'লাখ', 'কোটি', 'আর
 
 /**
  * Builds words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value in the range 0-999
+ * @returns {string} Bengali words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -138,6 +141,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Converts the fractional digits string to Bengali words.
+ *
+ * @param {string} decimalPart - The fractional digits (e.g. '05')
+ * @returns {string} Bengali words for the decimal part
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/cs-CZ.js
+++ b/src/cs-CZ.js
@@ -32,6 +32,7 @@ const TENS = ['', '', 'dvacet', 'třicet', 'čtyřicet', 'padesát', 'šedesát'
 const HUNDREDS = ['', 'sto', 'dvě stě', 'tři sta', 'čtyři sta', 'pět set', 'šest set', 'sedm set', 'osm set', 'devět set']
 
 // Scale plural forms [singular, few (2-4), many (5+)]
+/** @type {Record<number, string[]>} */
 const PLURAL_FORMS = {
   1: ['tisíc', 'tisíce', 'tisíc'], // 10^3
   2: ['milion', 'miliony', 'milionů'], // 10^6
@@ -81,6 +82,9 @@ const HALER_FORMS = ['haléř', 'haléře', 'haléřů']
 
 /**
  * Builds segment word for 0-999 (masculine, default form).
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Czech words
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -115,6 +119,9 @@ function buildSegment (n) {
 /**
  * Builds segment word for 0-999 with feminine hundreds.
  * Hundreds use irregular forms (dvě stě, tři sta) but ones remain masculine.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Czech words
  */
 function buildSegmentWithHundreds (n) {
   if (n === 0) return ''
@@ -174,6 +181,9 @@ function pluralize (n, forms) {
 /**
  * Gets the decimal separator word based on integer part.
  * celá (0-1), celé (2-4), celých (5+)
+ *
+ * @param {bigint} integerPart - The integer part of the value
+ * @returns {string} The decimal separator word
  */
 function getDecimalSeparator (integerPart) {
   if (integerPart === 0n || integerPart === 1n) {

--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -44,6 +44,7 @@ const SCALES = ['millioner', 'millarder', 'billioner', 'billarder', 'trillioner'
 
 // Danish ordinals: 1st-2nd special, others use -te/-nde suffix
 // "anden/andet" for 2nd (common/neuter), we use common form
+/** @type {Record<number, string>} */
 const ORDINAL_SPECIAL = {
   1: 'første',
   2: 'anden',
@@ -73,6 +74,9 @@ const ORE = 'øre' // same singular and plural
 
 /**
  * Builds segment word for 0-999.
+ *
+ * @param {number} n - Integer in range 0-999
+ * @returns {string} Danish words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -218,7 +222,7 @@ function buildLargeNumberWords (n) {
  * - After thousands with remainder: "tusinde og"
  * - Millions are space-separated
  *
- * @param {Array} parts - Parts with type metadata
+ * @param {Array<{word: string, type: string}>} parts - Parts with type metadata
  * @returns {string} Joined string
  */
 function joinDanishParts (parts) {

--- a/src/de-DE.js
+++ b/src/de-DE.js
@@ -251,7 +251,7 @@ function buildLargeNumberWords (n) {
  * Joins parts with German spacing rules.
  * Spaces only around million+ scale words.
  *
- * @param {Array} parts - Parts with metadata
+ * @param {Array<{words: string, isScale: boolean, scaleLevel: number}>} parts - Parts with metadata
  * @returns {string} Joined string
  */
 function joinGermanParts (parts) {

--- a/src/el-GR.js
+++ b/src/el-GR.js
@@ -58,6 +58,9 @@ const CENT_FORMS = ['λεπτό', 'λεπτά'] // Singular, plural
 
 /**
  * Builds segment word for 0-999.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Greek words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''

--- a/src/en-GH.js
+++ b/src/en-GH.js
@@ -60,6 +60,12 @@ const PESEWAS = 'pesewas'
 
 const segmentResult = { word: '', hasHundred: false }
 
+/**
+ * Builds the words for a three-digit segment (0-999).
+ *
+ * @param {number} n - The segment value (0-999)
+ * @returns {{word: string, hasHundred: boolean}} The segment words and whether it includes a hundred
+ */
 function buildSegment (n) {
   if (n === 0) {
     segmentResult.word = ''
@@ -99,6 +105,12 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to cardinal words.
+ *
+ * @param {bigint} n - The non-negative integer to convert
+ * @returns {string} The number in English words
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -124,6 +136,12 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * Builds cardinal words for integers of one million or greater.
+ *
+ * @param {bigint} n - The integer to convert (>= 1,000,000)
+ * @returns {string} The number in English words
+ */
 function buildLargeNumberWords (n) {
   const segments = []
   let temp = n
@@ -168,6 +186,12 @@ function buildLargeNumberWords (n) {
   return result
 }
 
+/**
+ * Converts the fractional digits of a decimal to words.
+ *
+ * @param {string} decimalPart - The decimal digits (e.g., "05")
+ * @returns {string} The decimal part in English words
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
 
@@ -217,6 +241,12 @@ function toCardinal (value) {
 // ORDINAL
 // ============================================================================
 
+/**
+ * Builds the ordinal words for a three-digit segment (0-999).
+ *
+ * @param {number} n - The segment value (0-999)
+ * @returns {string} The ordinal segment words
+ */
 function buildOrdinalSegment (n) {
   const ones = n % 10
   const tens = Math.trunc(n / 10) % 10
@@ -246,6 +276,12 @@ function buildOrdinalSegment (n) {
   return tensOnesOrdinal
 }
 
+/**
+ * Converts a positive integer to ordinal words.
+ *
+ * @param {bigint} n - The positive integer to convert
+ * @returns {string} The ordinal in English words
+ */
 function integerToOrdinal (n) {
   if (n < 1000n) {
     return buildOrdinalSegment(Number(n))
@@ -266,6 +302,12 @@ function integerToOrdinal (n) {
   return buildLargeOrdinal(n)
 }
 
+/**
+ * Builds ordinal words for integers of one million or greater.
+ *
+ * @param {bigint} n - The integer to convert (>= 1,000,000)
+ * @returns {string} The ordinal in English words
+ */
 function buildLargeOrdinal (n) {
   const segments = []
   let temp = n
@@ -309,6 +351,14 @@ function buildLargeOrdinal (n) {
   return result
 }
 
+/**
+ * Converts a numeric value to Ghanaian English ordinal words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
+ * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
+ * @throws {TypeError} If value is not a valid numeric type
+ * @throws {RangeError} If value is negative, zero, or has a decimal part
+ */
 function toOrdinal (value) {
   const integerPart = parseOrdinalValue(value)
   return integerToOrdinal(integerPart)
@@ -318,6 +368,15 @@ function toOrdinal (value) {
 // CURRENCY
 // ============================================================================
 
+/**
+ * Converts a numeric value to Ghanaian English currency words.
+ *
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {{and?: boolean}} [options] - Optional configuration
+ * @returns {string} The amount in Ghanaian English currency words
+ * @throws {TypeError} If value is not a valid numeric type
+ * @throws {Error} If value is not a valid number format
+ */
 function toCurrency (value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: cedis, cents: pesewas } = parseCurrencyValue(value)

--- a/src/en-KE.js
+++ b/src/en-KE.js
@@ -60,6 +60,9 @@ const CENTS = 'cents'
 
 const segmentResult = { word: '', hasHundred: false }
 
+/**
+ * @param {number} n
+ */
 function buildSegment (n) {
   if (n === 0) {
     segmentResult.word = ''
@@ -99,6 +102,9 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} n
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -124,6 +130,9 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * @param {bigint} n
+ */
 function buildLargeNumberWords (n) {
   const segments = []
   let temp = n
@@ -168,6 +177,9 @@ function buildLargeNumberWords (n) {
   return result
 }
 
+/**
+ * @param {string} decimalPart
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
 
@@ -217,6 +229,9 @@ function toCardinal (value) {
 // ORDINAL
 // ============================================================================
 
+/**
+ * @param {number} n
+ */
 function buildOrdinalSegment (n) {
   const ones = n % 10
   const tens = Math.trunc(n / 10) % 10
@@ -246,6 +261,9 @@ function buildOrdinalSegment (n) {
   return tensOnesOrdinal
 }
 
+/**
+ * @param {bigint} n
+ */
 function integerToOrdinal (n) {
   if (n < 1000n) {
     return buildOrdinalSegment(Number(n))
@@ -266,6 +284,9 @@ function integerToOrdinal (n) {
   return buildLargeOrdinal(n)
 }
 
+/**
+ * @param {bigint} n
+ */
 function buildLargeOrdinal (n) {
   const segments = []
   let temp = n
@@ -309,6 +330,12 @@ function buildLargeOrdinal (n) {
   return result
 }
 
+/**
+ * Converts a numeric value to Kenyan English ordinal words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert
+ * @returns {string} The ordinal in English words
+ */
 function toOrdinal (value) {
   const integerPart = parseOrdinalValue(value)
   return integerToOrdinal(integerPart)
@@ -318,6 +345,13 @@ function toOrdinal (value) {
 // CURRENCY
 // ============================================================================
 
+/**
+ * Converts a numeric value to Kenyan English currency words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert
+ * @param {{and?: boolean}} [options] - Currency formatting options
+ * @returns {string} The currency in English words
+ */
 function toCurrency (value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: shillings, cents } = parseCurrencyValue(value)

--- a/src/en-MY.js
+++ b/src/en-MY.js
@@ -61,6 +61,9 @@ const SEN = 'sen'
 
 const segmentResult = { word: '', hasHundred: false }
 
+/**
+ * @param {number} n
+ */
 function buildSegment (n) {
   if (n === 0) {
     segmentResult.word = ''
@@ -100,6 +103,9 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} n
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -125,6 +131,9 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * @param {bigint} n
+ */
 function buildLargeNumberWords (n) {
   const segments = []
   let temp = n
@@ -169,6 +178,9 @@ function buildLargeNumberWords (n) {
   return result
 }
 
+/**
+ * @param {string} decimalPart
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
 
@@ -218,6 +230,9 @@ function toCardinal (value) {
 // ORDINAL
 // ============================================================================
 
+/**
+ * @param {number} n
+ */
 function buildOrdinalSegment (n) {
   const ones = n % 10
   const tens = Math.trunc(n / 10) % 10
@@ -247,6 +262,9 @@ function buildOrdinalSegment (n) {
   return tensOnesOrdinal
 }
 
+/**
+ * @param {bigint} n
+ */
 function integerToOrdinal (n) {
   if (n < 1000n) {
     return buildOrdinalSegment(Number(n))
@@ -267,6 +285,9 @@ function integerToOrdinal (n) {
   return buildLargeOrdinal(n)
 }
 
+/**
+ * @param {bigint} n
+ */
 function buildLargeOrdinal (n) {
   const segments = []
   let temp = n
@@ -310,6 +331,10 @@ function buildLargeOrdinal (n) {
   return result
 }
 
+/**
+ * @param {number | string | bigint} value
+ * @returns {string}
+ */
 function toOrdinal (value) {
   const integerPart = parseOrdinalValue(value)
   return integerToOrdinal(integerPart)
@@ -319,6 +344,11 @@ function toOrdinal (value) {
 // CURRENCY
 // ============================================================================
 
+/**
+ * @param {number | string | bigint} value
+ * @param {{and?: boolean}} [options]
+ * @returns {string}
+ */
 function toCurrency (value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: ringgit, cents: sen } = parseCurrencyValue(value)

--- a/src/en-NZ.js
+++ b/src/en-NZ.js
@@ -247,6 +247,12 @@ function toCardinal (value) {
 // ORDINAL
 // ============================================================================
 
+/**
+ * Builds ordinal words for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Ordinal words
+ */
 function buildOrdinalSegment (n) {
   const ones = n % 10
   const tens = Math.trunc(n / 10) % 10
@@ -276,6 +282,12 @@ function buildOrdinalSegment (n) {
   return tensOnesOrdinal
 }
 
+/**
+ * Converts a non-negative integer to English ordinal words.
+ *
+ * @param {bigint} n - Non-negative integer to convert
+ * @returns {string} English ordinal words
+ */
 function integerToOrdinal (n) {
   if (n < 1000n) {
     return buildOrdinalSegment(Number(n))
@@ -296,6 +308,12 @@ function integerToOrdinal (n) {
   return buildLargeOrdinal(n)
 }
 
+/**
+ * Builds ordinal words for numbers >= 1,000,000.
+ *
+ * @param {bigint} n - Number >= 1,000,000
+ * @returns {string} English ordinal words
+ */
 function buildLargeOrdinal (n) {
   const segments = []
   let temp = n
@@ -339,6 +357,14 @@ function buildLargeOrdinal (n) {
   return result
 }
 
+/**
+ * Converts a numeric value to New Zealand English ordinal words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert (positive integer)
+ * @returns {string} The number as ordinal words
+ * @throws {TypeError} If value is not a valid numeric type
+ * @throws {RangeError} If value is negative, zero, or has a decimal part
+ */
 function toOrdinal (value) {
   const integerPart = parseOrdinalValue(value)
   return integerToOrdinal(integerPart)
@@ -348,6 +374,15 @@ function toOrdinal (value) {
 // CURRENCY
 // ============================================================================
 
+/**
+ * Converts a numeric value to New Zealand English currency words (New Zealand Dollar).
+ *
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {{and?: boolean}} [options] - Optional configuration
+ * @returns {string} The amount in New Zealand English currency words
+ * @throws {TypeError} If value is not a valid numeric type
+ * @throws {Error} If value is not a valid number format
+ */
 function toCurrency (value, options) {
   options = validateOptions(options)
   const { isNegative, dollars, cents } = parseCurrencyValue(value)

--- a/src/en-PH.js
+++ b/src/en-PH.js
@@ -60,6 +60,9 @@ const CENTAVOS = 'centavos'
 
 const segmentResult = { word: '', hasHundred: false }
 
+/**
+ * @param {number} n
+ */
 function buildSegment (n) {
   if (n === 0) {
     segmentResult.word = ''
@@ -99,6 +102,9 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} n
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -124,6 +130,9 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * @param {bigint} n
+ */
 function buildLargeNumberWords (n) {
   const segments = []
   let temp = n
@@ -168,6 +177,9 @@ function buildLargeNumberWords (n) {
   return result
 }
 
+/**
+ * @param {string} decimalPart
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
 
@@ -217,6 +229,9 @@ function toCardinal (value) {
 // ORDINAL
 // ============================================================================
 
+/**
+ * @param {number} n
+ */
 function buildOrdinalSegment (n) {
   const ones = n % 10
   const tens = Math.trunc(n / 10) % 10
@@ -246,6 +261,9 @@ function buildOrdinalSegment (n) {
   return tensOnesOrdinal
 }
 
+/**
+ * @param {bigint} n
+ */
 function integerToOrdinal (n) {
   if (n < 1000n) {
     return buildOrdinalSegment(Number(n))
@@ -266,6 +284,9 @@ function integerToOrdinal (n) {
   return buildLargeOrdinal(n)
 }
 
+/**
+ * @param {bigint} n
+ */
 function buildLargeOrdinal (n) {
   const segments = []
   let temp = n
@@ -309,6 +330,14 @@ function buildLargeOrdinal (n) {
   return result
 }
 
+/**
+ * Converts a numeric value to Philippine English ordinal words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
+ * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
+ * @throws {TypeError} If value is not a valid numeric type
+ * @throws {RangeError} If value is negative, zero, or has a decimal part
+ */
 function toOrdinal (value) {
   const integerPart = parseOrdinalValue(value)
   return integerToOrdinal(integerPart)
@@ -318,6 +347,15 @@ function toOrdinal (value) {
 // CURRENCY
 // ============================================================================
 
+/**
+ * Converts a numeric value to Philippine English currency words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert
+ * @param {{and?: boolean}} [options] - Optional configuration
+ * @returns {string} The amount in Philippine English currency words
+ * @throws {TypeError} If value is not a valid numeric type
+ * @throws {Error} If value is not a valid number format
+ */
 function toCurrency (value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: pesos, cents: centavos } = parseCurrencyValue(value)

--- a/src/en-SG.js
+++ b/src/en-SG.js
@@ -60,6 +60,10 @@ const CENTS = 'cents'
 
 const segmentResult = { word: '', hasHundred: false }
 
+/**
+ * @param {number} n - Number 0-999
+ * @returns {{ word: string, hasHundred: boolean }}
+ */
 function buildSegment (n) {
   if (n === 0) {
     segmentResult.word = ''
@@ -99,6 +103,10 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} n - Non-negative integer to convert
+ * @returns {string} English words
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -124,6 +132,10 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * @param {bigint} n - Number >= 1,000,000
+ * @returns {string} English words
+ */
 function buildLargeNumberWords (n) {
   const segments = []
   let temp = n
@@ -168,6 +180,10 @@ function buildLargeNumberWords (n) {
   return result
 }
 
+/**
+ * @param {string} decimalPart - Decimal digits (without the point)
+ * @returns {string} English words for decimal part
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
 
@@ -217,6 +233,10 @@ function toCardinal (value) {
 // ORDINAL
 // ============================================================================
 
+/**
+ * @param {number} n - Number 0-999
+ * @returns {string} Ordinal words for this segment
+ */
 function buildOrdinalSegment (n) {
   const ones = n % 10
   const tens = Math.trunc(n / 10) % 10
@@ -246,6 +266,10 @@ function buildOrdinalSegment (n) {
   return tensOnesOrdinal
 }
 
+/**
+ * @param {bigint} n - Positive integer to convert
+ * @returns {string} Ordinal English words
+ */
 function integerToOrdinal (n) {
   if (n < 1000n) {
     return buildOrdinalSegment(Number(n))
@@ -266,6 +290,10 @@ function integerToOrdinal (n) {
   return buildLargeOrdinal(n)
 }
 
+/**
+ * @param {bigint} n - Number >= 1,000,000
+ * @returns {string} Ordinal English words
+ */
 function buildLargeOrdinal (n) {
   const segments = []
   let temp = n
@@ -309,6 +337,12 @@ function buildLargeOrdinal (n) {
   return result
 }
 
+/**
+ * Converts a numeric value to Singaporean English ordinal words.
+ *
+ * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
+ * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
+ */
 function toOrdinal (value) {
   const integerPart = parseOrdinalValue(value)
   return integerToOrdinal(integerPart)
@@ -318,6 +352,13 @@ function toOrdinal (value) {
 // CURRENCY
 // ============================================================================
 
+/**
+ * Converts a numeric value to Singaporean English currency words.
+ *
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {{ and?: boolean }} [options] - Optional configuration
+ * @returns {string} The amount in Singaporean English currency words
+ */
 function toCurrency (value, options) {
   options = validateOptions(options)
   const { isNegative, dollars, cents } = parseCurrencyValue(value)

--- a/src/fa-IR.js
+++ b/src/fa-IR.js
@@ -17,9 +17,13 @@ import { parseOrdinalValue } from './utils/parse-ordinal.js'
 // Vocabulary
 // ============================================================================
 
+/** @type {Record<number, string>} */
 const ONES = { 1: 'یک', 2: 'دو', 3: 'سه', 4: 'چهار', 5: 'پنج', 6: 'شش', 7: 'هفت', 8: 'هشت', 9: 'نه' }
+/** @type {Record<number, string>} */
 const TEENS = { 10: 'ده', 11: 'یازده', 12: 'دوازده', 13: 'سیزده', 14: 'چهارده', 15: 'پانزده', 16: 'شانزده', 17: 'هفده', 18: 'هجده', 19: 'نوزده' }
+/** @type {Record<number, string>} */
 const TENS = { 20: 'بیست', 30: 'سی', 40: 'چهل', 50: 'پنجاه', 60: 'شصت', 70: 'هفتاد', 80: 'هشتاد', 90: 'نود' }
+/** @type {Record<number, string>} */
 const HUNDREDS = { 100: 'صد', 200: 'دویست', 300: 'سيصد', 400: 'چهار صد', 500: 'پانصد', 600: 'ششصد', 700: 'هفتصد', 800: 'هشتصد', 900: 'نهصد' }
 
 const THOUSAND = 'هزار'
@@ -37,6 +41,7 @@ const DECIMAL_SEP = 'ممیّز'
 // Persian ordinals: add -ُم (-om) suffix to cardinal
 // Special forms for 1st, 2nd, 3rd
 const ORDINAL_SUFFIX = 'م' // ـُم (-om)
+/** @type {Record<number, string>} */
 const ORDINAL_ONES = {
   1: 'اول', // avval (first)
   2: 'دوم', // dovvom (second)
@@ -59,6 +64,12 @@ const RIAL = 'ریال'
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Persian cardinal words.
+ *
+ * @param {bigint} n - Non-negative integer to convert
+ * @returns {string} Persian cardinal words
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -121,6 +132,12 @@ function integerToWords (n) {
   return `${milliardPrefix}${suffix}`
 }
 
+/**
+ * Converts the fractional digits of a number to Persian words.
+ *
+ * @param {string} decimalPart - The fractional digits as a string
+ * @returns {string} Persian words for the decimal portion
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/fi-FI.js
+++ b/src/fi-FI.js
@@ -66,6 +66,9 @@ const CENT_SINGULAR = 'sentti'
 /**
  * Builds segment word for 0-999.
  * Omits "yksi" before "sata" (hundred).
+ *
+ * @param {number} n - Integer 0-999 to convert
+ * @returns {string} Finnish words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -263,6 +266,9 @@ function toCardinal (value) {
 /**
  * Builds ordinal segment for 0-99.
  * Finnish ordinals have special forms.
+ *
+ * @param {number} n - Integer 0-99 to convert
+ * @returns {string} Finnish ordinal words for the segment
  */
 function buildOrdinalSegment (n) {
   if (n === 0) return ''

--- a/src/fil-PH.js
+++ b/src/fil-PH.js
@@ -58,6 +58,10 @@ const SENTIMO = 'sentimo'
 
 const VOWELS = ['a', 'e', 'i', 'o', 'u']
 
+/**
+ * @param {string} word - Word to append a linker to
+ * @returns {string} Word with "ng" or " na" linker appended
+ */
 function addLinker (word) {
   const lastChar = word[word.length - 1]
   if (VOWELS.includes(lastChar)) {
@@ -70,6 +74,10 @@ function addLinker (word) {
 // Segment Building
 // ============================================================================
 
+/**
+ * @param {number} n - Value 0-999 to convert to words
+ * @returns {string} Filipino words for the segment
+ */
 function buildSegment (n) {
   if (n === 0) return ''
 
@@ -114,6 +122,8 @@ function buildSegment (n) {
 
 /**
  * Builds segment with linker added to last word (for use before scale words).
+ * @param {number} n - Value 0-999 to convert to words
+ * @returns {string} Filipino words with a trailing linker
  */
 function buildSegmentWithLinker (n) {
   const segmentWord = buildSegment(n)
@@ -144,6 +154,10 @@ function buildSegmentWithLinker (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} n - Non-negative integer to convert to words
+ * @returns {string} Filipino words for the integer
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -191,6 +205,10 @@ function buildLargeNumberWords (n) {
   return result
 }
 
+/**
+ * @param {string} decimalPart - Digits after the decimal separator
+ * @returns {string} Per-digit Filipino reading of the decimal part
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/fr-BE.js
+++ b/src/fr-BE.js
@@ -56,6 +56,12 @@ const CENTIMES = 'centimes'
 // Segment Building
 // ============================================================================
 
+/**
+ * Builds the words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {{word: string, endsWithCents: boolean, endsWithVingts: boolean}} Segment words and flags
+ */
 function buildSegment (n) {
   if (n === 0) return { word: '', endsWithCents: false, endsWithVingts: false }
 
@@ -137,6 +143,13 @@ function buildSegment (n) {
 // Helper Functions
 // ============================================================================
 
+/**
+ * Returns the scale word (mille, million, milliard, ...) for a scale index.
+ *
+ * @param {number} scaleIndex - Scale group index
+ * @param {bigint} segment - Segment value used to decide pluralization
+ * @returns {string} The scale word
+ */
 function getScaleWord (scaleIndex, segment) {
   if (scaleIndex === 1) return THOUSAND
 
@@ -157,6 +170,13 @@ function getScaleWord (scaleIndex, segment) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Belgian French cardinal words.
+ *
+ * @param {bigint} n - Non-negative integer
+ * @param {boolean} [withHyphen=false] - Use hyphens between words
+ * @returns {string} The integer in Belgian French words
+ */
 function integerToWords (n, withHyphen = false) {
   if (n === 0n) return ZERO
 
@@ -196,6 +216,13 @@ function integerToWords (n, withHyphen = false) {
   return buildLargeNumberWords(n, withHyphen)
 }
 
+/**
+ * Builds words for large integers (>= 1,000,000) using scale groups.
+ *
+ * @param {bigint} n - Integer value (>= 1,000,000)
+ * @param {boolean} withHyphen - Use hyphens between words
+ * @returns {string} The integer in Belgian French words
+ */
 function buildLargeNumberWords (n, withHyphen) {
   const numStr = n.toString()
   const len = numStr.length
@@ -256,6 +283,13 @@ function buildLargeNumberWords (n, withHyphen) {
   return result
 }
 
+/**
+ * Converts the decimal part digits to words (leading zeros spoken as zéro).
+ *
+ * @param {string} decimalPart - Decimal digits as a string
+ * @param {boolean} withHyphen - Use hyphens between words
+ * @returns {string} The decimal part in Belgian French words
+ */
 function decimalPartToWords (decimalPart, withHyphen) {
   let result = ''
   const sep = withHyphen ? '-' : ' '

--- a/src/fr-FR.js
+++ b/src/fr-FR.js
@@ -60,6 +60,9 @@ const CENTIMES = 'centimes'
 /**
  * Builds segment word for 0-999.
  * Returns object with { word, endsWithCents, endsWithVingts } for pluralization handling.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {{ word: string, endsWithCents: boolean, endsWithVingts: boolean }} Segment words and pluralization flags
  */
 function buildSegment (n) {
   if (n === 0) return { word: '', endsWithCents: false, endsWithVingts: false }


### PR DESCRIPTION
## What

Batch 1 of 3 of the language-file annotations for the **full strict `checkJs`** migration (foundation landed in #326). Adds JSDoc type annotations to internal helpers in 20 language files so they pass `tsc` strict `checkJs` with zero errors.

Files (alphabetical, am-ET … fr-FR): `am-ET, am-Latn-ET, ar-SA, az-AZ, bn-BD, cs-CZ, da-DK, de-DE, el-GR, en-GH, en-KE, en-MY, en-NZ, en-PH, en-SG, fa-IR, fi-FI, fil-PH, fr-BE, fr-FR`.

## Nature of the change

JSDoc-only and behavior-preserving:
- `@param`/`@returns` on internal helpers (`TS7006`/`TS7023`), typed lookup tables (`TS7053` → `Record<number, …>`), self-referential vars (`TS7022`), `Array<T>` args (`TS2314`), precise option-bag types (`TS2339`), stale `@param` name fixes (`TS8024`).
- A couple of type-only casts (`/** @type {string} */ (...)`) where a `Map.get`/helper return is known non-null.
- `en-MY`'s `toOrdinal`/`toCurrency` gained the `@returns {string}` they were missing (previously masked by the conversions test's nearest-JSDoc heuristic).

No runtime logic changed.

## Verification (whole migration, before splitting into batches)

- `npm run typecheck` (strict checkJs over all src): **0 errors**.
- `npm test`: **264 pass**; `build:types` emits correct `.d.ts`; eslint clean.

`typecheck` is wired into CI in the final flip PR (which also sets `checkJs: true` on the build config). Batches 2–3 cover the remaining 38 files; all three are disjoint and independently mergeable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)