### PR TITLE
refactor(core): annotate language files for strict checkJs (batch 3/3)

### DIFF
--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -43,6 +43,7 @@ const ORDINAL_HUNDREDS = ['', 'centésimo', 'ducentésimo', 'tricentésimo', 'qu
 // ============================================================================
 
 // Dicionário focado no uso no Brasil (centavos para dólar e euro em vez de cêntimos)
+/** @type {Record<string, {major: string[], minor: string[]}>} */
 const CURRENCIES = {
   BRL: { major: ['real', 'reais'], minor: ['centavo', 'centavos'] },
   USD: { major: ['dólar', 'dólares'], minor: ['centavo', 'centavos'] },
@@ -61,6 +62,8 @@ const DEFAULT_CURRENCY_WORDS = { major: ['unidade', 'unidades'], minor: ['centav
 /**
  * Builds segment word for 0-999 with Portuguese "e" rules.
  * Returns the word and whether it's an exact hundred (for "cem" handling).
+ *
+ * @param {number} n - Number 0-999
  */
 function buildSegment (n) {
   if (n === 0) return { word: '', isExactHundred: false }
@@ -473,7 +476,10 @@ function toCurrency (value, options) {
   let currencyCode = options.currency
   if (!currencyCode) {
     try {
-      const localeInfo = new Intl.Locale('pt-BR')
+      // Intl Locale Info (getCurrencies) is a newer TC39 API present at
+      // runtime in modern engines but not yet in the TS ES2022 lib types;
+      // augment the type locally rather than widen the project's lib.
+      const localeInfo = /** @type {Intl.Locale & { getCurrencies(): string[] }} */ (new Intl.Locale('pt-BR'))
       currencyCode = localeInfo.getCurrencies?.()[0]
     } catch (e) {
       // Ignora erro em ambientes antigos (fallback garantido abaixo)

--- a/src/pt-PT.js
+++ b/src/pt-PT.js
@@ -51,6 +51,8 @@ const CENTIMOS = 'cêntimos'
 /**
  * Builds segment word for 0-999 with Portuguese "e" rules.
  * Returns the word and whether it's an exact hundred (for "cem" handling).
+ *
+ * @param {number} n - Number 0-999
  */
 function buildSegment (n) {
   if (n === 0) return { word: '', isExactHundred: false }

--- a/src/ro-RO.js
+++ b/src/ro-RO.js
@@ -71,6 +71,10 @@ const SCALE_META = [
 
 /**
  * Spells number under 100.
+ *
+ * @param {number} n - Number 0-99
+ * @param {boolean} [feminine] - Use feminine forms
+ * @param {boolean} [masculineTeens] - Use masculine teen forms
  */
 function spellUnder100 (n, feminine = false, masculineTeens = false) {
   if (n === 0) return ''
@@ -91,6 +95,10 @@ function spellUnder100 (n, feminine = false, masculineTeens = false) {
 
 /**
  * Spells number under 1000.
+ *
+ * @param {number} n - Number 0-999
+ * @param {boolean} [feminine] - Use feminine forms
+ * @param {boolean} [masculineTeens] - Use masculine teen forms
  */
 function spellUnder1000 (n, feminine = false, masculineTeens = false) {
   if (n === 0) return ''
@@ -107,6 +115,9 @@ function spellUnder1000 (n, feminine = false, masculineTeens = false) {
 /**
  * Builds scale word with proper pluralization and "de" insertion.
  * Romanian always uses feminine forms (două, not doi) when counting scale words.
+ *
+ * @param {number} segment - Three-digit segment value (1-999)
+ * @param {number} scaleIndex - Scale position (1 = thousands, 2 = millions, ...)
  */
 function buildScalePhrase (segment, scaleIndex) {
   const meta = SCALE_META[scaleIndex - 1]
@@ -139,7 +150,7 @@ function buildScalePhrase (segment, scaleIndex) {
  * Converts a non-negative integer to Romanian words.
  *
  * @param {bigint} n - Non-negative integer to convert
- * @param {Object} options - Conversion options
+ * @param {string | {gender?: string}} gender - Gender for numbers ('feminine'/'masculine')
  * @returns {string} Romanian words
  */
 function integerToWords (n, gender) {
@@ -159,7 +170,7 @@ function integerToWords (n, gender) {
  * Uses BigInt division for faster segment extraction.
  *
  * @param {bigint} n - Number >= 1000
- * @param {Object} options - Conversion options
+ * @param {string | {gender?: string}} gender - Gender for numbers ('feminine'/'masculine')
  * @returns {string} Romanian words
  */
 function buildLargeNumberWords (n, gender) {

--- a/src/ru-RU.js
+++ b/src/ru-RU.js
@@ -94,6 +94,13 @@ const KOPECK_FORMS = ['копейка', 'копейки', 'копеек']
 // Segment Building
 // ============================================================================
 
+/**
+ * Selects the correct plural form based on Russian pluralization rules.
+ *
+ * @param {number | bigint} n - The count
+ * @param {string[]} forms - [one, few, many] forms
+ * @returns {string} The matching plural form
+ */
 function pluralize (n, forms) {
   const num = typeof n === 'bigint' ? Number(n) : n
   const lastDigit = num % 10
@@ -108,6 +115,12 @@ function pluralize (n, forms) {
   return forms[2]
 }
 
+/**
+ * Builds masculine cardinal words for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Masculine cardinal words
+ */
 function buildSegmentMasc (n) {
   if (n === 0) return ''
 
@@ -134,6 +147,12 @@ function buildSegmentMasc (n) {
   return parts.join(' ')
 }
 
+/**
+ * Builds feminine cardinal words for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Feminine cardinal words
+ */
 function buildSegmentFem (n) {
   if (n === 0) return ''
 
@@ -164,6 +183,13 @@ function buildSegmentFem (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Russian cardinal words.
+ *
+ * @param {bigint} n - Non-negative integer to convert
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} Cardinal Russian words
+ */
 function integerToWords (n, gender) {
   if (n === 0n) return ZERO
 
@@ -193,6 +219,13 @@ function integerToWords (n, gender) {
   return buildLargeNumberWords(n, gender)
 }
 
+/**
+ * Builds cardinal words for numbers >= 1,000,000 via scale decomposition.
+ *
+ * @param {bigint} n - Number >= 1,000,000
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} Cardinal Russian words
+ */
 function buildLargeNumberWords (n, gender) {
   const feminine = gender === 'feminine'
   const numStr = n.toString()
@@ -237,6 +270,13 @@ function buildLargeNumberWords (n, gender) {
   return parts.join(' ')
 }
 
+/**
+ * Converts the fractional digit string to Russian words.
+ *
+ * @param {string} decimalPart - The fractional digits
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} Cardinal Russian words for the decimal part
+ */
 function decimalPartToWords (decimalPart, gender) {
   let result = ''
   let i = 0

--- a/src/sr-Cyrl-RS.js
+++ b/src/sr-Cyrl-RS.js
@@ -86,6 +86,13 @@ const SCALE_FORMS = [
 // Segment Building
 // ============================================================================
 
+/**
+ * Selects the correct plural form for a count.
+ *
+ * @param {number | bigint} n - The count
+ * @param {string[]} forms - Plural forms [one, few, many]
+ * @returns {string} The selected plural form
+ */
 function pluralize (n, forms) {
   const num = typeof n === 'bigint' ? Number(n) : n
   const lastDigit = num % 10
@@ -100,6 +107,12 @@ function pluralize (n, forms) {
   return forms[2]
 }
 
+/**
+ * Builds the masculine word form for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} The segment words
+ */
 function buildSegmentMasc (n) {
   if (n === 0) return ''
 
@@ -126,6 +139,12 @@ function buildSegmentMasc (n) {
   return parts.join(' ')
 }
 
+/**
+ * Builds the feminine word form for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} The segment words
+ */
 function buildSegmentFem (n) {
   if (n === 0) return ''
 
@@ -156,6 +175,13 @@ function buildSegmentFem (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Serbian words.
+ *
+ * @param {bigint} n - The integer to convert
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The integer in words
+ */
 function integerToWords (n, gender) {
   if (n === 0n) return ZERO
 
@@ -166,6 +192,13 @@ function integerToWords (n, gender) {
   return buildLargeNumberWords(n, gender)
 }
 
+/**
+ * Builds words for integers >= 1000 using scale decomposition.
+ *
+ * @param {bigint} n - The integer to convert (>= 1000)
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The integer in words
+ */
 function buildLargeNumberWords (n, gender) {
   const numStr = n.toString()
   const len = numStr.length
@@ -209,6 +242,13 @@ function buildLargeNumberWords (n, gender) {
   return parts.join(' ')
 }
 
+/**
+ * Converts the decimal-part digit string to Serbian words.
+ *
+ * @param {string} decimalPart - The decimal digits as a string
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The decimal part in words
+ */
 function decimalPartToWords (decimalPart, gender) {
   let result = ''
   let i = 0

--- a/src/sr-Latn-RS.js
+++ b/src/sr-Latn-RS.js
@@ -86,6 +86,13 @@ const SCALE_FORMS = [
 // Segment Building
 // ============================================================================
 
+/**
+ * Selects the correct plural form based on Serbian grammar rules.
+ *
+ * @param {number | bigint} n - The count
+ * @param {string[]} forms - Plural forms [one, few, many]
+ * @returns {string} The selected plural form
+ */
 function pluralize (n, forms) {
   const num = typeof n === 'bigint' ? Number(n) : n
   const lastDigit = num % 10
@@ -100,6 +107,12 @@ function pluralize (n, forms) {
   return forms[2]
 }
 
+/**
+ * Builds the masculine word form for a 0-999 segment.
+ *
+ * @param {number} n - Segment value 0-999
+ * @returns {string} The segment words
+ */
 function buildSegmentMasc (n) {
   if (n === 0) return ''
 
@@ -126,6 +139,12 @@ function buildSegmentMasc (n) {
   return parts.join(' ')
 }
 
+/**
+ * Builds the feminine word form for a 0-999 segment.
+ *
+ * @param {number} n - Segment value 0-999
+ * @returns {string} The segment words
+ */
 function buildSegmentFem (n) {
   if (n === 0) return ''
 
@@ -156,6 +175,13 @@ function buildSegmentFem (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Serbian words.
+ *
+ * @param {bigint} n - The integer to convert
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The integer in Serbian words
+ */
 function integerToWords (n, gender) {
   if (n === 0n) return ZERO
 
@@ -166,6 +192,13 @@ function integerToWords (n, gender) {
   return buildLargeNumberWords(n, gender)
 }
 
+/**
+ * Builds words for numbers >= 1000 using scale decomposition.
+ *
+ * @param {bigint} n - The integer to convert (>= 1000)
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The number in Serbian words
+ */
 function buildLargeNumberWords (n, gender) {
   const numStr = n.toString()
   const len = numStr.length
@@ -209,6 +242,13 @@ function buildLargeNumberWords (n, gender) {
   return parts.join(' ')
 }
 
+/**
+ * Converts the decimal-part digit string to Serbian words.
+ *
+ * @param {string} decimalPart - The fractional digits as a string
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The decimal part in Serbian words
+ */
 function decimalPartToWords (decimalPart, gender) {
   let result = ''
   let i = 0

--- a/src/sv-SE.js
+++ b/src/sv-SE.js
@@ -39,6 +39,7 @@ const SCALES = ['tusen', 'miljon', 'miljard', 'biljon', 'biljard', 'triljon', 't
 
 // Swedish ordinals: 1st-2nd use -a (första, andra), then -de suffix
 // Numbers ending in 1, 2 (except 11, 12) use special forms
+/** @type {Record<number, string>} */
 const ORDINAL_ONES = {
   1: 'första',
   2: 'andra',
@@ -69,6 +70,8 @@ const ORE = 'öre' // same singular and plural
 /**
  * Builds segment word for 0-999.
  * Returns object with word and metadata for "och" logic.
+ *
+ * @param {number} n - Integer in range 0-999
  */
 function buildSegment (n) {
   if (n === 0) return { word: '', hasHundred: false, lessThan100: false }
@@ -233,7 +236,7 @@ function buildLargeNumberWords (n) {
  * Joins parts with Swedish "och" rules.
  * Insert "och" before final segment if it follows a scale word and doesn't have "hundra".
  *
- * @param {Array} parts - Parts with metadata
+ * @param {Array<{word: string, hasHundred: boolean, isScale: boolean}>} parts - Parts with metadata
  * @returns {string} Joined string
  */
 function joinSwedishParts (parts) {

--- a/src/sw-KE.js
+++ b/src/sw-KE.js
@@ -18,6 +18,7 @@ import { parseOrdinalValue } from './utils/parse-ordinal.js'
 // ============================================================================
 
 const ONES = ['sifuri', 'moja', 'mbili', 'tatu', 'nne', 'tano', 'sita', 'saba', 'nane', 'tisa']
+/** @type {Record<number, string>} */
 const TENS = { 10: 'kumi', 20: 'ishirini', 30: 'thelathini', 40: 'arobaini', 50: 'hamsini', 60: 'sitini', 70: 'sabini', 80: 'themanini', 90: 'tisini' }
 
 const SCALE_WORDS = ['', 'elfu', 'milioni', 'bilioni', 'trilioni', 'kwadrilioni', 'kwintilioni']
@@ -32,6 +33,7 @@ const DECIMAL_SEP = 'nukta'
 
 // Swahili ordinals use "wa" + cardinal: wa kwanza (1st), wa pili (2nd)
 // First few have special forms
+/** @type {Record<number, string>} */
 const ORDINAL_ONES = {
   1: 'wa kwanza',
   2: 'wa pili',
@@ -56,6 +58,10 @@ const CENT = 'senti'
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {number} n
+ * @returns {string}
+ */
 function wordsUnder100 (n) {
   if (n < 10) return ONES[n]
   if (n === 10) return TENS[10]
@@ -69,6 +75,10 @@ function wordsUnder100 (n) {
   return TENS[tens] + ' na ' + ONES[ones]
 }
 
+/**
+ * @param {number} n
+ * @returns {string}
+ */
 function wordsUnder1000 (n) {
   if (n < 100) return wordsUnder100(n)
   if (n === 100) return 'mia moja'
@@ -89,6 +99,10 @@ function wordsUnder1000 (n) {
   return parts.join(' ')
 }
 
+/**
+ * @param {bigint} n
+ * @returns {number[]}
+ */
 function extractSegments (n) {
   const segments = []
   let temp = n
@@ -99,6 +113,10 @@ function extractSegments (n) {
   return segments
 }
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -131,6 +149,10 @@ function integerToWords (n) {
   return parts.join(' ').trim()
 }
 
+/**
+ * @param {string} decimalPart
+ * @returns {string}
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/ta-IN.js
+++ b/src/ta-IN.js
@@ -148,6 +148,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Converts the decimal portion of a number to Tamil words (per-digit reading).
+ *
+ * @param {string} decimalPart - The fractional digits as a string
+ * @returns {string} Tamil words for each decimal digit
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/te-IN.js
+++ b/src/te-IN.js
@@ -72,6 +72,9 @@ const SCALE_WORDS = ['', 'వెయ్యి', 'లక్ష', 'కోటి', '
 
 /**
  * Builds words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Telugu words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -139,6 +142,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Reads a decimal fraction digit-by-digit in Telugu.
+ *
+ * @param {string} decimalPart - Fractional digits as a string
+ * @returns {string} Telugu words for each digit
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/th-TH.js
+++ b/src/th-TH.js
@@ -43,6 +43,10 @@ const BAHT_ONLY = 'ถ้วน' // "exactly" suffix when no satang
 // Conversion Functions
 // ============================================================================
 
+/**
+ * @param {number} n
+ * @returns {string}
+ */
 function convertBelowMillion (n) {
   if (n === 0) return ''
 
@@ -102,6 +106,10 @@ function convertBelowMillion (n) {
   return parts.join('')
 }
 
+/**
+ * @param {bigint} n
+ * @returns {number[]}
+ */
 function splitMillionGroups (n) {
   const groups = []
   let remaining = n
@@ -116,6 +124,10 @@ function splitMillionGroups (n) {
   return groups
 }
 
+/**
+ * @param {bigint} n
+ * @returns {string}
+ */
 function integerToWords (n) {
   if (n === 0n) return ZERO
 
@@ -136,6 +148,10 @@ function integerToWords (n) {
   return parts.join('')
 }
 
+/**
+ * @param {string} decimalPart
+ * @returns {string}
+ */
 function decimalPartToWords (decimalPart) {
   // Per-digit decimal reading
   const digits = []

--- a/src/tr-TR.js
+++ b/src/tr-TR.js
@@ -39,6 +39,7 @@ const SCALES = ['milyon', 'milyar', 'trilyon', 'katrilyon', 'kentilyon']
 
 // Turkish ordinals use -(i/ı/u/ü)nci/ncı/ncu/ncü suffix with vowel harmony
 // Special forms for 1-10
+/** @type {Record<number, string>} */
 const ORDINAL_SPECIAL = {
   1: 'birinci',
   2: 'ikinci',
@@ -66,6 +67,10 @@ const KURUS = 'kuruş' // subunit (100 kuruş = 1 lira)
 /**
  * Builds segment word for 0-999.
  * Omits "bir" before "yüz" (hundred).
+ *
+ * @param {number} n - Segment value (0-999)
+ * @param {string} [separator=' '] - Separator between words
+ * @returns {string} Segment words
  */
 function buildSegment (n, separator = ' ') {
   if (n === 0) return ''
@@ -111,7 +116,7 @@ function buildSegment (n, separator = ' ') {
  * Converts a non-negative integer to Turkish words.
  *
  * @param {bigint} n - Non-negative integer to convert
- * @param {Object} options - Conversion options
+ * @param {boolean} dropSpaces - Remove spaces for compound form
  * @returns {string} Turkish words
  */
 function integerToWords (n, dropSpaces) {
@@ -152,7 +157,7 @@ function integerToWords (n, dropSpaces) {
  * Builds words for numbers >= 1,000,000.
  *
  * @param {bigint} n - Number >= 1,000,000
- * @param {Object} options - Conversion options
+ * @param {boolean} dropSpaces - Remove spaces for compound form
  * @returns {string} Turkish words
  */
 function buildLargeNumberWords (n, dropSpaces) {
@@ -213,7 +218,7 @@ function buildLargeNumberWords (n, dropSpaces) {
  * Converts decimal digits to Turkish words.
  *
  * @param {string} decimalPart - Decimal digits (without the point)
- * @param {Object} options - Conversion options
+ * @param {boolean} dropSpaces - Remove spaces for compound form
  * @returns {string} Turkish words for decimal part
  */
 function decimalPartToWords (decimalPart, dropSpaces) {

--- a/src/uk-UA.js
+++ b/src/uk-UA.js
@@ -78,6 +78,13 @@ const SCALE_FORMS = [
 // Segment Building
 // ============================================================================
 
+/**
+ * Selects the correct plural form for a count.
+ *
+ * @param {number | bigint} n - The count
+ * @param {string[]} forms - Plural forms [one, few, many]
+ * @returns {string} The selected plural form
+ */
 function pluralize (n, forms) {
   const num = typeof n === 'bigint' ? Number(n) : n
   const lastDigit = num % 10
@@ -92,6 +99,12 @@ function pluralize (n, forms) {
   return forms[2]
 }
 
+/**
+ * Builds the masculine words for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Segment words
+ */
 function buildSegmentMasc (n) {
   if (n === 0) return ''
 
@@ -118,6 +131,12 @@ function buildSegmentMasc (n) {
   return parts.join(' ')
 }
 
+/**
+ * Builds the feminine words for a 0-999 segment.
+ *
+ * @param {number} n - Number 0-999
+ * @returns {string} Segment words
+ */
 function buildSegmentFem (n) {
   if (n === 0) return ''
 
@@ -148,6 +167,13 @@ function buildSegmentFem (n) {
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Ukrainian words.
+ *
+ * @param {bigint} n - The integer to convert
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The integer in Ukrainian words
+ */
 function integerToWords (n, gender) {
   if (n === 0n) return ZERO
 
@@ -158,6 +184,13 @@ function integerToWords (n, gender) {
   return buildLargeNumberWords(n, gender)
 }
 
+/**
+ * Builds Ukrainian words for numbers >= 1000.
+ *
+ * @param {bigint} n - The integer to convert
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The integer in Ukrainian words
+ */
 function buildLargeNumberWords (n, gender) {
   const numStr = n.toString()
   const len = numStr.length
@@ -201,6 +234,13 @@ function buildLargeNumberWords (n, gender) {
   return parts.join(' ')
 }
 
+/**
+ * Converts a decimal fractional string to Ukrainian words.
+ *
+ * @param {string} decimalPart - The fractional digits
+ * @param {('masculine'|'feminine')} gender - Grammatical gender
+ * @returns {string} The fractional part in Ukrainian words
+ */
 function decimalPartToWords (decimalPart, gender) {
   let result = ''
   let i = 0

--- a/src/ur-PK.js
+++ b/src/ur-PK.js
@@ -67,6 +67,9 @@ const SCALE_WORDS = ['', 'ہزار', 'لاکھ', 'کروڑ', 'ارب', 'کھرب
 
 /**
  * Builds words for a 0-999 segment.
+ *
+ * @param {number} n - Segment value (0-999)
+ * @returns {string} Urdu words for the segment
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -132,6 +135,12 @@ function integerToWords (n) {
   return words.join(' ')
 }
 
+/**
+ * Converts the fractional digit string to Urdu words.
+ *
+ * @param {string} decimalPart - Digits after the decimal separator
+ * @returns {string} Urdu words for the decimal part
+ */
 function decimalPartToWords (decimalPart) {
   let result = ''
   let i = 0

--- a/src/vi-VN.js
+++ b/src/vi-VN.js
@@ -59,6 +59,9 @@ const LAM = 'lăm' // 5 in tens position (25, 35, etc.)
 
 /**
  * Builds word for 0-99 with special forms (mốt, lăm).
+ *
+ * @param {number} n - Integer in range 0-99
+ * @returns {string} Vietnamese words
  */
 function buildBelowHundred (n) {
   if (n === 0) return ONES[0]
@@ -85,6 +88,9 @@ function buildBelowHundred (n) {
 
 /**
  * Builds segment word for 0-999.
+ *
+ * @param {number} n - Integer in range 0-999
+ * @returns {string} Vietnamese words
  */
 function buildSegment (n) {
   if (n === 0) return ''
@@ -120,6 +126,9 @@ function buildSegment (n) {
 
 /**
  * Builds "lẻ" prefixed word for small remainders (1-99) after scale words.
+ *
+ * @param {number} n - Integer in range 0-99
+ * @returns {string} Vietnamese words
  */
 function buildLeSegment (n) {
   if (n === 0) return ''

--- a/src/yo-NG.js
+++ b/src/yo-NG.js
@@ -60,6 +60,7 @@ const TEENS_SUB = [
 // Decades (base-20 structure)
 // Even decades are multiples of 20
 // Odd decades subtract 10 from next even decade
+/** @type {Record<number, string>} */
 const DECADES = {
   20: 'ogún', // 20 = 20 × 1
   30: 'ọgbọ̀n', // 30 = 20 + 10 (special word)
@@ -73,6 +74,7 @@ const DECADES = {
 }
 
 // Prefixes for adding to decades (lé lógún, lé lọgbọ̀n, etc.)
+/** @type {Record<number, string>} */
 const DECADE_ADD_SUFFIX = {
   20: 'lógún',
   30: 'lọgbọ̀n',
@@ -86,6 +88,7 @@ const DECADE_ADD_SUFFIX = {
 }
 
 // Prefixes for subtracting from decades (dín lógójì, etc.)
+/** @type {Record<number, string>} */
 const DECADE_SUB_SUFFIX = {
   20: 'dínlógún',
   30: 'dínlọgbọ̀n',
@@ -135,6 +138,9 @@ const KOBO = 'kọ́bọ̀'
 
 /**
  * Builds word for numbers 0-99
+ *
+ * @param {number} n - Integer in the range 0-99
+ * @returns {string} Yoruba words for the number
  */
 function buildUnder100 (n) {
   if (n === 0) return ''
@@ -169,6 +175,9 @@ function buildUnder100 (n) {
 
 /**
  * Converts hundreds (100-999)
+ *
+ * @param {number} n - Integer in the range 0-999
+ * @returns {string} Yoruba words for the number
  */
 function convertHundreds (n) {
   if (n < 100) return buildUnder100(n)

--- a/src/zh-Hans-CN.js
+++ b/src/zh-Hans-CN.js
@@ -69,6 +69,13 @@ const ZHENG = '整'
 
 /**
  * Convert number below 万 (10,000) to words using direct string concatenation.
+ *
+ * @param {bigint} value
+ * @param {string[]} ones
+ * @param {string} ten
+ * @param {string} hundred
+ * @param {string} thousand
+ * @returns {string}
  */
 function convertBelowWan (value, ones, ten, hundred, thousand) {
   if (value === 0n) return ''
@@ -117,6 +124,13 @@ function convertBelowWan (value, ones, ten, hundred, thousand) {
 
 /**
  * Convert number below 亿 (100 million) to words.
+ *
+ * @param {bigint} value
+ * @param {string[]} ones
+ * @param {string} ten
+ * @param {string} hundred
+ * @param {string} thousand
+ * @returns {string}
  */
 function convertBelowYi (value, ones, ten, hundred, thousand) {
   if (value === 0n) return ''
@@ -139,6 +153,13 @@ function convertBelowYi (value, ones, ten, hundred, thousand) {
   return convertBelowWan(value, ones, ten, hundred, thousand)
 }
 
+/**
+ * Convert an integer to Simplified Chinese words.
+ *
+ * @param {bigint} n
+ * @param {boolean} [formal]
+ * @returns {string}
+ */
 function integerToWords (n, formal = true) {
   if (n === 0n) return ZERO
 
@@ -167,6 +188,10 @@ function integerToWords (n, formal = true) {
 
 /**
  * Convert decimal digits to words using direct concatenation.
+ *
+ * @param {string} decimalString
+ * @param {string[]} ones
+ * @returns {string}
  */
 function decimalDigitsToWords (decimalString, ones) {
   let result = ''

--- a/src/zh-Hant-TW.js
+++ b/src/zh-Hant-TW.js
@@ -66,6 +66,13 @@ const YUAN_COMMON = '元'
 // Conversion Functions
 // ============================================================================
 
+/**
+ * Converts a non-negative integer to Traditional Chinese words.
+ *
+ * @param {bigint} n - The integer value to convert
+ * @param {boolean} [formal=true] - Use formal/financial numerals
+ * @returns {string} The integer in Traditional Chinese words
+ */
 function integerToWords (n, formal = true) {
   if (n === 0n) return ZERO
 
@@ -75,6 +82,10 @@ function integerToWords (n, formal = true) {
   const thousand = formal ? THOUSAND_FORMAL : THOUSAND_COMMON
 
   // Convert number below 萬 (10,000)
+  /**
+   * @param {bigint} value
+   * @returns {string}
+   */
   function convertBelowWan (value) {
     if (value === 0n) return ''
 
@@ -128,6 +139,10 @@ function integerToWords (n, formal = true) {
   }
 
   // Convert number below 億 (100 million)
+  /**
+   * @param {bigint} value
+   * @returns {string}
+   */
   function convertBelowYi (value) {
     if (value === 0n) return ''
 
@@ -179,6 +194,13 @@ function integerToWords (n, formal = true) {
   return parts.join('')
 }
 
+/**
+ * Converts each digit of a decimal string to Traditional Chinese words.
+ *
+ * @param {string} decimalString - The decimal digits to convert
+ * @param {boolean} [formal=true] - Use formal/financial numerals
+ * @returns {string[]} The decimal digits as Traditional Chinese words
+ */
 function decimalDigitsToWords (decimalString, formal = true) {
   const ones = formal ? ONES_FORMAL : ONES_COMMON
   const words = []


### PR DESCRIPTION
## What

Batch 3 of 3 (final language batch) of the **full strict `checkJs`** migration (foundation: #326; batches: #327, #328). JSDoc type annotations on internal helpers in 18 language files.

Files (pt-BR … zh-Hant-TW): `pt-BR, pt-PT, ro-RO, ru-RU, sr-Cyrl-RS, sr-Latn-RS, sv-SE, sw-KE, ta-IN, te-IN, th-TH, tr-TR, uk-UA, ur-PK, vi-VN, yo-NG, zh-Hans-CN, zh-Hant-TW`.

JSDoc-only and behavior-preserving (same error classes as batches 1–2). Includes the one non-annotation fix: **`pt-BR`** uses `Intl.Locale#getCurrencies()` (a newer TC39 API present at runtime but not in the TS ES2022 lib types) — augmented with a local type cast `/** @type {Intl.Locale & { getCurrencies(): string[] }} */` rather than widening the project's `lib` (verified `ESNext.Intl` does not yet declare it in TS 6.0.3) or suppressing with `@ts-ignore`. No runtime change — the call stays optional-chained + try/caught with a `BRL` fallback.

Disjoint from batches 1–2. Once all three land, `npm run typecheck` is **0 errors** across all src; the final flip PR then sets `checkJs: true` on the build config and wires `typecheck` into CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)