### PR TITLE
refactor(core): annotate language files for strict checkJs (batch 2/3)

### DIFF
--- a/src/gu-IN.js
+++ b/src/gu-IN.js
@@ -68,6 +68,9 @@ const SCALE_WORDS = ['', 'હજાર', 'લાખ', 'કરોડ', 'અબજ
 
 /**
  * Builds words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Gujarati words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -133,6 +136,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Converts the fractional digits to per-digit Gujarati words.
+ *
+ * @param {string} decimalPart - Decimal digits as a string
+ * @returns {string} Gujarati words for each digit
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/ha-NG.js
+++ b/src/ha-NG.js
@@ -60,6 +60,9 @@ const KOBO = 'kobo'
  * Build segment for 0-999 with Hausa patterns.
  * Hausa uses reversed order for hundreds: "biyu ɗari" (200)
  * And "da" connector for ones: "ashirin da ɗaya" (21)
+ *
+ * @param {number} n - Integer segment value (0-999)
+ * @returns {string}
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -110,6 +113,10 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} n - Non-negative integer value
+ * @returns {string}
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -122,11 +129,18 @@ function integerToWords (n) {
 
 /**
  * Checks if a word is a single digit (1-9).
+ *
+ * @param {string} word - Word to test
+ * @returns {boolean}
  */
 function isSingleDigit (word) {
   return ONES.slice(1).includes(word)
 }
 
+/**
+ * @param {bigint} n - Integer value of 1000 or greater
+ * @returns {string}
+ */
 function buildLargeNumberWords (n) {
   const numStr = n.toString()
   const len = numStr.length
@@ -202,6 +216,10 @@ function buildLargeNumberWords (n) {
   return result.join('')
 }
 
+/**
+ * @param {string} decimalPart - Digit string of the fractional part
+ * @returns {string}
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/hbo-IL.js
+++ b/src/hbo-IL.js
@@ -62,6 +62,13 @@ const GERAH_PLURAL = 'גרות'
 /**
  * Builds segment word for scale segments (thousands, millions, etc.).
  * "ו" is added before tens and ones when following hundreds.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @param {string} andWord - Conjunction word
+ * @param {string[]} ONES - Ones vocabulary
+ * @param {string[]} TEENS - Teens vocabulary
+ * @param {string[]} HUNDREDS_ARR - Hundreds vocabulary
+ * @returns {string} Segment word
  */
 function buildScaleSegment (n, andWord, ONES, TEENS, HUNDREDS_ARR) {
   if (n === 0) return ''
@@ -112,6 +119,13 @@ function buildScaleSegment (n, andWord, ONES, TEENS, HUNDREDS_ARR) {
 /**
  * Builds segment word for units segment (no scale word).
  * "ו" is only added before the final ones digit.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @param {string} andWord - Conjunction word
+ * @param {string[]} ONES - Ones vocabulary
+ * @param {string[]} TEENS - Teens vocabulary
+ * @param {string[]} HUNDREDS_ARR - Hundreds vocabulary
+ * @returns {string} Segment word
  */
 function buildUnitsSegment (n, andWord, ONES, TEENS, HUNDREDS_ARR) {
   if (n === 0) return ''
@@ -165,7 +179,8 @@ function buildUnitsSegment (n, andWord, ONES, TEENS, HUNDREDS_ARR) {
  * Converts a non-negative integer to Biblical Hebrew words.
  *
  * @param {bigint} n - Non-negative integer to convert
- * @param {Object} options - Conversion options
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @param {string} andWord - Conjunction word
  * @returns {string} Biblical Hebrew words
  */
 function integerToWords (n, gender, andWord) {
@@ -242,7 +257,8 @@ function integerToWords (n, gender, andWord) {
  * Converts decimal digits to Biblical Hebrew words (digit by digit).
  *
  * @param {string} decimalPart - Decimal digits (without the point)
- * @param {Object} options - Conversion options
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @param {string} andWord - Conjunction word
  * @returns {string} Biblical Hebrew words for decimal part
  */
 function decimalPartToWords (decimalPart, gender, andWord) {

--- a/src/he-IL.js
+++ b/src/he-IL.js
@@ -59,6 +59,10 @@ const AGORA_PLURAL = 'אגורות'
 /**
  * Builds segment word for scale segments (thousands, millions, etc.).
  * "ו" is added before tens and ones when following hundreds.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @param {string} andWord - Conjunction word
+ * @returns {string} Hebrew words for the segment
  */
 function buildScaleSegment (n, andWord) {
   if (n === 0) return ''
@@ -109,6 +113,10 @@ function buildScaleSegment (n, andWord) {
 /**
  * Builds segment word for units segment (no scale word).
  * "ו" is only added before the final ones digit.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @param {string} andWord - Conjunction word
+ * @returns {string} Hebrew words for the segment
  */
 function buildUnitsSegment (n, andWord) {
   if (n === 0) return ''
@@ -415,6 +423,9 @@ function toOrdinal (value) {
 
 /**
  * Builds segment word for currency (masculine forms).
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Hebrew words for the segment (masculine form)
  */
 function buildCurrencySegment (n) {
   if (n === 0) return ''

--- a/src/hi-IN.js
+++ b/src/hi-IN.js
@@ -144,6 +144,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Converts the decimal-part digit string to Hindi words.
+ *
+ * @param {string} decimalPart - The digits after the decimal separator
+ * @returns {string} Hindi words for the decimal part
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/hr-HR.js
+++ b/src/hr-HR.js
@@ -78,6 +78,13 @@ const SCALE_FORMS = [
 // Segment Building
 // ============================================================================
 
+/**
+ * Selects the correct plural form for a count.
+ *
+ * @param {number | bigint} n - The count
+ * @param {string[]} forms - The [one, few, many] plural forms
+ * @returns {string} The selected plural form
+ */
 function pluralize (n, forms) {
   const num = typeof n === 'bigint' ? Number(n) : n
   const lastDigit = num % 10
@@ -92,6 +99,12 @@ function pluralize (n, forms) {
   return forms[2]
 }
 
+/**
+ * Builds the masculine words for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} The segment words
+ */
 function buildSegmentMasc (n) {
   if (n === 0) return ''
 
@@ -118,6 +131,12 @@ function buildSegmentMasc (n) {
   return parts.join(' ')
 }
 
+/**
+ * Builds the feminine words for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} The segment words
+ */
 function buildSegmentFem (n) {
   if (n === 0) return ''
 
@@ -148,6 +167,13 @@ function buildSegmentFem (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Croatian words.
+ *
+ * @param {bigint} n - Non-negative integer to convert
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The number in Croatian words
+ */
 function integerToWords (n, gender) {
   if (n === 0n) return ZERO
 
@@ -158,6 +184,13 @@ function integerToWords (n, gender) {
   return buildLargeNumberWords(n, gender)
 }
 
+/**
+ * Builds words for numbers >= 1000.
+ *
+ * @param {bigint} n - Number >= 1000
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The number in Croatian words
+ */
 function buildLargeNumberWords (n, gender) {
   const numStr = n.toString()
   const len = numStr.length
@@ -201,6 +234,13 @@ function buildLargeNumberWords (n, gender) {
   return parts.join(' ')
 }
 
+/**
+ * Converts the decimal-part digit string to Croatian words.
+ *
+ * @param {string} decimalPart - The decimal digits as a string
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The decimal part in Croatian words
+ */
 function decimalPartToWords (decimalPart, gender) {
   let result = ''
   let i = 0

--- a/src/hu-HU.js
+++ b/src/hu-HU.js
@@ -79,6 +79,7 @@ const DECIMAL_SEP = 'egész'
 
 // Hungarian ordinals: special forms 1-10, then cardinal + -dik/-ik suffix
 // Vowel harmony determines -dik vs -ik
+/** @type {Record<number, string>} */
 const ORDINAL_SPECIAL = {
   1: 'első',
   2: 'második',
@@ -113,19 +114,31 @@ const FILLER = 'fillér' // subunit (rarely used, same singular and plural)
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {bigint} value
+ * @returns {string | undefined}
+ */
 function wordForScale (value) {
   return WORDS.get(value)
 }
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function tensToCardinal (n) {
   if (WORDS.has(n)) {
-    return WORDS.get(n)
+    return /** @type {string} */ (WORDS.get(n))
   }
   const tens = n / 10n
   const units = n % 10n
   return wordForScale(tens * 10n) + integerToWordsInner(units)
 }
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function hundredsToCardinal (n) {
   const hundreds = n / 100n
   let prefix = 'száz'
@@ -136,6 +149,10 @@ function hundredsToCardinal (n) {
   return prefix + postfix
 }
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function thousandsToCardinal (n) {
   const thousands = n / 1000n
   let prefix = 'ezer'
@@ -159,6 +176,10 @@ const SCALES = [
   1_000_000n
 ]
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function bigNumberToCardinal (n) {
   // Find appropriate scale using BigInt comparison (avoids toString)
   let exp = 1_000_000n
@@ -175,6 +196,11 @@ function bigNumberToCardinal (n) {
   return prefix + wordForScale(exp) + postfix
 }
 
+/**
+ * @param {bigint} n
+ * @param {string} [zeroWord]
+ * @returns {string}
+ */
 function integerToWordsInner (n, zeroWord = ZERO) {
   // Normalize to BigInt for consistent comparisons
   if (typeof n !== 'bigint') n = BigInt(n)
@@ -186,7 +212,7 @@ function integerToWordsInner (n, zeroWord = ZERO) {
     return 'két'
   }
   if (n < 30n) {
-    return wordForScale(n)
+    return /** @type {string} */ (wordForScale(n))
   }
   if (n < 100n) {
     return tensToCardinal(n)
@@ -200,10 +226,18 @@ function integerToWordsInner (n, zeroWord = ZERO) {
   return bigNumberToCardinal(n)
 }
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function integerToWords (n) {
   return integerToWordsInner(n, ZERO)
 }
 
+/**
+ * @param {string} decimalPart
+ * @returns {string}
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/id-ID.js
+++ b/src/id-ID.js
@@ -48,6 +48,12 @@ const RUPIAH = 'rupiah'
 // Segment Building
 // ============================================================================
 
+/**
+ * Builds the Indonesian words for a 1-3 digit segment (0-999).
+ *
+ * @param {number} n - The segment value (0-999)
+ * @returns {string} The segment in Indonesian words
+ */
 function buildSegment (n) {
   if (n === 0) return ''
 
@@ -88,6 +94,12 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Indonesian words.
+ *
+ * @param {bigint} n - The integer value to convert
+ * @returns {string} The integer in Indonesian words
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -116,6 +128,12 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * Builds Indonesian words for large numbers (1,000,000 and above).
+ *
+ * @param {bigint} n - The integer value to convert
+ * @returns {string} The number in Indonesian words
+ */
 function buildLargeNumberWords (n) {
   const numStr = n.toString()
   const len = numStr.length
@@ -162,6 +180,12 @@ function buildLargeNumberWords (n) {
   return parts.join(' ')
 }
 
+/**
+ * Converts the decimal-part digit string to Indonesian words.
+ *
+ * @param {string} decimalPart - The decimal digits as a string
+ * @returns {string} The decimal part in Indonesian words
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
 

--- a/src/it-IT.js
+++ b/src/it-IT.js
@@ -72,6 +72,9 @@ const CENTESIMI = 'centesimi'
  * - Tens ending in vowel + uno/otto → drop tens vowel: ventuno, ventotto
  * - Hundreds cento + otto/ottanta → centotto, centottanta (drop 'o')
  * - Final 'tre' in compounds becomes 'tré': ventitré, trentatré
+ *
+ * @param {number} n - Number 0-999 to convert
+ * @returns {string} Segment word
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -129,6 +132,9 @@ function buildSegment (n) {
 /**
  * Builds segment word with "un" for scale context (millions, billions).
  * Same as buildSegment but returns "un" for 1 instead of "uno".
+ *
+ * @param {number} n - Number 0-999 to convert
+ * @returns {string} Segment word
  */
 function buildSegmentForScale (n) {
   if (n === 0) return ''
@@ -139,6 +145,9 @@ function buildSegmentForScale (n) {
 /**
  * Builds thousands word for 1-999 thousand.
  * Handles elision: tre + mila = tremila (no accent), otto + mila = ottomila
+ *
+ * @param {number} n - Number of thousands 1-999
+ * @returns {string} Thousands word
  */
 function buildThousands (n) {
   if (n === 0) return ''

--- a/src/ja-JP.js
+++ b/src/ja-JP.js
@@ -76,6 +76,9 @@ const THOUSAND = '千'
 /**
  * Builds segment word for 0-9999 with 一 omission rules.
  * - Omit 一 before 十, 百, 千
+ *
+ * @param {number} n - Segment value (0-9999)
+ * @returns {string} Japanese kanji words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''

--- a/src/kn-IN.js
+++ b/src/kn-IN.js
@@ -68,6 +68,9 @@ const SCALE_WORDS = ['', 'ಸಾವಿರ', 'ಲಕ್ಷ', 'ಕೋಟಿ', 'ಅ
 
 /**
  * Builds words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Kannada words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -133,6 +136,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Reads a decimal-fraction digit string per-digit in Kannada.
+ *
+ * @param {string} decimalPart - Digits after the decimal separator
+ * @returns {string} Per-digit Kannada words
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/ko-KR.js
+++ b/src/ko-KR.js
@@ -51,6 +51,9 @@ const WON = '원'
 /**
  * Builds segment word for 0-9999 (4-digit myriad segment).
  * Korean omits "일" before 십, 백, 천.
+ *
+ * @param {number} n - Segment value (0-9999)
+ * @returns {string} Korean words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -182,7 +185,7 @@ function buildLargeNumberWords (n) {
  * - Concatenate without spaces within segments
  * - Space after scale words before next number
  *
- * @param {Array} parts - Parts with isScale metadata
+ * @param {Array<{word: string, isScale: boolean}>} parts - Parts with isScale metadata
  * @returns {string} Joined string
  */
 function joinKoreanParts (parts) {

--- a/src/lt-LT.js
+++ b/src/lt-LT.js
@@ -80,6 +80,9 @@ const SCALE_FORMS = [
 
 /**
  * Builds segment word for 0-999 (masculine form).
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Segment words
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -113,6 +116,9 @@ function buildSegment (n) {
 
 /**
  * Builds segment word for 0-999 (feminine form - only differs in ones).
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Segment words
  */
 function buildSegmentFeminine (n) {
   if (n === 0) return ''
@@ -191,7 +197,7 @@ function pluralize (n, forms) {
  * Converts a non-negative integer to Lithuanian words.
  *
  * @param {bigint} n - Non-negative integer to convert
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Lithuanian words
  */
 function integerToWords (n, gender) {
@@ -213,7 +219,7 @@ function integerToWords (n, gender) {
  * Builds words for numbers >= 1000.
  *
  * @param {bigint} n - Number >= 1000
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Lithuanian words
  */
 function buildLargeNumberWords (n, gender) {
@@ -266,7 +272,7 @@ function buildLargeNumberWords (n, gender) {
  * Converts decimal digits to Lithuanian words.
  *
  * @param {string} decimalPart - Decimal digits (without the point)
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Lithuanian words for decimal part
  */
 function decimalPartToWords (decimalPart, gender) {

--- a/src/lv-LV.js
+++ b/src/lv-LV.js
@@ -83,6 +83,8 @@ const SCALE_FORMS = [
  * Builds segment word for 0-999 (masculine form).
  * Does NOT include special handling for segment=1 (omitOneBeforeScale).
  * That's handled at join time.
+ *
+ * @param {number} n - Segment value 0-999
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -125,6 +127,8 @@ function buildSegment (n) {
 
 /**
  * Builds segment word for 0-999 (feminine form - only differs in ones).
+ *
+ * @param {number} n - Segment value 0-999
  */
 function buildSegmentFeminine (n) {
   if (n === 0) return ''
@@ -229,7 +233,7 @@ function pluralizeCurrency (n, forms) {
  * Converts a non-negative integer to Latvian words.
  *
  * @param {bigint} n - Non-negative integer to convert
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000
  * @returns {string} Latvian words
  */
 function integerToWords (n, gender) {
@@ -250,7 +254,7 @@ function integerToWords (n, gender) {
  * Builds words for numbers >= 1000.
  *
  * @param {bigint} n - Number >= 1000
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000
  * @returns {string} Latvian words
  */
 function buildLargeNumberWords (n, gender) {
@@ -309,7 +313,7 @@ function buildLargeNumberWords (n, gender) {
  * Converts decimal digits to Latvian words.
  *
  * @param {string} decimalPart - Decimal digits (without the point)
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000
  * @returns {string} Latvian words for decimal part
  */
 function decimalPartToWords (decimalPart, gender) {

--- a/src/mr-IN.js
+++ b/src/mr-IN.js
@@ -68,6 +68,9 @@ const SCALE_WORDS = ['', 'हजार', 'लाख', 'कोटी', 'अब्
 
 /**
  * Builds words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Marathi words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -133,6 +136,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Reads the fractional digits per-digit in Marathi.
+ *
+ * @param {string} decimalPart - Decimal digit string
+ * @returns {string} Marathi words for each digit
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/ms-MY.js
+++ b/src/ms-MY.js
@@ -49,6 +49,12 @@ const SEN = 'sen'
 // Segment Building
 // ============================================================================
 
+/**
+ * Builds the words for a number segment (0-999).
+ *
+ * @param {number} n - Integer segment in range 0-999
+ * @returns {string} The segment in Malay words
+ */
 function buildSegment (n) {
   if (n === 0) return ''
 
@@ -89,6 +95,12 @@ function buildSegment (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Malay words.
+ *
+ * @param {bigint} n - Non-negative integer to convert
+ * @returns {string} The integer in Malay words
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -117,6 +129,12 @@ function integerToWords (n) {
   return buildLargeNumberWords(n)
 }
 
+/**
+ * Builds words for large numbers (>= 1,000,000) using scale words.
+ *
+ * @param {bigint} n - Integer to convert (>= 1,000,000)
+ * @returns {string} The integer in Malay words
+ */
 function buildLargeNumberWords (n) {
   const numStr = n.toString()
   const len = numStr.length
@@ -167,6 +185,12 @@ function buildLargeNumberWords (n) {
   return parts.join(' ')
 }
 
+/**
+ * Converts the decimal part (digit string) to Malay words.
+ *
+ * @param {string} decimalPart - Decimal digits as a string
+ * @returns {string} The decimal digits in Malay words
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
 

--- a/src/nb-NO.js
+++ b/src/nb-NO.js
@@ -38,6 +38,7 @@ const SCALES = ['million', 'milliard', 'billion', 'billiard', 'kvintillion', 'se
 // ============================================================================
 
 // Norwegian ordinals: 1st-12th special forms, then cardinal + -de/-te
+/** @type {Record<number, string>} */
 const ORDINAL_SPECIAL = {
   1: 'første',
   2: 'andre',
@@ -68,6 +69,9 @@ const ORE = 'øre' // same singular and plural
 /**
  * Builds segment word for 0-999.
  * Returns object with word and hasHundred flag.
+ *
+ * @param {number} n - Integer 0-999
+ * @returns {{word: string, hasHundred: boolean}} Segment word and hundred flag
  */
 function buildSegment (n) {
   if (n === 0) return { word: '', hasHundred: false }
@@ -211,7 +215,7 @@ function buildLargeNumberWords (n) {
 /**
  * Joins parts with Norwegian spacing and comma rules.
  *
- * @param {Array} parts - Parts with type metadata
+ * @param {Array<{word: string, hasHundred: boolean, type: string}>} parts - Parts with type metadata
  * @returns {string} Joined string
  */
 function joinNorwegianParts (parts) {

--- a/src/nl-NL.js
+++ b/src/nl-NL.js
@@ -110,7 +110,7 @@ function buildSegment (n, withAnd) {
  * Converts a non-negative integer to Dutch words.
  *
  * @param {bigint} n - Non-negative integer to convert
- * @param {Object} options - Conversion options
+ * @param {{accentOne: boolean, includeOptionalAnd: boolean, noHundredPairing: boolean}} options - Conversion options
  * @returns {string} Dutch words
  */
 function integerToWords (n, options) {
@@ -119,6 +119,7 @@ function integerToWords (n, options) {
   const { accentOne, includeOptionalAnd, noHundredPairing } = options
 
   // Apply één/een replacement
+  /** @param {string} word */
   const applyAccent = (word) => {
     if (accentOne) {
       return word.replace(/\been\b/g, 'één')
@@ -186,7 +187,7 @@ function integerToWords (n, options) {
  * Uses BigInt division for faster segment extraction (4x faster than string slicing).
  *
  * @param {bigint} n - Number >= 1,000,000
- * @param {Object} options - Conversion options
+ * @param {{accentOne: boolean, includeOptionalAnd: boolean, noHundredPairing: boolean}} options - Conversion options
  * @returns {string} Dutch words
  */
 function buildLargeNumberWords (n, options) {
@@ -251,7 +252,7 @@ function buildLargeNumberWords (n, options) {
  * Converts decimal digits to Dutch words.
  *
  * @param {string} decimalPart - Decimal digits (without the point)
- * @param {Object} options - Conversion options
+ * @param {{accentOne: boolean, includeOptionalAnd: boolean, noHundredPairing: boolean}} options - Conversion options
  * @returns {string} Dutch words for decimal part
  */
 function decimalPartToWords (decimalPart, options) {

--- a/src/pa-IN.js
+++ b/src/pa-IN.js
@@ -67,6 +67,9 @@ const SCALE_WORDS = ['', 'ਹਜ਼ਾਰ', 'ਲੱਖ', 'ਕਰੋੜ', 'ਅਰ
 
 /**
  * Builds words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Punjabi words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -132,6 +135,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Converts the fractional digit string to Punjabi words.
+ *
+ * @param {string} decimalPart - Digits after the decimal point
+ * @returns {string} Punjabi words for the decimal part
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/pl-PL.js
+++ b/src/pl-PL.js
@@ -31,6 +31,7 @@ const TENS = ['', '', 'dwadzieścia', 'trzydzieści', 'czterdzieści', 'pięćdz
 const HUNDREDS = ['', 'sto', 'dwieście', 'trzysta', 'czterysta', 'pięćset', 'sześćset', 'siedemset', 'osiemset', 'dziewięćset']
 
 // Scale words: [singular, few (2-4), many (5+)]
+/** @type {Record<number, string[]>} */
 const PLURAL_FORMS = {
   1: ['tysiąc', 'tysiące', 'tysięcy'],
   2: ['milion', 'miliony', 'milionów'],
@@ -187,7 +188,7 @@ function pluralize (n, forms) {
  * Converts a non-negative integer to Polish words.
  *
  * @param {bigint} n - Non-negative integer to convert
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Polish words
  */
 function integerToWords (n, gender) {
@@ -229,7 +230,7 @@ function integerToWords (n, gender) {
  * Uses BigInt division for faster segment extraction.
  *
  * @param {bigint} n - Number >= 1,000,000
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Polish words
  */
 function buildLargeNumberWords (n, gender) {
@@ -279,7 +280,7 @@ function buildLargeNumberWords (n, gender) {
  * Converts decimal digits to Polish words.
  *
  * @param {string} decimalPart - Decimal digits (without the point)
- * @param {Object} options - Conversion options
+ * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Polish words for decimal part
  */
 function decimalPartToWords (decimalPart, gender) {


### PR DESCRIPTION
## What

Batch 2 of 3 of the language-file annotations for the **full strict `checkJs`** migration (foundation: #326; batch 1: #327). JSDoc type annotations on internal helpers in 20 language files so they pass strict `checkJs` with zero errors.

Files (gu-IN … pl-PL): `gu-IN, ha-NG, hbo-IL, he-IL, hi-IN, hr-HR, hu-HU, id-ID, it-IT, ja-JP, kn-IN, ko-KR, lt-LT, lv-LV, mr-IN, ms-MY, nb-NO, nl-NL, pa-IN, pl-PL`.

JSDoc-only and behavior-preserving (same error classes as batch 1: `TS7006/7053/7022/7023/8024/2314/2339`). No runtime logic changed. Disjoint from batches 1 and 3 — independently mergeable. Full-migration verification (0 typecheck errors, 264 tests) reported in #327.

🤖 Generated with [Claude Code](https://claude.com/claude-code)