### PR TITLE
build: enforce strict checkJs (gate build:types + CI typecheck step)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Strict checkJs over src (tsconfig.typecheck.json, noEmit) — fast type
+      # gate that fails in the cheap lint job before the test matrix. The
+      # shipped declarations are independently gated by build:types
+      # (checkJs + noEmitOnError) in the test job and prepack.
+      - name: Typecheck
+        run: npm run typecheck
+
   test:
     name: Test (Node ${{ matrix.node }}${{ matrix.coverage && ' + Coverage' || '' }})
     runs-on: ubuntu-latest

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,6 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "checkJs": true,
+    "noEmitOnError": true,
     "noEmit": false,
     "declaration": true,
     "emitDeclarationOnly": true,


### PR DESCRIPTION
## What

Final stage of the strict-`checkJs` migration (after #326 + the language batches #327/#328/#329 brought `npm run typecheck` to **0 errors**). This turns type-checking from a measurable target into an **enforced gate**.

1. **`tsconfig.build.json`** → `checkJs: true` + `noEmitOnError: true`. `build:types` now *type-checks* the shipped source (not just emits `.d.ts`). Because `build:types` runs inside `npm test` and `prepack`, this gates types in:
   - **pre-push** husky hook (`npm test`)
   - **CI test job** (`npm test`)
   - **`prepack` / publish** (`npm run build`) — a type error now aborts a publish before the registry write.
   `noEmitOnError` ensures a type error never emits broken declarations.
2. **`ci.yml` lint job** → explicit **Typecheck** step (`npm run typecheck`, `noEmit`) — a fast, dedicated gate that fails in the cheap lint job before the test matrix runs.

## Enforcement summary (answering "is it in husky + CI?")

| Path | Gated by |
|---|---|
| CI (fast fail) | new **Typecheck** step in lint job |
| CI (test matrix) | `npm test` → `build:types` (checkJs) |
| Husky **pre-push** | `npm test` → `build:types` (checkJs) |
| Publish | `prepack` → `npm run build` → `build:types` (checkJs) |

(Pre-push is gated transitively via `npm test`; no separate hook line, to avoid running `tsc` twice. Happy to add an explicit fast-fail line if preferred.)

## Verification

- `build:types` clean → passes + emits 78 `.d.ts`. With an injected type error → **exit 1**, no emit (`TS2339`), proving the gate. Restored → passes.
- `npm run typecheck`: 0 errors. `npm test`: 264 pass. `actionlint`: clean.

Scope note: the type-check covers the shipped source (`src/*.js` + `src/utils/*.js`). `test/`/`scripts/`/`bench/` are not yet in scope — a possible future expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)