### PR TITLE
build: collapse typecheck into build config (drop tsconfig.typecheck.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "prepare:husky": "husky",
     "test": "node --run test:unit && node --run build:types",
     "test:unit": "ava \"test/*.test.js\" \"test/utils/*.test.js\"",
-    "typecheck": "tsc --project tsconfig.typecheck.json"
+    "typecheck": "tsc --project tsconfig.build.json --noEmit"
   },
   "ava": {
     "extensions": [

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,8 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "checkJs": true,
-    "noEmit": true
-  },
-  "include": ["src/*.js", "src/utils/*.js"]
-}


### PR DESCRIPTION
## What

Removes the now-redundant `tsconfig.typecheck.json` and derives `npm run typecheck` from the build config instead:

```diff
- "typecheck": "tsc --project tsconfig.typecheck.json"
+ "typecheck": "tsc --project tsconfig.build.json --noEmit"
```

## Why

`tsconfig.typecheck.json` existed only **during the strict-checkJs migration** — it provided a `checkJs` gate while `tsconfig.build.json` was still `checkJs:false` (so `build:types` wouldn't break before the language files were annotated). Now that #330 flipped `build.json` to `checkJs:true`, the two configs are identical (`checkJs:true`, same `src` include) except `build.json` emits — and `--noEmit` overrides that. So the third file is pure duplication.

Collapsing to **two configs** also removes a sync hazard: the `src` include no longer has to be kept identical in two places.

| Config | Role |
|---|---|
| `tsconfig.json` | editor/IDE base (broad include, `noEmit`, shared options) |
| `tsconfig.build.json` | emit `.d.ts` + type-check src (`checkJs`); `--noEmit` reuses it for `typecheck` |

## Verification

- `npm run typecheck` → 0 errors, **0 `.d.ts` emitted** (identical to the old behavior); still exits non-zero on an injected type error.
- `npm test` → 264 pass; CI's `Typecheck` step (unchanged — still calls `npm run typecheck`) keeps working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)