### PR TITLE
build: adopt full eslint-plugin-jsdoc (recommended-typescript-flavor)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,7 @@ import n from 'eslint-plugin-n'
 import importX from 'eslint-plugin-import-x'
 import ava from 'eslint-plugin-ava'
 import comments from '@eslint-community/eslint-plugin-eslint-comments/configs'
+import jsdoc from 'eslint-plugin-jsdoc'
 import globals from 'globals'
 
 // Flat config (ESLint 10). Built on ESLint's own recommended rules + @stylistic
@@ -45,6 +46,16 @@ export default defineConfig([
       compat.configs['flat/recommended'],
       esx.configs['flat/restrict-to-es2022'],
     ],
+  },
+
+  // JSDoc correctness on shipped source — JSDoc is the type source for the
+  // generated .d.ts, so its accuracy is enforced. Full recommended set for
+  // JS-type-checked-via-JSDoc (matches our checkJs setup), at error level,
+  // adopted as-published with no rule disables.
+  {
+    name: 'n2words/src-jsdoc',
+    files: ['src/**/*.js'],
+    extends: [jsdoc.configs['flat/recommended-typescript-flavor-error']],
   },
 
   // Tests run on the CI Node matrix (down to the engines floor), so n checks

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-compat": "^7.0.2",
         "eslint-plugin-es-x": "^9.6.0",
         "eslint-plugin-import-x": "^4.16.2",
+        "eslint-plugin-jsdoc": "^63.0.1",
         "eslint-plugin-n": "^18.0.1",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
@@ -400,6 +401,33 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.87.0.tgz",
+      "integrity": "sha512-mFXZloZMzuJZXSHUmAFu/pXTk0ZJTJBluuAkrvbzidpTN8W6F2bpRFuedSH+85kbdlRLJqc+gfN+kD3JOLJK5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@eslint-community/eslint-plugin-eslint-comments": {
@@ -1300,6 +1328,19 @@
         "url": "https://ko-fi.com/dangreen"
       }
     },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -1898,6 +1939,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/argparse": {
@@ -3244,6 +3295,66 @@
         }
       }
     },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.0.1.tgz",
+      "integrity": "sha512-2uQ2ShksMXRUI4K96/CyNs5sYmXQHaSoRjn1cxL2RcRHF+9d+njIkT03cZS7/g/eI/fPJTRfjm/MgIlOezD+KQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.87.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.1",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-plugin-n": {
       "version": "18.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.0.1.tgz",
@@ -3928,6 +4039,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -4345,6 +4473,16 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/json-buffer": {
@@ -5596,6 +5734,13 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -5742,6 +5887,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -5773,6 +5928,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -5946,6 +6108,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve": {
@@ -6276,6 +6451,31 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6538,6 +6738,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tr46": {

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "eslint-plugin-compat": "^7.0.2",
     "eslint-plugin-es-x": "^9.6.0",
     "eslint-plugin-import-x": "^4.16.2",
+    "eslint-plugin-jsdoc": "^63.0.1",
     "eslint-plugin-n": "^18.0.1",
     "globals": "^17.6.0",
     "husky": "^9.1.7",

--- a/src/am-ET.js
+++ b/src/am-ET.js
@@ -58,8 +58,8 @@ const SCALE_WORDS = ['', THOUSAND, 'ሚሊዮን', 'ቢሊዮን']
 // ============================================================================
 
 /**
- * @param {number} n
- * @returns {string}
+ * @param {number} n The three-digit segment value (0-999) to convert.
+ * @returns {string} The segment in Amharic words.
  */
 function buildSegment(n) {
   if (n === 0) return ''
@@ -95,8 +95,8 @@ function buildSegment(n) {
 // ============================================================================
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The non-negative integer to convert.
+ * @returns {string} The integer in Amharic words.
  */
 function integerToWords(n) {
   if (n === 0n) return ZERO
@@ -109,8 +109,8 @@ function integerToWords(n) {
 }
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer (>= 1000) to convert using scale words.
+ * @returns {string} The integer in Amharic words.
  */
 function buildLargeNumberWords(n) {
   const numStr = n.toString()
@@ -154,8 +154,8 @@ function buildLargeNumberWords(n) {
 }
 
 /**
- * @param {string} decimalPart
- * @returns {string}
+ * @param {string} decimalPart The digit string after the decimal point.
+ * @returns {string} The decimal digits read individually in Amharic words.
  */
 function decimalPartToWords(decimalPart) {
   // Per-digit decimal reading
@@ -169,7 +169,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Amharic words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Amharic words
  */
@@ -200,7 +199,6 @@ function toCardinal(value) {
  *
  * In Amharic, ordinals are formed by adding -ኛ suffix to the cardinal.
  * Special case: 1 = አንደኛ (not አንድኛ)
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Amharic ordinal words
  */
@@ -220,12 +218,10 @@ function integerToOrdinal(n) {
  *
  * Amharic ordinals: add -ኛ suffix to cardinal.
  * Special case: 1 → አንደኛ
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'አንደኛ'
  * toOrdinal(2)    // 'ሁለትኛ'
@@ -243,12 +239,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Amharic currency words (Ethiopian Birr).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Amharic currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'አርባ ሁለት ብር ሃምሳ ሳንቲም'
  * toCurrency(1)      // 'አንድ ብር'

--- a/src/am-Latn-ET.js
+++ b/src/am-Latn-ET.js
@@ -59,7 +59,6 @@ const SCALE_WORDS = ['', THOUSAND, 'miliyon', 'billiyon']
 
 /**
  * Builds the words for a 3-digit segment (0-999).
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} The segment in Amharic (Latin) words
  */
@@ -98,7 +97,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Amharic (Latin script) words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} The integer in Amharic (Latin) words
  */
@@ -114,7 +112,6 @@ function integerToWords(n) {
 
 /**
  * Builds the words for a number of 1000 or greater using short-scale grouping.
- *
  * @param {bigint} n - Integer of 1000 or greater
  * @returns {string} The number in Amharic (Latin) words
  */
@@ -161,7 +158,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Reads the decimal part digit by digit.
- *
  * @param {string} decimalPart - The fractional digits as a string
  * @returns {string} The decimal digits in Amharic (Latin) words
  */
@@ -177,7 +173,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Amharic (Latin script) words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Amharic Latin words
  */
@@ -208,7 +203,6 @@ function toCardinal(value) {
  *
  * In Amharic, ordinals are formed by adding -nya suffix to the cardinal.
  * Special case: 1 = andenya
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Amharic (Latin) ordinal words
  */
@@ -225,12 +219,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Amharic (Latin script) ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'andenya'
  * toOrdinal(2)    // 'huletnya'
@@ -247,12 +239,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Amharic (Latin script) currency words (Ethiopian Birr).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Amharic (Latin) currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'arba hulet birr hamsa santim'
  * toCurrency(1)      // 'and birr'

--- a/src/ar-SA.js
+++ b/src/ar-SA.js
@@ -76,7 +76,6 @@ const HALALA_PLURAL_11 = 'هللة'
  * Convert a 3-digit group to words.
  * Returns a clean string with no leading/trailing spaces.
  * Arabic "و" (and) is attached to following word: "مائة وخمسة" not "مائة و خمسة"
- *
  * @param {number} groupNumber - The 3-digit group value (0-999)
  * @param {number} groupLevel - The scale level of this group (0 = units, 1 = thousands, ...)
  * @param {bigint} fullNumber - The full number being converted
@@ -140,7 +139,6 @@ function segmentToWords(groupNumber, groupLevel, fullNumber, ones) {
 
 /**
  * Convert a non-negative integer to Arabic words.
- *
  * @param {bigint} n - The non-negative integer to convert
  * @param {string} gender - 'masculine' or 'feminine'
  * @returns {string} The number rendered as words
@@ -199,7 +197,6 @@ function integerToWords(n, gender) {
 
 /**
  * Convert the fractional digits of a number to Arabic words.
- *
  * @param {string} decimalPart - The decimal digits (after the separator)
  * @param {string} gender - 'masculine' or 'feminine'
  * @returns {string} The decimal part rendered as words
@@ -223,13 +220,11 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Arabic words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @param {string} [options.negativeWord] - Custom word for negative numbers
  * @returns {string} The number in Arabic words
- *
  * @example
  * toCardinal(1)                        // 'واحد'
  * toCardinal(1, {gender: 'feminine'})  // 'واحدة'
@@ -268,7 +263,6 @@ function toCardinal(value, options) {
  * Gets the Arabic ordinal form for a number.
  *
  * Arabic ordinals 1-10 have special forms, beyond 10 use cardinal + position.
- *
  * @param {bigint} n - Positive integer to convert
  * @param {string} gender - 'masculine' or 'feminine'
  * @returns {string} Arabic ordinal words
@@ -288,14 +282,12 @@ function integerToOrdinal(n, gender) {
 
 /**
  * Converts a numeric value to Arabic ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)                        // 'الأول'
  * toOrdinal(1, {gender: 'feminine'})  // 'الأولى'
@@ -320,7 +312,6 @@ function toOrdinal(value, options) {
  * - 2: dual
  * - 3-10: plural form 1
  * - 11+: plural form 2 (different ending)
- *
  * @param {bigint} n - The riyal count
  * @returns {string} The appropriate riyal word form
  */
@@ -333,7 +324,6 @@ function getRiyalForm(n) {
 
 /**
  * Gets the appropriate halala word form based on number.
- *
  * @param {bigint} n - The halala count
  * @returns {string} The appropriate halala word form
  */
@@ -346,12 +336,10 @@ function getHalalaForm(n) {
 
 /**
  * Converts a numeric value to Arabic currency words (Saudi Riyal).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Arabic currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'اثنان وأربعون ريالاً وخمسون هللة'
  * toCurrency(1)      // 'ريال واحد'

--- a/src/az-AZ.js
+++ b/src/az-AZ.js
@@ -195,7 +195,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Azerbaijani words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Azerbaijani words
  */
@@ -253,7 +252,6 @@ function getOrdinalSuffix(word) {
  *
  * Azerbaijani ordinals: birinci (1st), ikinci (2nd), üçüncü (3rd), etc.
  * Uses vowel harmony for suffix selection.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Azerbaijani ordinal words
  */
@@ -271,12 +269,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Azerbaijani ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'birinci'
  * toOrdinal(2)    // 'ikinci'
@@ -295,12 +291,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Azerbaijani currency words (Manat).
  *
  * Uses manat and qəpik (100 qəpik = 1 manat).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Azerbaijani currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'qırx iki manat'
  * toCurrency(1.50)   // 'bir manat əlli qəpik'

--- a/src/bn-BD.js
+++ b/src/bn-BD.js
@@ -65,7 +65,6 @@ const SCALE_WORDS = ['', 'হাজার', 'লাখ', 'কোটি', 'আর
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Segment value in the range 0-999
  * @returns {string} Bengali words for the segment
  */
@@ -91,7 +90,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Bengali words
  */
@@ -144,7 +142,6 @@ function integerToWords(n) {
 
 /**
  * Converts the fractional digits string to Bengali words.
- *
  * @param {string} decimalPart - The fractional digits (e.g. '05')
  * @returns {string} Bengali words for the decimal part
  */
@@ -169,7 +166,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Bengali words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Bengali words
  */
@@ -199,7 +195,6 @@ function toCardinal(value) {
  * Converts a positive integer to Bengali ordinal words.
  *
  * Bengali ordinals: First 6 are irregular, then add -তম suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Bengali ordinal words
  */
@@ -216,12 +211,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Bengali ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'প্রথম'
  * toOrdinal(2)    // 'দ্বিতীয়'
@@ -239,12 +232,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Bengali currency words (Bangladeshi Taka).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Bengali currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'বেয়াল্লিশ টাকা পঞ্চাশ পয়সা'
  * toCurrency(1)      // 'এক টাকা'

--- a/src/cs-CZ.js
+++ b/src/cs-CZ.js
@@ -82,7 +82,6 @@ const HALER_FORMS = ['haléř', 'haléře', 'haléřů']
 
 /**
  * Builds segment word for 0-999 (masculine, default form).
- *
  * @param {number} n - Number 0-999
  * @returns {string} Czech words
  */
@@ -121,7 +120,6 @@ function buildSegment(n) {
 /**
  * Builds segment word for 0-999 with feminine hundreds.
  * Hundreds use irregular forms (dvě stě, tři sta) but ones remain masculine.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Czech words
  */
@@ -163,7 +161,6 @@ function buildSegmentWithHundreds(n) {
 /**
  * Czech pluralization: 1 = singular, 2-4 = few, else = many.
  * Teens (11-19) always use "many" form.
- *
  * @param {bigint} n - The number
  * @param {string[]} forms - [singular, few, many]
  * @returns {string} The appropriate form
@@ -185,7 +182,6 @@ function pluralize(n, forms) {
 /**
  * Gets the decimal separator word based on integer part.
  * celá (0-1), celé (2-4), celých (5+)
- *
  * @param {bigint} integerPart - The integer part of the value
  * @returns {string} The decimal separator word
  */
@@ -207,7 +203,6 @@ function getDecimalSeparator(integerPart) {
 
 /**
  * Converts a non-negative integer to Czech words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Czech words
  */
@@ -250,7 +245,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Czech words
  */
@@ -304,7 +298,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Czech words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Czech words for decimal part
  */
@@ -334,12 +327,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Czech words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)           // 'dvacet jedna'
  * toCardinal(1000)         // 'tisíc'
@@ -371,7 +362,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -398,7 +388,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a positive integer to Czech ordinal words (masculine nominative).
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Czech words
  */
@@ -440,7 +429,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Czech words
  */
@@ -504,12 +492,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Czech ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'první'
  * toOrdinal(2)    // 'druhý'
@@ -528,12 +514,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Czech currency words (Koruna).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Czech currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'čtyřicet dva koruny'
  * toCurrency(1)      // 'jedna koruna'

--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -74,7 +74,6 @@ const ORE = 'øre' // same singular and plural
 
 /**
  * Builds segment word for 0-999.
- *
  * @param {number} n - Integer in range 0-999
  * @returns {string} Danish words for the segment
  */
@@ -128,7 +127,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Danish words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Danish words
  */
@@ -162,7 +160,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Danish words
  */
@@ -227,7 +224,6 @@ function buildLargeNumberWords(n) {
  * Joins parts with Danish spacing rules.
  * - After thousands with remainder: "tusinde og"
  * - Millions are space-separated
- *
  * @param {Array<{word: string, type: string}>} parts - Parts with type metadata
  * @returns {string} Joined string
  */
@@ -268,7 +264,6 @@ function joinDanishParts(parts) {
 
 /**
  * Converts decimal digits to Danish words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Danish words for decimal part
  */
@@ -295,12 +290,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Danish words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Danish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)       // 'enogtyve'
  * toCardinal(1000)     // 'ettusind'
@@ -333,7 +326,6 @@ function toCardinal(value) {
  *
  * Danish ordinals: første (1st), anden (2nd), tredje (3rd), etc.
  * 1-12 have special forms, others use cardinal + -de/-nde suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Danish ordinal words
  */
@@ -350,12 +342,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Danish ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'første'
  * toOrdinal(2)    // 'anden'
@@ -374,12 +364,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Danish currency words (Danish Krone).
  *
  * Uses krone/kroner and øre (100 øre = 1 krone).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Danish currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)      // 'en krone'
  * toCurrency(42)     // 'toogfyrre kroner'

--- a/src/de-DE.js
+++ b/src/de-DE.js
@@ -75,7 +75,6 @@ const CENT = 'Cent'
 /**
  * Builds segment word for 0-999 (standalone form, uses "eins").
  * German inverts ones and tens: "einundzwanzig" = one-and-twenty
- *
  * @param {number} n - Number 0-999
  * @returns {string} German words for the segment
  */
@@ -119,7 +118,6 @@ function buildSegment(n) {
 /**
  * Builds segment word for use before "tausend".
  * Uses "ein" instead of "eins" for 1.
- *
  * @param {number} n - Number 0-999
  * @returns {string} German words for thousand context
  */
@@ -162,7 +160,6 @@ function buildSegmentForThousand(n) {
 
 /**
  * Converts a non-negative integer to German words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} German words
  */
@@ -195,7 +192,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} German words
  */
@@ -260,7 +256,6 @@ function buildLargeNumberWords(n) {
 /**
  * Joins parts with German spacing rules.
  * Spaces only around million+ scale words.
- *
  * @param {Array<{words: string, isScale: boolean, scaleLevel: number}>} parts - Parts with metadata
  * @returns {string} Joined string
  */
@@ -291,7 +286,6 @@ function joinGermanParts(parts) {
 
 /**
  * Converts decimal digits to German words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} German words for decimal part
  */
@@ -321,12 +315,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in German words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)           // 'einundzwanzig'
  * toCardinal(1000)         // 'eintausend'
@@ -358,7 +350,6 @@ function toCardinal(value) {
  * Builds ordinal segment for 0-999.
  * Only the final component becomes ordinal.
  * Uses -te for 1-19, -ste for 20+.
- *
  * @param {number} n - Number 0-999
  * @param {boolean} isFinal - Whether this is the final segment (gets ordinal suffix)
  * @returns {string} German ordinal words for this segment
@@ -425,7 +416,6 @@ function buildOrdinalSegment(n, isFinal) {
 
 /**
  * Converts integer to German ordinal words.
- *
  * @param {bigint} n - Positive integer
  * @returns {string} German ordinal words
  */
@@ -455,7 +445,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} German ordinal words
  */
@@ -541,12 +530,10 @@ function buildLargeOrdinal(n) {
  *
  * German ordinals add -te for 1-19 and -ste for 20+.
  * Irregular forms: erste (1st), dritte (3rd), siebte (7th), achte (8th).
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'erste'
  * toOrdinal(2)    // 'zweite'
@@ -566,14 +553,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to German currency words (Euro).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "und" between euros and cents
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "und" between euros and cents
  * @returns {string} The amount in German currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                 // 'zweiundvierzig Euro und fünfzig Cent'
  * toCurrency(1)                     // 'ein Euro'

--- a/src/el-GR.js
+++ b/src/el-GR.js
@@ -58,7 +58,6 @@ const CENT_FORMS = ['λεπτό', 'λεπτά'] // Singular, plural
 
 /**
  * Builds segment word for 0-999.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Greek words for the segment
  */
@@ -104,7 +103,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Greek words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Greek words
  */
@@ -143,7 +141,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Greek words
  */
@@ -209,7 +206,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Greek words (per-digit).
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Greek words for decimal part
  */
@@ -231,12 +227,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Greek words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Greek words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)       // 'είκοσι ένα'
  * toCardinal(1000)     // 'χίλια'
@@ -266,7 +260,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal for tens and ones (0-99).
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal word
  */
@@ -286,7 +279,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a non-negative integer to Greek ordinal words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Greek ordinal words
  */
@@ -369,12 +361,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Greek ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The ordinal in Greek words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)   // 'πρώτος'
  * toOrdinal(21)  // 'εικοστός πρώτος'
@@ -390,12 +380,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Greek Euro currency words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The currency in Greek words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)     // 'ένα ευρώ'
  * toCurrency(2.50)  // 'δύο ευρώ πενήντα λεπτά'

--- a/src/en-AU.js
+++ b/src/en-AU.js
@@ -55,9 +55,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment (British-style with "and" after hundreds).
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether a hundreds place was present
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -106,7 +105,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -140,7 +138,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} English words
  */
@@ -191,7 +188,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -216,12 +212,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Australian English words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(101)          // 'one hundred and one'
@@ -251,7 +245,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -290,7 +283,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Converts a positive integer to ordinal words.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -316,7 +308,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal English words
  */
@@ -367,12 +358,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Australian English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'first'
  * toOrdinal(42)   // 'forty-second'
@@ -389,14 +378,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Australian English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between dollars and cents
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between dollars and cents
  * @returns {string} The amount in Australian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two dollars and fifty cents'
  * toCurrency(1)                        // 'one dollar'

--- a/src/en-BD.js
+++ b/src/en-BD.js
@@ -50,9 +50,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment (British-style with "and" after hundreds).
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether a hundred was emitted
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -97,9 +96,8 @@ function buildSegment(n) {
 
 /**
  * Builds words for a 0-99 segment (no hundreds).
- *
  * @param {number} n - Number 0-99
- * @returns {string}
+ * @returns {string} The segment in words
  */
 function buildSmallSegment(n) {
   if (n === 0) return ''
@@ -125,7 +123,6 @@ function buildSmallSegment(n) {
  *
  * Uses BigInt modulo for segment extraction.
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -182,7 +179,6 @@ function integerToWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -209,12 +205,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to English words using Indian numbering.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(100000)       // 'one lakh'
@@ -245,7 +239,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -286,7 +279,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Converts a positive integer to ordinal words using Indian numbering.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -356,12 +348,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to English ordinal words using Indian numbering.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)       // 'first'
  * toOrdinal(100000)  // 'one lakhth'
@@ -378,14 +368,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Bangladeshi English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between taka and paise
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between taka and paise
  * @returns {string} The amount in Bangladeshi English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two taka and fifty paise'
  * toCurrency(100000)                   // 'one lakh taka'

--- a/src/en-CA.js
+++ b/src/en-CA.js
@@ -64,10 +64,9 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @param {boolean} useAnd - Whether to use "and" after hundreds
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether a hundreds place is present
  */
 function buildSegment(n, useAnd) {
   if (n === 0) {
@@ -117,7 +116,6 @@ function buildSegment(n, useAnd) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} hundredPairing - Use hundred-pairing for 1100-9999
  * @param {boolean} useAnd - Use "and" after hundreds and before final segment
@@ -179,7 +177,6 @@ function integerToWords(n, hundredPairing, useAnd) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {boolean} useAnd - Use "and" after hundreds and before final segment
  * @returns {string} English words
@@ -240,7 +237,6 @@ function buildLargeNumberWords(n, useAnd) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {boolean} useAnd - Use "and" in number conversion
  * @returns {string} English words for decimal part
@@ -271,15 +267,13 @@ function decimalPartToWords(decimalPart, useAnd) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.hundredPairing=false] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
- * @param {boolean} [options.and=true] - Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.hundredPairing] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
+ * @param {boolean} [options.and] - Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)
  * @returns {string} The number in Canadian English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)                            // 'forty-two'
  * toCardinal(101)                           // 'one hundred and one'
@@ -316,7 +310,6 @@ function toCardinal(value, options) {
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
  * Returns ordinal form: "first", "twenty-third", "one hundred forty-fifth"
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -364,7 +357,6 @@ function buildOrdinalSegment(n) {
 /**
  * Converts a positive integer to ordinal words.
  * Generates ordinals directly without string manipulation.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -396,7 +388,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal English words
  */
@@ -454,12 +445,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Canadian English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'first'
  * toOrdinal(2)    // 'second'
@@ -481,14 +470,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Canadian English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
  * @returns {string} The amount in Canadian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two dollars and fifty cents'
  * toCurrency(1)                        // 'one dollar'

--- a/src/en-GB.js
+++ b/src/en-GB.js
@@ -56,9 +56,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether it includes a hundreds place
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -107,7 +106,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -142,7 +140,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} English words
  */
@@ -200,7 +197,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -230,12 +226,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(-3.14)        // 'minus three point fourteen'
@@ -266,7 +260,6 @@ function toCardinal(value) {
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
  * Returns ordinal form: "first", "twenty-third", "one hundred forty-fifth"
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -314,7 +307,6 @@ function buildOrdinalSegment(n) {
 /**
  * Converts a positive integer to ordinal words.
  * Generates ordinals directly without string manipulation.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -346,7 +338,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal English words
  */
@@ -404,12 +395,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to British English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'first'
  * toOrdinal(2)    // 'second'
@@ -431,14 +420,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to British English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between pounds and pence (e.g., "one pound and fifty pence")
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between pounds and pence (e.g., "one pound and fifty pence")
  * @returns {string} The amount in British English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two pounds and fifty pence'
  * toCurrency(1)                        // 'one pound'

--- a/src/en-GH.js
+++ b/src/en-GH.js
@@ -62,7 +62,6 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds the words for a three-digit segment (0-999).
- *
  * @param {number} n - The segment value (0-999)
  * @returns {{word: string, hasHundred: boolean}} The segment words and whether it includes a hundred
  */
@@ -111,7 +110,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to cardinal words.
- *
  * @param {bigint} n - The non-negative integer to convert
  * @returns {string} The number in English words
  */
@@ -142,7 +140,6 @@ function integerToWords(n) {
 
 /**
  * Builds cardinal words for integers of one million or greater.
- *
  * @param {bigint} n - The integer to convert (>= 1,000,000)
  * @returns {string} The number in English words
  */
@@ -193,7 +190,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts the fractional digits of a decimal to words.
- *
  * @param {string} decimalPart - The decimal digits (e.g., "05")
  * @returns {string} The decimal part in English words
  */
@@ -218,7 +214,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Ghanaian English words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
@@ -248,7 +243,6 @@ function toCardinal(value) {
 
 /**
  * Builds the ordinal words for a three-digit segment (0-999).
- *
  * @param {number} n - The segment value (0-999)
  * @returns {string} The ordinal segment words
  */
@@ -287,7 +281,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Converts a positive integer to ordinal words.
- *
  * @param {bigint} n - The positive integer to convert
  * @returns {string} The ordinal in English words
  */
@@ -313,7 +306,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for integers of one million or greater.
- *
  * @param {bigint} n - The integer to convert (>= 1,000,000)
  * @returns {string} The ordinal in English words
  */
@@ -364,7 +356,6 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Ghanaian English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
@@ -381,7 +372,6 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Ghanaian English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @param {{and?: boolean}} [options] - Optional configuration
  * @returns {string} The amount in Ghanaian English currency words

--- a/src/en-IE.js
+++ b/src/en-IE.js
@@ -65,9 +65,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether a hundreds part is present.
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -116,7 +115,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -151,7 +149,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} English words
  */
@@ -209,7 +206,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -239,12 +235,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(-3.14)        // 'minus three point fourteen'
@@ -275,7 +269,6 @@ function toCardinal(value) {
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
  * Returns ordinal form: "first", "twenty-third", "one hundred forty-fifth"
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -323,7 +316,6 @@ function buildOrdinalSegment(n) {
 /**
  * Converts a positive integer to ordinal words.
  * Generates ordinals directly without string manipulation.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -355,7 +347,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal English words
  */
@@ -413,12 +404,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Irish English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'first'
  * toOrdinal(2)    // 'second'
@@ -440,14 +429,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Irish English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between euro and cent (e.g., "one euro and fifty cents")
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between euro and cent (e.g., "one euro and fifty cents")
  * @returns {string} The amount in Irish English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two euro and fifty cents'
  * toCurrency(1)                        // 'one euro'

--- a/src/en-IN.js
+++ b/src/en-IN.js
@@ -51,9 +51,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment (British-style with "and" after hundreds).
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether a hundred was included
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -98,9 +97,8 @@ function buildSegment(n) {
 
 /**
  * Builds words for a 0-99 segment (no hundreds).
- *
  * @param {number} n - Number 0-99
- * @returns {string}
+ * @returns {string} The segment in words
  */
 function buildSmallSegment(n) {
   if (n === 0) return ''
@@ -126,7 +124,6 @@ function buildSmallSegment(n) {
  *
  * Uses BigInt modulo for segment extraction.
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -183,7 +180,6 @@ function integerToWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -210,12 +206,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to English words using Indian numbering.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(100000)       // 'one lakh'
@@ -246,7 +240,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -287,7 +280,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Converts a positive integer to ordinal words using Indian numbering.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -357,12 +349,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to English ordinal words using Indian numbering.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)       // 'first'
  * toOrdinal(100000)  // 'one lakhth'
@@ -379,14 +369,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Indian English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between rupees and paise
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between rupees and paise
  * @returns {string} The amount in Indian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two rupees and fifty paise'
  * toCurrency(100000)                   // 'one lakh rupees'

--- a/src/en-KE.js
+++ b/src/en-KE.js
@@ -61,7 +61,8 @@ const CENTS = 'cents'
 const segmentResult = { word: '', hasHundred: false }
 
 /**
- * @param {number} n
+ * @param {number} n The 0-999 group value to convert
+ * @returns {{word: string, hasHundred: boolean}} The segment words and whether it includes a hundreds place
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -107,7 +108,8 @@ function buildSegment(n) {
 // ============================================================================
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The non-negative integer to convert
+ * @returns {string} The integer in English words
  */
 function integerToWords(n) {
   if (n === 0n) return ZERO
@@ -135,7 +137,8 @@ function integerToWords(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The integer of one million or greater to convert
+ * @returns {string} The integer in English words
  */
 function buildLargeNumberWords(n) {
   const segments = []
@@ -183,7 +186,8 @@ function buildLargeNumberWords(n) {
 }
 
 /**
- * @param {string} decimalPart
+ * @param {string} decimalPart The fractional digits as a string
+ * @returns {string} The decimal digits in English words
  */
 function decimalPartToWords(decimalPart) {
   let result = ''
@@ -206,7 +210,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Kenyan English words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
@@ -235,7 +238,8 @@ function toCardinal(value) {
 // ============================================================================
 
 /**
- * @param {number} n
+ * @param {number} n The 0-999 group value to convert
+ * @returns {string} The segment as ordinal English words
  */
 function buildOrdinalSegment(n) {
   const ones = n % 10
@@ -271,7 +275,8 @@ function buildOrdinalSegment(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The non-negative integer to convert
+ * @returns {string} The integer as ordinal English words
  */
 function integerToOrdinal(n) {
   if (n < 1000n) {
@@ -294,7 +299,8 @@ function integerToOrdinal(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The integer of one million or greater to convert
+ * @returns {string} The integer as ordinal English words
  */
 function buildLargeOrdinal(n) {
   const segments = []
@@ -343,7 +349,6 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Kenyan English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The ordinal in English words
  */
@@ -358,7 +363,6 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Kenyan English currency words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @param {{and?: boolean}} [options] - Currency formatting options
  * @returns {string} The currency in English words

--- a/src/en-MY.js
+++ b/src/en-MY.js
@@ -62,7 +62,8 @@ const SEN = 'sen'
 const segmentResult = { word: '', hasHundred: false }
 
 /**
- * @param {number} n
+ * @param {number} n The 0-999 segment to convert.
+ * @returns {{word: string, hasHundred: boolean}} The segment in words and whether it includes a hundreds part.
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -108,7 +109,8 @@ function buildSegment(n) {
 // ============================================================================
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The non-negative integer to convert.
+ * @returns {string} The integer in English words.
  */
 function integerToWords(n) {
   if (n === 0n) return ZERO
@@ -136,7 +138,8 @@ function integerToWords(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The integer of one million or greater to convert.
+ * @returns {string} The integer in English words.
  */
 function buildLargeNumberWords(n) {
   const segments = []
@@ -184,7 +187,8 @@ function buildLargeNumberWords(n) {
 }
 
 /**
- * @param {string} decimalPart
+ * @param {string} decimalPart The fractional digits after the decimal point.
+ * @returns {string} The decimal digits in English words.
  */
 function decimalPartToWords(decimalPart) {
   let result = ''
@@ -207,7 +211,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Malaysian English words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
@@ -236,7 +239,8 @@ function toCardinal(value) {
 // ============================================================================
 
 /**
- * @param {number} n
+ * @param {number} n The 0-999 segment to convert.
+ * @returns {string} The segment as an ordinal in English words.
  */
 function buildOrdinalSegment(n) {
   const ones = n % 10
@@ -272,7 +276,8 @@ function buildOrdinalSegment(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The non-negative integer to convert.
+ * @returns {string} The integer as an ordinal in English words.
  */
 function integerToOrdinal(n) {
   if (n < 1000n) {
@@ -295,7 +300,8 @@ function integerToOrdinal(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The integer of one million or greater to convert.
+ * @returns {string} The integer as an ordinal in English words.
  */
 function buildLargeOrdinal(n) {
   const segments = []
@@ -343,8 +349,8 @@ function buildLargeOrdinal(n) {
 }
 
 /**
- * @param {number | string | bigint} value
- * @returns {string}
+ * @param {number | string | bigint} value The numeric value to convert.
+ * @returns {string} The number as an ordinal in English words.
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
@@ -356,9 +362,9 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
- * @param {number | string | bigint} value
- * @param {{and?: boolean}} [options]
- * @returns {string}
+ * @param {number | string | bigint} value The numeric value to convert.
+ * @param {{and?: boolean}} [options] Formatting options, such as whether to join ringgit and sen with "and".
+ * @returns {string} The amount in Malaysian ringgit and sen in English words.
  */
 function toCurrency(value, options) {
   options = validateOptions(options)

--- a/src/en-NG.js
+++ b/src/en-NG.js
@@ -64,9 +64,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether it includes a hundreds place
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -115,7 +114,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -150,7 +148,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} English words
  */
@@ -208,7 +205,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -238,12 +234,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(-3.14)        // 'minus three point fourteen'
@@ -274,7 +268,6 @@ function toCardinal(value) {
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
  * Returns ordinal form: "first", "twenty-third", "one hundred forty-fifth"
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -322,7 +315,6 @@ function buildOrdinalSegment(n) {
 /**
  * Converts a positive integer to ordinal words.
  * Generates ordinals directly without string manipulation.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -354,7 +346,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal English words
  */
@@ -412,12 +403,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Nigerian English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'first'
  * toOrdinal(2)    // 'second'
@@ -439,14 +428,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Nigerian English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between naira and kobo (e.g., "one naira and fifty kobo")
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between naira and kobo (e.g., "one naira and fifty kobo")
  * @returns {string} The amount in Nigerian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two naira and fifty kobo'
  * toCurrency(1)                        // 'one naira'

--- a/src/en-NZ.js
+++ b/src/en-NZ.js
@@ -63,9 +63,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether a hundreds part is present
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -114,7 +113,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -148,7 +146,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} English words
  */
@@ -199,7 +196,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -224,7 +220,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to New Zealand English words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
@@ -254,7 +249,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words
  */
@@ -293,7 +287,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Converts a non-negative integer to English ordinal words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English ordinal words
  */
@@ -319,7 +312,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} English ordinal words
  */
@@ -370,7 +362,6 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to New Zealand English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
@@ -387,7 +378,6 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to New Zealand English currency words (New Zealand Dollar).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @param {{and?: boolean}} [options] - Optional configuration
  * @returns {string} The amount in New Zealand English currency words

--- a/src/en-PH.js
+++ b/src/en-PH.js
@@ -61,7 +61,8 @@ const CENTAVOS = 'centavos'
 const segmentResult = { word: '', hasHundred: false }
 
 /**
- * @param {number} n
+ * @param {number} n The 0-999 segment value to convert.
+ * @returns {{word: string, hasHundred: boolean}} The segment words and whether it includes a hundreds place.
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -107,7 +108,8 @@ function buildSegment(n) {
 // ============================================================================
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The non-negative integer to convert.
+ * @returns {string} The integer in English words.
  */
 function integerToWords(n) {
   if (n === 0n) return ZERO
@@ -135,7 +137,8 @@ function integerToWords(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The integer of one million or greater to convert.
+ * @returns {string} The integer in English words.
  */
 function buildLargeNumberWords(n) {
   const segments = []
@@ -183,7 +186,8 @@ function buildLargeNumberWords(n) {
 }
 
 /**
- * @param {string} decimalPart
+ * @param {string} decimalPart The fractional digits to convert.
+ * @returns {string} The decimal digits in English words.
  */
 function decimalPartToWords(decimalPart) {
   let result = ''
@@ -206,7 +210,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Philippine English words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
@@ -235,7 +238,8 @@ function toCardinal(value) {
 // ============================================================================
 
 /**
- * @param {number} n
+ * @param {number} n The 0-999 segment value to convert.
+ * @returns {string} The segment as ordinal words.
  */
 function buildOrdinalSegment(n) {
   const ones = n % 10
@@ -271,7 +275,8 @@ function buildOrdinalSegment(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The positive integer to convert.
+ * @returns {string} The integer as ordinal words.
  */
 function integerToOrdinal(n) {
   if (n < 1000n) {
@@ -294,7 +299,8 @@ function integerToOrdinal(n) {
 }
 
 /**
- * @param {bigint} n
+ * @param {bigint} n The integer of one million or greater to convert.
+ * @returns {string} The integer as ordinal words.
  */
 function buildLargeOrdinal(n) {
   const segments = []
@@ -343,7 +349,6 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Philippine English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
@@ -360,7 +365,6 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Philippine English currency words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @param {{and?: boolean}} [options] - Optional configuration
  * @returns {string} The amount in Philippine English currency words

--- a/src/en-PK.js
+++ b/src/en-PK.js
@@ -51,9 +51,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment (British-style with "and" after hundreds).
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether it includes a hundreds place
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -98,9 +97,8 @@ function buildSegment(n) {
 
 /**
  * Builds words for a 0-99 segment (no hundreds).
- *
  * @param {number} n - Number 0-99
- * @returns {string}
+ * @returns {string} The number in words
  */
 function buildSmallSegment(n) {
   if (n === 0) return ''
@@ -126,7 +124,6 @@ function buildSmallSegment(n) {
  *
  * Uses BigInt modulo for segment extraction.
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -183,7 +180,6 @@ function integerToWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -210,12 +206,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to English words using Indian numbering.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(100000)       // 'one lakh'
@@ -246,7 +240,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -287,7 +280,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Converts a positive integer to ordinal words using Indian numbering.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -357,12 +349,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to English ordinal words using Indian numbering.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)       // 'first'
  * toOrdinal(100000)  // 'one lakhth'
@@ -379,14 +369,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Pakistani English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between rupees and paise
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between rupees and paise
  * @returns {string} The amount in Pakistani English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two rupees and fifty paise'
  * toCurrency(100000)                   // 'one lakh rupees'

--- a/src/en-SG.js
+++ b/src/en-SG.js
@@ -62,7 +62,7 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether it contains a hundreds part
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -210,7 +210,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Singaporean English words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
@@ -350,7 +349,6 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Singaporean English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  */
@@ -365,7 +363,6 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Singaporean English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @param {{ and?: boolean }} [options] - Optional configuration
  * @returns {string} The amount in Singaporean English currency words

--- a/src/en-US.js
+++ b/src/en-US.js
@@ -62,10 +62,9 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @param {boolean} useAnd - Whether to use "and" after hundreds
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether a hundreds place was used
  */
 function buildSegment(n, useAnd) {
   if (n === 0) {
@@ -115,7 +114,6 @@ function buildSegment(n, useAnd) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} hundredPairing - Use hundred-pairing for 1100-9999
  * @param {boolean} useAnd - Use "and" after hundreds and before final segment
@@ -177,7 +175,6 @@ function integerToWords(n, hundredPairing, useAnd) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {boolean} useAnd - Use "and" after hundreds and before final segment
  * @returns {string} English words
@@ -238,7 +235,6 @@ function buildLargeNumberWords(n, useAnd) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {boolean} useAnd - Use "and" in number conversion
  * @returns {string} English words for decimal part
@@ -269,15 +265,13 @@ function decimalPartToWords(decimalPart, useAnd) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.hundredPairing=false] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
- * @param {boolean} [options.and=false] - Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.hundredPairing] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
+ * @param {boolean} [options.and] - Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")
  * @returns {string} The number in American English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)                            // 'forty-two'
  * toCardinal(101)                           // 'one hundred one'
@@ -314,7 +308,6 @@ function toCardinal(value, options) {
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
  * Returns ordinal form: "first", "twenty-third", "one hundred forty-fifth"
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -362,7 +355,6 @@ function buildOrdinalSegment(n) {
 /**
  * Converts a positive integer to ordinal words.
  * Generates ordinals directly without string manipulation.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -394,7 +386,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal English words
  */
@@ -452,12 +443,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to American English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'first'
  * toOrdinal(2)    // 'second'
@@ -479,14 +468,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to American English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
  * @returns {string} The amount in American English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two dollars and fifty cents'
  * toCurrency(1)                        // 'one dollar'

--- a/src/en-ZA.js
+++ b/src/en-ZA.js
@@ -64,9 +64,8 @@ const segmentResult = { word: '', hasHundred: false }
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
- * @returns {{ word: string, hasHundred: boolean }}
+ * @returns {{ word: string, hasHundred: boolean }} The segment words and whether it contains a hundreds place
  */
 function buildSegment(n) {
   if (n === 0) {
@@ -115,7 +114,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to English words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} English words
  */
@@ -150,7 +148,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} English words
  */
@@ -208,7 +205,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to English words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} English words for decimal part
  */
@@ -238,12 +234,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'forty-two'
  * toCardinal(-3.14)        // 'minus three point fourteen'
@@ -274,7 +268,6 @@ function toCardinal(value) {
 /**
  * Builds ordinal words for a 0-999 segment (final segment only).
  * Returns ordinal form: "first", "twenty-third", "one hundred forty-fifth"
- *
  * @param {number} n - Number 0-999
  * @returns {string} Ordinal words for this segment
  */
@@ -322,7 +315,6 @@ function buildOrdinalSegment(n) {
 /**
  * Converts a positive integer to ordinal words.
  * Generates ordinals directly without string manipulation.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal English words
  */
@@ -354,7 +346,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal English words
  */
@@ -412,12 +403,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to South African English ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "first", "forty-second")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'first'
  * toOrdinal(2)    // 'second'
@@ -439,14 +428,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to South African English currency words.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "and" between rand and cents (e.g., "one rand and fifty cents")
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between rand and cents (e.g., "one rand and fifty cents")
  * @returns {string} The amount in South African English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'forty-two rand and fifty cents'
  * toCurrency(1)                        // 'one rand'

--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -137,7 +137,6 @@ function buildSegment(n, feminine) {
 
 /**
  * Gets scale word for Spanish compound long scale.
- *
  * @param {number} scaleIndex - Scale level (1 = thousand, 2 = million, etc.)
  * @param {bigint} segment - Segment value for pluralization
  * @returns {string} Scale word
@@ -168,7 +167,6 @@ function getScaleWord(scaleIndex, segment) {
 
 /**
  * Converts a non-negative integer to Spanish words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words
@@ -217,7 +215,6 @@ function integerToWords(n, feminine) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words
@@ -284,7 +281,6 @@ function buildLargeNumberWords(n, feminine) {
 
 /**
  * Converts decimal digits to Spanish words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words for decimal part
@@ -315,14 +311,12 @@ function decimalPartToWords(decimalPart, feminine) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Spanish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)                        // 'veintiuno'
  * toCardinal(21, {gender: 'feminine'})  // 'veintiuna'
@@ -363,7 +357,6 @@ function toCardinal(value, options) {
  * - 21st = "vigésimo primero"
  * - 100th = "centésimo"
  * - 101st = "centésimo primero"
- *
  * @param {number} n - Segment value 0-999
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish ordinal word
@@ -409,7 +402,6 @@ function buildOrdinalSegment(n, feminine) {
 
 /**
  * Converts a positive integer to Spanish ordinal words.
- *
  * @param {bigint} n - Positive integer to convert
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish ordinal words
@@ -470,14 +462,12 @@ function integerToOrdinal(n, feminine) {
  *
  * Spanish ordinals agree in gender with the noun they modify.
  * Only positive integers are valid for ordinals.
- *
  * @param {number | string | bigint} value - The positive integer to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Spanish ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)                          // 'primero'
  * toOrdinal(1, { gender: 'feminine' })  // 'primera'
@@ -503,14 +493,12 @@ function toOrdinal(value, options) {
  *
  * Spanish currency uses masculine gender for euros (el euro)
  * and masculine for céntimos (el céntimo).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "con" between euros and cents
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "con" between euros and cents
  * @returns {string} The amount in Spanish currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                  // 'cuarenta y dos euros con cincuenta céntimos'
  * toCurrency(1)                      // 'un euro'

--- a/src/es-MX.js
+++ b/src/es-MX.js
@@ -137,7 +137,6 @@ function buildSegment(n, feminine) {
 
 /**
  * Gets scale word for Spanish compound long scale.
- *
  * @param {number} scaleIndex - Scale level (1 = thousand, 2 = million, etc.)
  * @param {bigint} segment - Segment value for pluralization
  * @returns {string} Scale word
@@ -168,7 +167,6 @@ function getScaleWord(scaleIndex, segment) {
 
 /**
  * Converts a non-negative integer to Spanish words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words
@@ -217,7 +215,6 @@ function integerToWords(n, feminine) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words
@@ -284,7 +281,6 @@ function buildLargeNumberWords(n, feminine) {
 
 /**
  * Converts decimal digits to Spanish words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words for decimal part
@@ -312,14 +308,12 @@ function decimalPartToWords(decimalPart, feminine) {
 
 /**
  * Converts a numeric value to Spanish words (long scale).
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Spanish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)                        // 'veintiuno'
  * toCardinal(21, {gender: 'feminine'})  // 'veintiuna'
@@ -354,7 +348,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal word for a 0-999 segment.
- *
  * @param {number} n - Segment value 0-999
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish ordinal word
@@ -398,7 +391,6 @@ function buildOrdinalSegment(n, feminine) {
 
 /**
  * Converts a positive integer to Spanish ordinal words.
- *
  * @param {bigint} n - Positive integer to convert
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish ordinal words
@@ -455,14 +447,12 @@ function integerToOrdinal(n, feminine) {
 
 /**
  * Converts a numeric value to Spanish ordinal words.
- *
  * @param {number | string | bigint} value - The positive integer to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Spanish ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)                          // 'primero'
  * toOrdinal(1, { gender: 'feminine' })  // 'primera'
@@ -487,14 +477,12 @@ function toOrdinal(value, options) {
  *
  * Mexican currency uses masculine gender for pesos (el peso)
  * and masculine for centavos (el centavo).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "con" between pesos and centavos
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "con" between pesos and centavos
  * @returns {string} The amount in Mexican currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                  // 'cuarenta y dos pesos con cincuenta centavos'
  * toCurrency(1)                      // 'un peso'

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -135,7 +135,6 @@ function buildSegment(n, feminine) {
 
 /**
  * Converts a non-negative integer to Spanish words (short scale).
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words
@@ -201,7 +200,6 @@ function integerToWords(n, feminine) {
 
 /**
  * Converts decimal digits to Spanish words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish words for decimal part
@@ -229,14 +227,12 @@ function decimalPartToWords(decimalPart, feminine) {
 
 /**
  * Converts a numeric value to Spanish words (US short scale).
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Spanish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)                        // 'veintiuno'
  * toCardinal(21, {gender: 'feminine'})  // 'veintiuna'
@@ -271,7 +267,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal word for a 0-999 segment.
- *
  * @param {number} n - Segment value 0-999
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish ordinal word
@@ -315,7 +310,6 @@ function buildOrdinalSegment(n, feminine) {
 
 /**
  * Converts a positive integer to Spanish ordinal words.
- *
  * @param {bigint} n - Positive integer to convert
  * @param {boolean} feminine - Use feminine forms
  * @returns {string} Spanish ordinal words
@@ -372,14 +366,12 @@ function integerToOrdinal(n, feminine) {
 
 /**
  * Converts a numeric value to Spanish ordinal words.
- *
  * @param {number | string | bigint} value - The positive integer to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Spanish ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)                          // 'primero'
  * toOrdinal(1, { gender: 'feminine' })  // 'primera'
@@ -404,14 +396,12 @@ function toOrdinal(value, options) {
  *
  * US Dollar uses masculine gender for dólares (el dólar)
  * and masculine for centavos (el centavo).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "con" between dollars and cents
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "con" between dollars and cents
  * @returns {string} The amount in Spanish US Dollar currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                  // 'cuarenta y dos dólares con cincuenta centavos'
  * toCurrency(1)                      // 'un dólar'

--- a/src/fa-IR.js
+++ b/src/fa-IR.js
@@ -66,7 +66,6 @@ const RIAL = 'ریال'
 
 /**
  * Converts a non-negative integer to Persian cardinal words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Persian cardinal words
  */
@@ -134,7 +133,6 @@ function integerToWords(n) {
 
 /**
  * Converts the fractional digits of a number to Persian words.
- *
  * @param {string} decimalPart - The fractional digits as a string
  * @returns {string} Persian words for the decimal portion
  */
@@ -159,7 +157,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Persian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Persian words
  */
@@ -189,7 +186,6 @@ function toCardinal(value) {
  * Converts a non-negative integer to Persian ordinal words.
  *
  * Persian ordinals: اول (1st), دوم (2nd), سوم (3rd), then cardinal + م suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Persian ordinal words
  */
@@ -206,12 +202,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Persian ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'اول'
  * toOrdinal(2)    // 'دوم'
@@ -231,12 +225,10 @@ function toOrdinal(value) {
  *
  * Iranian Rial has no subunit in modern usage.
  * (Historically dinar was 1/100 rial, but not used today)
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Persian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'چهل و دو ریال'
  * toCurrency(1000)   // 'هزار ریال'

--- a/src/fi-FI.js
+++ b/src/fi-FI.js
@@ -66,7 +66,6 @@ const CENT_SINGULAR = 'sentti'
 /**
  * Builds segment word for 0-999.
  * Omits "yksi" before "sata" (hundred).
- *
  * @param {number} n - Integer 0-999 to convert
  * @returns {string} Finnish words for the segment
  */
@@ -118,7 +117,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Finnish words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Finnish words
  */
@@ -157,7 +155,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Finnish words
  */
@@ -218,7 +215,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Finnish words (per-digit).
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Finnish words for decimal part
  */
@@ -240,12 +236,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Finnish words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Finnish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)       // 'kaksikymmentäyksi'
  * toCardinal(1000)     // 'tuhat'
@@ -276,7 +270,6 @@ function toCardinal(value) {
 /**
  * Builds ordinal segment for 0-99.
  * Finnish ordinals have special forms.
- *
  * @param {number} n - Integer 0-99 to convert
  * @returns {string} Finnish ordinal words for the segment
  */
@@ -302,7 +295,6 @@ function buildOrdinalSegment(n) {
  *
  * Finnish ordinals: ensimmäinen (1st), toinen (2nd), kolmas (3rd), etc.
  * For larger numbers, use cardinal + ordinal ending.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Finnish ordinal words
  */
@@ -325,12 +317,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Finnish ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'ensimmäinen'
  * toOrdinal(2)    // 'toinen'
@@ -351,12 +341,10 @@ function toOrdinal(value) {
  *
  * Euro uses sentti as subunit (100 senttiä = 1 euro).
  * Finnish has singular/plural: 1 euro vs 2 euroa, 1 sentti vs 2 senttiä.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Finnish currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)      // 'yksi euro'
  * toCurrency(42)     // 'neljäkymmentäkaksi euroa'

--- a/src/fil-PH.js
+++ b/src/fil-PH.js
@@ -227,7 +227,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Filipino words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Filipino words
  */
@@ -257,7 +256,6 @@ function toCardinal(value) {
  * Converts a non-negative integer to Filipino ordinal words.
  *
  * Filipino ordinals: una (1st), ikalawa (2nd), then ika- + cardinal.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Filipino ordinal words
  */
@@ -272,12 +270,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Filipino ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'una'
  * toOrdinal(2)    // 'ikalawa'
@@ -296,12 +292,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Filipino currency words (Philippine Peso).
  *
  * Uses piso (peso) and sentimo (centavo).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Filipino currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'apatnapu dalawang piso'
  * toCurrency(1.50)   // 'isang piso at limampung sentimo'

--- a/src/fr-BE.js
+++ b/src/fr-BE.js
@@ -58,7 +58,6 @@ const CENTIMES = 'centimes'
 
 /**
  * Builds the words for a 0-999 segment.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {{word: string, endsWithCents: boolean, endsWithVingts: boolean}} Segment words and flags
  */
@@ -161,7 +160,6 @@ function buildSegment(n) {
 
 /**
  * Returns the scale word (mille, million, milliard, ...) for a scale index.
- *
  * @param {number} scaleIndex - Scale group index
  * @param {bigint} segment - Segment value used to decide pluralization
  * @returns {string} The scale word
@@ -189,9 +187,8 @@ function getScaleWord(scaleIndex, segment) {
 
 /**
  * Converts a non-negative integer to Belgian French cardinal words.
- *
  * @param {bigint} n - Non-negative integer
- * @param {boolean} [withHyphen=false] - Use hyphens between words
+ * @param {boolean} [withHyphen] - Use hyphens between words
  * @returns {string} The integer in Belgian French words
  */
 function integerToWords(n, withHyphen = false) {
@@ -236,7 +233,6 @@ function integerToWords(n, withHyphen = false) {
 
 /**
  * Builds words for large integers (>= 1,000,000) using scale groups.
- *
  * @param {bigint} n - Integer value (>= 1,000,000)
  * @param {boolean} withHyphen - Use hyphens between words
  * @returns {string} The integer in Belgian French words
@@ -306,7 +302,6 @@ function buildLargeNumberWords(n, withHyphen) {
 
 /**
  * Converts the decimal part digits to words (leading zeros spoken as zéro).
- *
  * @param {string} decimalPart - Decimal digits as a string
  * @param {boolean} withHyphen - Use hyphens between words
  * @returns {string} The decimal part in Belgian French words
@@ -333,10 +328,9 @@ function decimalPartToWords(decimalPart, withHyphen) {
 
 /**
  * Converts a numeric value to Belgian French words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.withHyphenSeparator=false] - Use hyphens between words
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.withHyphenSeparator] - Use hyphens between words
  * @returns {string} The number in Belgian French words
  */
 function toCardinal(value, options) {
@@ -373,7 +367,6 @@ function toCardinal(value, options) {
  * - Drop final -e before adding -ième (quatre → quatrième)
  * - cinq → cinquième (add -u- before -ième)
  * - neuf → neuvième (f → v before -ième)
- *
  * @param {string} cardinalWord - Cardinal word to convert
  * @returns {string} Ordinal form
  */
@@ -415,7 +408,6 @@ function cardinalToOrdinal(cardinalWord) {
 
 /**
  * Converts a positive integer to Belgian French ordinal words.
- *
  * @param {bigint} n - Positive integer
  * @returns {string} Belgian French ordinal words
  */
@@ -435,12 +427,10 @@ function integerToOrdinal(n) {
  *
  * Belgian French ordinals: premier (1st), then cardinal + ième.
  * Special rules: quatre→quatrième, cinq→cinquième, neuf→neuvième.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'premier'
  * toOrdinal(2)    // 'deuxième'
@@ -458,14 +448,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Belgian French currency words (Euro).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "et" between euros and centimes
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "et" between euros and centimes
  * @returns {string} The amount in Belgian French currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                 // 'quarante-deux euros et cinquante centimes'
  * toCurrency(1)                     // 'un euro'

--- a/src/fr-FR.js
+++ b/src/fr-FR.js
@@ -60,7 +60,6 @@ const CENTIMES = 'centimes'
 /**
  * Builds segment word for 0-999.
  * Returns object with { word, endsWithCents, endsWithVingts } for pluralization handling.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {{ word: string, endsWithCents: boolean, endsWithVingts: boolean }} Segment words and pluralization flags
  */
@@ -168,7 +167,6 @@ function buildSegment(n) {
 
 /**
  * Gets scale word for French long scale with -ard pattern.
- *
  * @param {number} scaleIndex - Scale level (1 = thousand, 2 = million, etc.)
  * @param {bigint} segment - Segment value for pluralization
  * @returns {string} Scale word
@@ -198,7 +196,6 @@ function getScaleWord(scaleIndex, segment) {
 
 /**
  * Converts a non-negative integer to French words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} withHyphen - Whether to use hyphen separators
  * @returns {string} French words
@@ -250,7 +247,6 @@ function integerToWords(n, withHyphen = false) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {boolean} withHyphen - Whether to use hyphen separators
  * @returns {string} French words
@@ -326,7 +322,6 @@ function buildLargeNumberWords(n, withHyphen) {
 
 /**
  * Converts decimal digits to French words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {boolean} withHyphen - Whether to use hyphen separators
  * @returns {string} French words for decimal part
@@ -358,14 +353,12 @@ function decimalPartToWords(decimalPart, withHyphen) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.withHyphenSeparator=false] - Use hyphens between all words
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.withHyphenSeparator] - Use hyphens between all words
  * @returns {string} The number in French words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)           // 'vingt et un'
  * toCardinal(80)           // 'quatre-vingts'
@@ -405,7 +398,6 @@ function toCardinal(value, options) {
  * - Drop final -e before adding -ième (quatre → quatrième)
  * - cinq → cinquième (add -u- before -ième)
  * - neuf → neuvième (f → v before -ième)
- *
  * @param {string} cardinalWord - Cardinal word to convert
  * @returns {string} Ordinal form
  */
@@ -447,7 +439,6 @@ function cardinalToOrdinal(cardinalWord) {
 
 /**
  * Converts a positive integer to French ordinal words.
- *
  * @param {bigint} n - Positive integer
  * @returns {string} French ordinal words
  */
@@ -467,12 +458,10 @@ function integerToOrdinal(n) {
  *
  * French ordinals: premier (1st), then cardinal + ième.
  * Special rules: quatre→quatrième, cinq→cinquième, neuf→neuvième.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'premier'
  * toOrdinal(2)    // 'deuxième'
@@ -494,14 +483,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to French currency words (Euro).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "et" between euros and centimes
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "et" between euros and centimes
  * @returns {string} The amount in French currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                 // 'quarante-deux euros et cinquante centimes'
  * toCurrency(1)                     // 'un euro'

--- a/src/gu-IN.js
+++ b/src/gu-IN.js
@@ -68,7 +68,6 @@ const SCALE_WORDS = ['', 'હજાર', 'લાખ', 'કરોડ', 'અબજ
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Gujarati words for the segment
  */
@@ -94,7 +93,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Gujarati words
  */
@@ -139,7 +137,6 @@ function integerToWords(n) {
 
 /**
  * Converts the fractional digits to per-digit Gujarati words.
- *
  * @param {string} decimalPart - Decimal digits as a string
  * @returns {string} Gujarati words for each digit
  */
@@ -155,7 +152,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Gujarati words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Gujarati words
  */
@@ -185,7 +181,6 @@ function toCardinal(value) {
  * Converts a positive integer to Gujarati ordinal words.
  *
  * Gujarati ordinals: First 6 are irregular, then add -મું suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Gujarati ordinal words
  */
@@ -202,12 +197,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Gujarati ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'પહેલું'
  * toOrdinal(2)    // 'બીજું'
@@ -224,12 +217,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Gujarati currency words (Indian Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Gujarati currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'બેતાળીસ રૂપિયા પચાસ પૈસા'
  * toCurrency(1)      // 'એક રૂપિયો'

--- a/src/ha-NG.js
+++ b/src/ha-NG.js
@@ -60,9 +60,8 @@ const KOBO = 'kobo'
  * Build segment for 0-999 with Hausa patterns.
  * Hausa uses reversed order for hundreds: "biyu ɗari" (200)
  * And "da" connector for ones: "ashirin da ɗaya" (21)
- *
  * @param {number} n - Integer segment value (0-999)
- * @returns {string}
+ * @returns {string} The segment in Hausa words
  */
 function buildSegment(n) {
   if (n === 0) return ''
@@ -121,7 +120,7 @@ function buildSegment(n) {
 
 /**
  * @param {bigint} n - Non-negative integer value
- * @returns {string}
+ * @returns {string} The integer in Hausa words
  */
 function integerToWords(n) {
   if (n === 0n) return ZERO
@@ -135,9 +134,8 @@ function integerToWords(n) {
 
 /**
  * Checks if a word is a single digit (1-9).
- *
  * @param {string} word - Word to test
- * @returns {boolean}
+ * @returns {boolean} True if the word is a single digit (1-9)
  */
 function isSingleDigit(word) {
   return ONES.slice(1).includes(word)
@@ -145,7 +143,7 @@ function isSingleDigit(word) {
 
 /**
  * @param {bigint} n - Integer value of 1000 or greater
- * @returns {string}
+ * @returns {string} The number in Hausa words
  */
 function buildLargeNumberWords(n) {
   const numStr = n.toString()
@@ -226,7 +224,7 @@ function buildLargeNumberWords(n) {
 
 /**
  * @param {string} decimalPart - Digit string of the fractional part
- * @returns {string}
+ * @returns {string} The fractional digits in Hausa words
  */
 function decimalPartToWords(decimalPart) {
   // Per-digit decimal reading
@@ -240,7 +238,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Hausa words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Hausa words
  */
@@ -270,7 +267,6 @@ function toCardinal(value) {
  * Converts a non-negative integer to Hausa ordinal words.
  *
  * Hausa ordinals: na farko (1st), na biyu (2nd), na uku (3rd), etc.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Hausa ordinal words
  */
@@ -284,12 +280,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Hausa ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'na farko'
  * toOrdinal(2)    // 'na biyu'
@@ -308,12 +302,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Hausa currency words (Nigerian Naira).
  *
  * Uses naira and kobo (100 kobo = 1 naira).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Hausa currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'arba'in da biyu naira'
  * toCurrency(1.50)   // 'ɗaya naira da hamsin kobo'

--- a/src/hbo-IL.js
+++ b/src/hbo-IL.js
@@ -62,7 +62,6 @@ const GERAH_PLURAL = 'גרות'
 /**
  * Builds segment word for scale segments (thousands, millions, etc.).
  * "ו" is added before tens and ones when following hundreds.
- *
  * @param {number} n - Segment value (0-999)
  * @param {string} andWord - Conjunction word
  * @param {string[]} ONES - Ones vocabulary
@@ -123,7 +122,6 @@ function buildScaleSegment(n, andWord, ONES, TEENS, HUNDREDS_ARR) {
 /**
  * Builds segment word for units segment (no scale word).
  * "ו" is only added before the final ones digit.
- *
  * @param {number} n - Segment value (0-999)
  * @param {string} andWord - Conjunction word
  * @param {string[]} ONES - Ones vocabulary
@@ -185,7 +183,6 @@ function buildUnitsSegment(n, andWord, ONES, TEENS, HUNDREDS_ARR) {
 
 /**
  * Converts a non-negative integer to Biblical Hebrew words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @param {string} andWord - Conjunction word
@@ -269,7 +266,6 @@ function integerToWords(n, gender, andWord) {
 
 /**
  * Converts decimal digits to Biblical Hebrew words (digit by digit).
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} Biblical Hebrew words for decimal part
@@ -289,11 +285,10 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Biblical Hebrew words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
- * @param {string} [options.andWord='ו'] - Custom conjunction word
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {string} [options.andWord] - Custom conjunction word
  * @returns {string} The number in Biblical Hebrew words
  */
 function toCardinal(value, options) {
@@ -327,7 +322,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal for tens and ones (0-99).
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal word
  */
@@ -349,7 +343,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a non-negative integer to Biblical Hebrew ordinal words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Biblical Hebrew ordinal words
  */
@@ -432,12 +425,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Biblical Hebrew ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The ordinal in Biblical Hebrew words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)   // 'ראשון'
  * toOrdinal(21)  // 'עשרים וראשון'
@@ -453,12 +444,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Biblical Hebrew Shekel currency words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The currency in Biblical Hebrew words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)     // 'שקל אחד'
  * toCurrency(2.50)  // 'שניים שקלים חמישים גרות'

--- a/src/he-IL.js
+++ b/src/he-IL.js
@@ -59,7 +59,6 @@ const AGORA_PLURAL = 'אגורות'
 /**
  * Builds segment word for scale segments (thousands, millions, etc.).
  * "ו" is added before tens and ones when following hundreds.
- *
  * @param {number} n - Segment value (0-999)
  * @param {string} andWord - Conjunction word
  * @returns {string} Hebrew words for the segment
@@ -117,7 +116,6 @@ function buildScaleSegment(n, andWord) {
 /**
  * Builds segment word for units segment (no scale word).
  * "ו" is only added before the final ones digit.
- *
  * @param {number} n - Segment value (0-999)
  * @param {string} andWord - Conjunction word
  * @returns {string} Hebrew words for the segment
@@ -176,7 +174,6 @@ function buildUnitsSegment(n, andWord) {
 
 /**
  * Converts a non-negative integer to Hebrew words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {string} andWord - Conjunction word
  * @returns {string} Hebrew words
@@ -251,7 +248,6 @@ function integerToWords(n, andWord) {
 
 /**
  * Converts decimal digits to Hebrew words (digit by digit).
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Hebrew words for decimal part
  */
@@ -269,10 +265,9 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Modern Hebrew words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {string} [options.andWord='ו'] - Custom conjunction word
+ * @param {object} [options] - Optional configuration
+ * @param {string} [options.andWord] - Custom conjunction word
  * @returns {string} The number in Modern Hebrew words
  */
 function toCardinal(value, options) {
@@ -303,7 +298,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal for tens and ones (0-99).
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal word
  */
@@ -325,7 +319,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a non-negative integer to Hebrew ordinal words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Hebrew ordinal words
  */
@@ -419,12 +412,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Hebrew ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The ordinal in Hebrew words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)   // 'ראשון'
  * toOrdinal(21)  // 'עשרים וראשון'
@@ -440,7 +431,6 @@ function toOrdinal(value) {
 
 /**
  * Builds segment word for currency (masculine forms).
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Hebrew words for the segment (masculine form)
  */
@@ -496,7 +486,6 @@ function buildCurrencySegment(n) {
 
 /**
  * Converts a non-negative integer to Hebrew currency words (masculine).
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Hebrew words (masculine form)
  */
@@ -516,12 +505,10 @@ function integerToCurrencyWords(n) {
 
 /**
  * Converts a numeric value to Hebrew New Israeli Shekel currency words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The currency in Hebrew words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)     // 'שקל אחד'
  * toCurrency(2.50)  // 'שניים שקלים חמישים אגורות'

--- a/src/hi-IN.js
+++ b/src/hi-IN.js
@@ -68,7 +68,6 @@ const SCALE_WORDS = ['', 'हज़ार', 'लाख', 'करोड़', 'अ
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Hindi words for the segment
  */
@@ -94,7 +93,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Hindi words
  */
@@ -147,7 +145,6 @@ function integerToWords(n) {
 
 /**
  * Converts the decimal-part digit string to Hindi words.
- *
  * @param {string} decimalPart - The digits after the decimal separator
  * @returns {string} Hindi words for the decimal part
  */
@@ -172,7 +169,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Hindi words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Hindi words
  */
@@ -202,7 +198,6 @@ function toCardinal(value) {
  * Converts a positive integer to Hindi ordinal words.
  *
  * Hindi ordinals: First 6 are irregular, then add -वाँ suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Hindi ordinal words
  */
@@ -219,12 +214,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Hindi ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'पहला'
  * toOrdinal(2)    // 'दूसरा'
@@ -242,12 +235,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Hindi currency words (Indian Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Hindi currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'बयालीस रुपये पचास पैसे'
  * toCurrency(1)      // 'एक रुपया'

--- a/src/hr-HR.js
+++ b/src/hr-HR.js
@@ -80,7 +80,6 @@ const SCALE_FORMS = [
 
 /**
  * Selects the correct plural form for a count.
- *
  * @param {number | bigint} n - The count
  * @param {string[]} forms - The [one, few, many] plural forms
  * @returns {string} The selected plural form
@@ -101,7 +100,6 @@ function pluralize(n, forms) {
 
 /**
  * Builds the masculine words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} The segment words
  */
@@ -134,7 +132,6 @@ function buildSegmentMasc(n) {
 
 /**
  * Builds the feminine words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} The segment words
  */
@@ -171,7 +168,6 @@ function buildSegmentFem(n) {
 
 /**
  * Converts a non-negative integer to Croatian words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The number in Croatian words
@@ -188,7 +184,6 @@ function integerToWords(n, gender) {
 
 /**
  * Builds words for numbers >= 1000.
- *
  * @param {bigint} n - Number >= 1000
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The number in Croatian words
@@ -239,7 +234,6 @@ function buildLargeNumberWords(n, gender) {
 
 /**
  * Converts the decimal-part digit string to Croatian words.
- *
  * @param {string} decimalPart - The decimal digits as a string
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The decimal part in Croatian words
@@ -265,10 +259,9 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Croatian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Croatian words
  */
 function toCardinal(value, options) {
@@ -299,7 +292,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -326,7 +318,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a positive integer to Croatian ordinal words (masculine nominative).
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Croatian words
  */
@@ -368,7 +359,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Croatian words
  */
@@ -441,12 +431,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Croatian ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'prvi'
  * toOrdinal(2)    // 'drugi'
@@ -465,12 +453,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Croatian currency words (Euro).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Croatian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'četrdeset dva eura'
  * toCurrency(1)      // 'jedan euro'

--- a/src/hu-HU.js
+++ b/src/hu-HU.js
@@ -115,16 +115,16 @@ const FILLER = 'fillér' // subunit (rarely used, same singular and plural)
 // ============================================================================
 
 /**
- * @param {bigint} value
- * @returns {string | undefined}
+ * @param {bigint} value The scale or vocabulary key to look up
+ * @returns {string | undefined} The Hungarian word for the key, or undefined if absent
  */
 function wordForScale(value) {
   return WORDS.get(value)
 }
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer (under 100) to convert
+ * @returns {string} The number in Hungarian words
  */
 function tensToCardinal(n) {
   if (WORDS.has(n)) {
@@ -136,8 +136,8 @@ function tensToCardinal(n) {
 }
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer (under 1000) to convert
+ * @returns {string} The number in Hungarian words
  */
 function hundredsToCardinal(n) {
   const hundreds = n / 100n
@@ -150,8 +150,8 @@ function hundredsToCardinal(n) {
 }
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer (under one million) to convert
+ * @returns {string} The number in Hungarian words
  */
 function thousandsToCardinal(n) {
   const thousands = n / 1000n
@@ -177,8 +177,8 @@ const SCALES = [
 ]
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer (one million or greater) to convert
+ * @returns {string} The number in Hungarian words
  */
 function bigNumberToCardinal(n) {
   // Find appropriate scale using BigInt comparison (avoids toString)
@@ -197,9 +197,9 @@ function bigNumberToCardinal(n) {
 }
 
 /**
- * @param {bigint} n
- * @param {string} [zeroWord]
- * @returns {string}
+ * @param {bigint} n The integer to convert
+ * @param {string} [zeroWord] The word to use for zero (empty string in compound contexts)
+ * @returns {string} The number in Hungarian words
  */
 function integerToWordsInner(n, zeroWord = ZERO) {
   // Normalize to BigInt for consistent comparisons
@@ -227,16 +227,16 @@ function integerToWordsInner(n, zeroWord = ZERO) {
 }
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer to convert
+ * @returns {string} The number in Hungarian words
  */
 function integerToWords(n) {
   return integerToWordsInner(n, ZERO)
 }
 
 /**
- * @param {string} decimalPart
- * @returns {string}
+ * @param {string} decimalPart The decimal digits (after the separator) to convert
+ * @returns {string} The decimal digits in Hungarian words
  */
 function decimalPartToWords(decimalPart) {
   let result = ''
@@ -259,7 +259,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Hungarian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Hungarian words
  */
@@ -290,7 +289,6 @@ function toCardinal(value) {
  *
  * Hungarian ordinals: első (1st), második (2nd), harmadik (3rd), etc.
  * 1-10 have special forms, others use cardinal + -dik/-edik/-adik/-ödik suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Hungarian ordinal words
  */
@@ -341,12 +339,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Hungarian ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'első'
  * toOrdinal(2)    // 'második'
@@ -366,12 +362,10 @@ function toOrdinal(value) {
  *
  * Uses forint (no plural form needed in Hungarian).
  * Fillér (1/100) is rarely used but included for completeness.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Hungarian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'negyvenkettő forint'
  * toCurrency(1.50)   // 'egy forint ötven fillér'

--- a/src/id-ID.js
+++ b/src/id-ID.js
@@ -50,7 +50,6 @@ const RUPIAH = 'rupiah'
 
 /**
  * Builds the Indonesian words for a 1-3 digit segment (0-999).
- *
  * @param {number} n - The segment value (0-999)
  * @returns {string} The segment in Indonesian words
  */
@@ -101,7 +100,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Indonesian words.
- *
  * @param {bigint} n - The integer value to convert
  * @returns {string} The integer in Indonesian words
  */
@@ -136,7 +134,6 @@ function integerToWords(n) {
 
 /**
  * Builds Indonesian words for large numbers (1,000,000 and above).
- *
  * @param {bigint} n - The integer value to convert
  * @returns {string} The number in Indonesian words
  */
@@ -191,7 +188,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts the decimal-part digit string to Indonesian words.
- *
  * @param {string} decimalPart - The decimal digits as a string
  * @returns {string} The decimal part in Indonesian words
  */
@@ -216,7 +212,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Indonesian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Indonesian words
  */
@@ -247,7 +242,6 @@ function toCardinal(value) {
  *
  * Indonesian ordinals use "ke-" prefix + cardinal number.
  * Special case: "pertama" for 1st (not "kesatu").
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Indonesian ordinal words
  */
@@ -263,12 +257,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Indonesian ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'pertama'
  * toOrdinal(2)    // 'kedua'
@@ -288,12 +280,10 @@ function toOrdinal(value) {
  *
  * Indonesian Rupiah has no subunit in modern usage (sen are historical).
  * Amounts are rounded to whole rupiah.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Indonesian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'empat puluh dua rupiah'
  * toCurrency(1000)   // 'seribu rupiah'

--- a/src/it-IT.js
+++ b/src/it-IT.js
@@ -72,7 +72,6 @@ const CENTESIMI = 'centesimi'
  * - Tens ending in vowel + uno/otto → drop tens vowel: ventuno, ventotto
  * - Hundreds cento + otto/ottanta → centotto, centottanta (drop 'o')
  * - Final 'tre' in compounds becomes 'tré': ventitré, trentatré
- *
  * @param {number} n - Number 0-999 to convert
  * @returns {string} Segment word
  */
@@ -140,7 +139,6 @@ function buildSegment(n) {
 /**
  * Builds segment word with "un" for scale context (millions, billions).
  * Same as buildSegment but returns "un" for 1 instead of "uno".
- *
  * @param {number} n - Number 0-999 to convert
  * @returns {string} Segment word
  */
@@ -153,7 +151,6 @@ function buildSegmentForScale(n) {
 /**
  * Builds thousands word for 1-999 thousand.
  * Handles elision: tre + mila = tremila (no accent), otto + mila = ottomila
- *
  * @param {number} n - Number of thousands 1-999
  * @returns {string} Thousands word
  */
@@ -174,6 +171,7 @@ function buildThousands(n) {
 /**
  * Gets singular scale word for index.
  * @param {number} scaleIndex - 2=million, 3=billion, etc.
+ * @returns {string} Singular scale word
  */
 function getScaleWordSingular(scaleIndex) {
   if (scaleIndex < 2) return ''
@@ -187,6 +185,7 @@ function getScaleWordSingular(scaleIndex) {
 /**
  * Gets plural scale word for index.
  * @param {number} scaleIndex - 2=million, 3=billion, etc.
+ * @returns {string} Plural scale word
  */
 function getScaleWordPlural(scaleIndex) {
   if (scaleIndex < 2) return ''
@@ -203,7 +202,6 @@ function getScaleWordPlural(scaleIndex) {
 
 /**
  * Converts a non-negative integer to Italian words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Italian words
  */
@@ -234,7 +232,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Italian words
  */
@@ -284,7 +281,6 @@ function buildLargeNumberWords(n) {
 /**
  * Joins parts with Italian connector rules.
  * Uses "e" before simple (non-compound) final segment.
- *
  * @param {string[]} parts - Parts to join
  * @returns {string} Joined string
  */
@@ -314,7 +310,6 @@ function joinPartsWithConnector(parts) {
 
 /**
  * Converts decimal digits to Italian words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Italian words for decimal part
  */
@@ -344,12 +339,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Italian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(28)           // 'ventotto'
  * toCardinal(23)           // 'ventitré'
@@ -381,7 +374,6 @@ function toCardinal(value) {
 
 /**
  * Converts a cardinal word to ordinal form by dropping final vowel and adding -esimo.
- *
  * @param {string} cardinalWord - Cardinal word to convert
  * @returns {string} Ordinal form
  */
@@ -420,7 +412,6 @@ function cardinalToOrdinal(cardinalWord) {
 
 /**
  * Converts a positive integer to Italian ordinal words.
- *
  * @param {bigint} n - Positive integer
  * @returns {string} Italian ordinal words (masculine form)
  */
@@ -440,12 +431,10 @@ function integerToOrdinal(n) {
  *
  * Italian ordinals: primo, secondo, terzo... (1-10 irregular)
  * For 11+: cardinal word (drop final vowel) + -esimo
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words (masculine form)
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'primo'
  * toOrdinal(2)    // 'secondo'
@@ -465,14 +454,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Italian currency words (Euro).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "e" between euros and centesimi
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "e" between euros and centesimi
  * @returns {string} The amount in Italian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                 // 'quarantadue euro e cinquanta centesimi'
  * toCurrency(1)                     // 'un euro'

--- a/src/ja-JP.js
+++ b/src/ja-JP.js
@@ -76,7 +76,6 @@ const THOUSAND = '千'
 /**
  * Builds segment word for 0-9999 with 一 omission rules.
  * - Omit 一 before 十, 百, 千
- *
  * @param {number} n - Segment value (0-9999)
  * @returns {string} Japanese kanji words for the segment
  */
@@ -134,7 +133,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Japanese words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Japanese kanji words
  */
@@ -174,7 +172,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 100,000,000.
  * Uses BigInt modulo for 4-digit (myriad) segment extraction.
- *
  * @param {bigint} n - Number >= 100,000,000
  * @returns {string} Japanese kanji words
  */
@@ -215,7 +212,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Japanese words (digit by digit).
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Japanese kanji words for decimal part
  */
@@ -240,12 +236,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Japanese kanji words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // '四十二'
  * toCardinal(10000)        // '一万'
@@ -277,7 +271,6 @@ function toCardinal(value) {
  * Converts a positive integer to Japanese ordinal words.
  *
  * Japanese ordinals: 第 prefix + cardinal number.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Japanese ordinal words
  */
@@ -287,12 +280,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Japanese ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // '第一'
  * toOrdinal(10)   // '第十'
@@ -312,12 +303,10 @@ function toOrdinal(value) {
  *
  * Note: Sen (銭, 1/100 yen) is included for completeness but is rarely used
  * in modern Japan. Most transactions are in whole yen.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Japanese currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // '四十二円'
  * toCurrency(1)      // '一円'

--- a/src/ka-GE.js
+++ b/src/ka-GE.js
@@ -130,7 +130,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Georgian words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Georgian words
  */
@@ -173,7 +172,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Georgian words
  */
@@ -243,7 +241,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Georgian words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Georgian words for decimal part
  */
@@ -273,12 +270,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Georgian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)           // 'ოცდაერთი'
  * toCardinal(100)          // 'ასი'
@@ -311,7 +306,6 @@ function toCardinal(value) {
  * Georgian ordinals are formed by:
  * - 1-9: special forms (პირველი, მეორე, მესამე, etc.)
  * - 10+: მე- prefix + cardinal + -ე suffix
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Georgian ordinal words
  */
@@ -337,12 +331,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Georgian ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The ordinal in Georgian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)   // 'პირველი'
  * toOrdinal(10)  // 'მეათე'
@@ -359,12 +351,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Georgian Lari currency words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The currency in Georgian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)     // 'ერთი ლარი'
  * toCurrency(2.50)  // 'ორი ლარი ორმოცდაათი თეთრი'

--- a/src/kn-IN.js
+++ b/src/kn-IN.js
@@ -68,7 +68,6 @@ const SCALE_WORDS = ['', 'ಸಾವಿರ', 'ಲಕ್ಷ', 'ಕೋಟಿ', 'ಅ
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Kannada words for the segment
  */
@@ -94,7 +93,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Kannada words
  */
@@ -139,7 +137,6 @@ function integerToWords(n) {
 
 /**
  * Reads a decimal-fraction digit string per-digit in Kannada.
- *
  * @param {string} decimalPart - Digits after the decimal separator
  * @returns {string} Per-digit Kannada words
  */
@@ -155,7 +152,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Kannada words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Kannada words
  */
@@ -185,7 +181,6 @@ function toCardinal(value) {
  * Converts a positive integer to Kannada ordinal words.
  *
  * Kannada ordinals: First 6 are special, then add -ನೇ suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Kannada ordinal words
  */
@@ -202,12 +197,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Kannada ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'ಮೊದಲನೇ'
  * toOrdinal(2)    // 'ಎರಡನೇ'
@@ -224,12 +217,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Kannada currency words (Indian Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Kannada currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'ನಲವತ್ತೆರಡು ರೂಪಾಯಿಗಳು ಐವತ್ತು ಪೈಸೆಗಳು'
  * toCurrency(1)      // 'ಒಂದು ರೂಪಾಯಿ'

--- a/src/ko-KR.js
+++ b/src/ko-KR.js
@@ -51,7 +51,6 @@ const WON = '원'
 /**
  * Builds segment word for 0-9999 (4-digit myriad segment).
  * Korean omits "일" before 십, 백, 천.
- *
  * @param {number} n - Segment value (0-9999)
  * @returns {string} Korean words for the segment
  */
@@ -109,7 +108,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Korean words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Korean words
  */
@@ -128,7 +126,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 10000.
  * Uses myriad (만) grouping - 4 digits per segment.
- *
  * @param {bigint} n - Number >= 10000
  * @returns {string} Korean words
  */
@@ -189,7 +186,6 @@ function buildLargeNumberWords(n) {
  * Joins parts with Korean spacing rules.
  * - Concatenate without spaces within segments
  * - Space after scale words before next number
- *
  * @param {Array<{word: string, isScale: boolean}>} parts - Parts with isScale metadata
  * @returns {string} Joined string
  */
@@ -216,7 +212,6 @@ function joinKoreanParts(parts) {
 
 /**
  * Converts decimal digits to Korean words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Korean words for decimal part (space-separated)
  */
@@ -241,12 +236,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Korean words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Korean words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)         // '이십일'
  * toCardinal(10000)      // '만'
@@ -279,7 +272,6 @@ function toCardinal(value) {
  * Converts a non-negative integer to Korean ordinal words.
  *
  * Korean ordinals use "제" prefix + Sino-Korean numeral.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Korean ordinal words
  */
@@ -289,12 +281,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Korean ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // '제일'
  * toOrdinal(2)    // '제이'
@@ -314,12 +304,10 @@ function toOrdinal(value) {
  *
  * Korean Won has no subunit (jeon are historical).
  * Amounts are rounded to whole won.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Korean currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // '사십이원'
  * toCurrency(1000)   // '천원'

--- a/src/lt-LT.js
+++ b/src/lt-LT.js
@@ -80,7 +80,6 @@ const SCALE_FORMS = [
 
 /**
  * Builds segment word for 0-999 (masculine form).
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Segment words
  */
@@ -117,7 +116,6 @@ function buildSegment(n) {
 
 /**
  * Builds segment word for 0-999 (feminine form - only differs in ones).
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Segment words
  */
@@ -161,7 +159,6 @@ function buildSegmentFeminine(n) {
  * - Singular: ends in 1 (except 11)
  * - Plural: ends in 2-9 (except 12-19)
  * - Genitive: 0, 10-19, or ends in 0
- *
  * @param {number} n - The segment value
  * @param {string[]} forms - [singular, plural, genitive]
  * @returns {string} The appropriate form
@@ -197,7 +194,6 @@ function pluralize(n, forms) {
 
 /**
  * Converts a non-negative integer to Lithuanian words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Lithuanian words
@@ -219,7 +215,6 @@ function integerToWords(n, gender) {
 
 /**
  * Builds words for numbers >= 1000.
- *
  * @param {bigint} n - Number >= 1000
  * @returns {string} Lithuanian words
  */
@@ -272,7 +267,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Lithuanian words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Lithuanian words for decimal part
@@ -300,14 +294,12 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Lithuanian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Conversion options
- * @param {string} [options.gender='masculine'] - Gender for numbers < 1000
+ * @param {object} [options] - Conversion options
+ * @param {string} [options.gender] - Gender for numbers < 1000
  * @returns {string} The number in Lithuanian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)                          // 'keturiasdešimt du'
  * toCardinal(1, { gender: 'feminine' })   // 'viena'
@@ -341,7 +333,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -368,7 +359,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a positive integer to Lithuanian ordinal words (masculine nominative).
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Lithuanian words
  */
@@ -414,7 +404,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Lithuanian words
  */
@@ -486,12 +475,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Lithuanian ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'pirmas'
  * toOrdinal(2)    // 'antras'
@@ -510,12 +497,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Lithuanian currency words (Euro).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Lithuanian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'keturiasdešimt du eurai'
  * toCurrency(1)      // 'vienas euras'

--- a/src/lv-LV.js
+++ b/src/lv-LV.js
@@ -83,8 +83,8 @@ const SCALE_FORMS = [
  * Builds segment word for 0-999 (masculine form).
  * Does NOT include special handling for segment=1 (omitOneBeforeScale).
  * That's handled at join time.
- *
  * @param {number} n - Segment value 0-999
+ * @returns {string} The segment in Latvian words
  */
 function buildSegment(n) {
   if (n === 0) return ''
@@ -130,8 +130,8 @@ function buildSegment(n) {
 
 /**
  * Builds segment word for 0-999 (feminine form - only differs in ones).
- *
  * @param {number} n - Segment value 0-999
+ * @returns {string} The segment in Latvian words
  */
 function buildSegmentFeminine(n) {
   if (n === 0) return ''
@@ -180,7 +180,6 @@ function buildSegmentFeminine(n) {
  * Latvian pluralization - simpler than Slavic.
  * Singular: ends in 1 (except 11)
  * Plural: everything else
- *
  * @param {number} n - The segment value
  * @param {string[]} forms - [singular, plural, genitive]
  * @returns {string} The appropriate form
@@ -201,7 +200,6 @@ function pluralize(n, forms) {
 /**
  * Latvian currency pluralization.
  * Uses genitive for 0, 10-19, and multiples of 10.
- *
  * @param {number} n - The segment value
  * @param {string[]} forms - [singular, plural, genitive]
  * @returns {string} The appropriate form
@@ -237,7 +235,6 @@ function pluralizeCurrency(n, forms) {
 
 /**
  * Converts a non-negative integer to Latvian words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {string} gender - Gender for numbers < 1000
  * @returns {string} Latvian words
@@ -258,7 +255,6 @@ function integerToWords(n, gender) {
 
 /**
  * Builds words for numbers >= 1000.
- *
  * @param {bigint} n - Number >= 1000
  * @returns {string} Latvian words
  */
@@ -318,7 +314,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Latvian words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {string} gender - Gender for numbers < 1000
  * @returns {string} Latvian words for decimal part
@@ -346,14 +341,12 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Latvian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Conversion options
- * @param {string} [options.gender='masculine'] - Gender for numbers < 1000
+ * @param {object} [options] - Conversion options
+ * @param {string} [options.gender] - Gender for numbers < 1000
  * @returns {string} The number in Latvian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)                          // 'četrdesmit divi'
  * toCardinal(1, { gender: 'feminine' })   // 'viena'
@@ -387,7 +380,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -414,7 +406,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a positive integer to Latvian ordinal words (masculine nominative).
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Latvian words
  */
@@ -466,7 +457,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Latvian words
  */
@@ -543,12 +533,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Latvian ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'pirmais'
  * toOrdinal(2)    // 'otrais'
@@ -567,12 +555,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Latvian currency words (Euro).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Latvian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'četrdesmit divi eiro'
  * toCurrency(1)      // 'viens eiro'

--- a/src/mr-IN.js
+++ b/src/mr-IN.js
@@ -68,7 +68,6 @@ const SCALE_WORDS = ['', 'हजार', 'लाख', 'कोटी', 'अब्
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Marathi words for the segment
  */
@@ -94,7 +93,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Marathi words
  */
@@ -139,7 +137,6 @@ function integerToWords(n) {
 
 /**
  * Reads the fractional digits per-digit in Marathi.
- *
  * @param {string} decimalPart - Decimal digit string
  * @returns {string} Marathi words for each digit
  */
@@ -155,7 +152,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Marathi words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Marathi words
  */
@@ -185,7 +181,6 @@ function toCardinal(value) {
  * Converts a positive integer to Marathi ordinal words.
  *
  * Marathi ordinals: First 6 are irregular, then add -वा suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Marathi ordinal words
  */
@@ -202,12 +197,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Marathi ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'पहिला'
  * toOrdinal(2)    // 'दुसरा'
@@ -225,12 +218,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Marathi currency words (Indian Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Marathi currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'बेचाळीस रुपये पन्नास पैसे'
  * toCurrency(1)      // 'एक रुपया'

--- a/src/ms-MY.js
+++ b/src/ms-MY.js
@@ -51,7 +51,6 @@ const SEN = 'sen'
 
 /**
  * Builds the words for a number segment (0-999).
- *
  * @param {number} n - Integer segment in range 0-999
  * @returns {string} The segment in Malay words
  */
@@ -102,7 +101,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Malay words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} The integer in Malay words
  */
@@ -137,7 +135,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for large numbers (>= 1,000,000) using scale words.
- *
  * @param {bigint} n - Integer to convert (>= 1,000,000)
  * @returns {string} The integer in Malay words
  */
@@ -197,7 +194,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts the decimal part (digit string) to Malay words.
- *
  * @param {string} decimalPart - Decimal digits as a string
  * @returns {string} The decimal digits in Malay words
  */
@@ -222,7 +218,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Malay words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Malay words
  */
@@ -253,7 +248,6 @@ function toCardinal(value) {
  *
  * Malay ordinals use "ke-" prefix + cardinal number.
  * Special case: "pertama" for 1st (not "kesatu").
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Malay ordinal words
  */
@@ -269,12 +263,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Malay ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'pertama'
  * toOrdinal(2)    // 'kedua'
@@ -293,12 +285,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Malay currency words (Ringgit).
  *
  * Malaysian Ringgit uses sen as subunit (100 sen = 1 ringgit).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Malay currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'empat puluh dua ringgit'
  * toCurrency(1.50)   // 'satu ringgit lima puluh sen'

--- a/src/nb-NO.js
+++ b/src/nb-NO.js
@@ -69,7 +69,6 @@ const ORE = 'øre' // same singular and plural
 /**
  * Builds segment word for 0-999.
  * Returns object with word and hasHundred flag.
- *
  * @param {number} n - Integer 0-999
  * @returns {{word: string, hasHundred: boolean}} Segment word and hundred flag
  */
@@ -125,7 +124,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Norwegian Bokmål words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Norwegian words
  */
@@ -164,7 +162,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Norwegian words
  */
@@ -221,7 +218,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Joins parts with Norwegian spacing and comma rules.
- *
  * @param {Array<{word: string, hasHundred: boolean, type: string}>} parts - Parts with type metadata
  * @returns {string} Joined string
  */
@@ -267,7 +263,6 @@ function joinNorwegianParts(parts) {
 
 /**
  * Converts decimal digits to Norwegian words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Norwegian words for decimal part
  */
@@ -294,12 +289,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Norwegian Bokmål words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Norwegian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)       // 'tjue-en'
  * toCardinal(101)      // 'en hundre og en'
@@ -335,7 +328,6 @@ function toCardinal(value) {
  * Teens (13-19): drop -en and add -ende (tretten → trettende)
  * Numbers ending in 'en' (one): replace with 'ende' (tjue-en → tjue-ende)
  * Numbers ending in 9 (ni): add 'ede' (nitti-ni → nitti-niede)
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Norwegian ordinal words
  */
@@ -372,12 +364,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Norwegian Bokmål ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'første'
  * toOrdinal(2)    // 'andre'
@@ -396,12 +386,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Norwegian currency words (Norwegian Krone).
  *
  * Uses krone/kroner and øre (100 øre = 1 krone).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Norwegian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)      // 'en krone'
  * toCurrency(42)     // 'førti-to kroner'

--- a/src/nl-NL.js
+++ b/src/nl-NL.js
@@ -115,7 +115,6 @@ function buildSegment(n, withAnd) {
 
 /**
  * Converts a non-negative integer to Dutch words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {{accentOne: boolean, includeOptionalAnd: boolean, noHundredPairing: boolean}} options - Conversion options
  * @returns {string} Dutch words
@@ -126,7 +125,10 @@ function integerToWords(n, options) {
   const { accentOne, includeOptionalAnd, noHundredPairing } = options
 
   // Apply één/een replacement
-  /** @param {string} word */
+  /**
+   * @param {string} word The word to apply accent replacement to
+   * @returns {string} The word with "een" replaced by "één" when accentOne is set
+   */
   const applyAccent = (word) => {
     if (accentOne) {
       return word.replace(/\been\b/g, 'één')
@@ -195,7 +197,6 @@ function integerToWords(n, options) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction (4x faster than string slicing).
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {{accentOne: boolean, includeOptionalAnd: boolean, noHundredPairing: boolean}} options - Conversion options
  * @returns {string} Dutch words
@@ -266,7 +267,6 @@ function buildLargeNumberWords(n, options) {
 
 /**
  * Converts decimal digits to Dutch words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {{accentOne: boolean, includeOptionalAnd: boolean, noHundredPairing: boolean}} options - Conversion options
  * @returns {string} Dutch words for decimal part
@@ -298,16 +298,14 @@ function decimalPartToWords(decimalPart, options) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.accentOne=true] - Use "één" instead of "een"
- * @param {boolean} [options.includeOptionalAnd=false] - Include "en" before small numbers
- * @param {boolean} [options.noHundredPairing=false] - Disable hundred pairing (1104→duizend honderdvier)
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.accentOne] - Use "één" instead of "een"
+ * @param {boolean} [options.includeOptionalAnd] - Include "en" before small numbers
+ * @param {boolean} [options.noHundredPairing] - Disable hundred pairing (1104→duizend honderdvier)
  * @returns {string} The number in Dutch words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)                        // 'eenentwintig'
  * toCardinal(1)                         // 'één'
@@ -352,7 +350,6 @@ const ORDINAL_ONES = ['', 'eerste', 'tweede', 'derde', 'vierde', 'vijfde', 'zesd
 /**
  * Converts a small cardinal to ordinal.
  * Rules: 1-19 add -de (except eerste, derde, achtste), 20+ add -ste
- *
  * @param {string} cardinalWord - Cardinal word
  * @param {number} n - The number value (0-99)
  * @returns {string} Ordinal word
@@ -375,7 +372,6 @@ function smallCardinalToOrdinal(cardinalWord, n) {
 
 /**
  * Builds ordinal words for 0-999.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Dutch ordinal words
  */
@@ -413,10 +409,8 @@ function buildOrdinalSegment(n) {
 
 /**
  * Converts a number to Dutch ordinal words.
- *
  * @param {number | string | bigint} value - The number to convert
  * @returns {string} Dutch ordinal words
- *
  * @example
  * toOrdinal(1)     // 'eerste'
  * toOrdinal(21)    // 'eenentwintigste'
@@ -445,7 +439,6 @@ function toOrdinal(value) {
 
 /**
  * Builds ordinal words for large numbers.
- *
  * @param {bigint} n - Non-negative integer >= 1000
  * @returns {string} Dutch ordinal words
  */
@@ -534,12 +527,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a number to Dutch currency words (Euro).
- *
  * @param {number | string | bigint} value - The amount to convert
- * @param {Object} [options]
- * @param {boolean} [options.and=true] - Include "en" between euros and cents
+ * @param {object} [options] Optional configuration
+ * @param {boolean} [options.and] - Include "en" between euros and cents
  * @returns {string} Dutch currency words
- *
  * @example
  * toCurrency(42.50)  // 'tweeënveertig euro en vijftig cent'
  * toCurrency(1)      // 'één euro'

--- a/src/pa-IN.js
+++ b/src/pa-IN.js
@@ -67,7 +67,6 @@ const SCALE_WORDS = ['', 'ਹਜ਼ਾਰ', 'ਲੱਖ', 'ਕਰੋੜ', 'ਅਰ
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Punjabi words for the segment
  */
@@ -93,7 +92,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Punjabi words
  */
@@ -138,7 +136,6 @@ function integerToWords(n) {
 
 /**
  * Converts the fractional digit string to Punjabi words.
- *
  * @param {string} decimalPart - Digits after the decimal point
  * @returns {string} Punjabi words for the decimal part
  */
@@ -163,7 +160,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Punjabi words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Punjabi words
  */
@@ -193,7 +189,6 @@ function toCardinal(value) {
  * Converts a positive integer to Punjabi ordinal words.
  *
  * Punjabi ordinals: First 6 are irregular, then add -ਵਾਂ suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Punjabi ordinal words
  */
@@ -210,12 +205,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Punjabi ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'ਪਹਿਲਾ'
  * toOrdinal(2)    // 'ਦੂਜਾ'
@@ -233,12 +226,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Punjabi currency words (Indian Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Punjabi currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'ਬਿਆਲੀ ਰੁਪਏ ਪੰਜਾਹ ਪੈਸੇ'
  * toCurrency(1)      // 'ਇੱਕ ਰੁਪਇਆ'

--- a/src/pl-PL.js
+++ b/src/pl-PL.js
@@ -160,7 +160,6 @@ function buildSegmentFeminine(n) {
 /**
  * Polish pluralization: 1 = singular, 2-4 = few, else = many.
  * Special case: 11-19 always use many form.
- *
  * @param {bigint} n - Number to pluralize
  * @param {string[]} forms - [singular, few, many]
  * @returns {string} Correct plural form
@@ -188,7 +187,6 @@ function pluralize(n, forms) {
 
 /**
  * Converts a non-negative integer to Polish words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Polish words
@@ -231,7 +229,6 @@ function integerToWords(n, gender) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Polish words
  */
@@ -282,7 +279,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Polish words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {string} gender - Gender for numbers < 1000 ('masculine' or 'feminine')
  * @returns {string} Polish words for decimal part
@@ -313,14 +309,12 @@ function decimalPartToWords(decimalPart, gender) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Conversion options
- * @param {string} [options.gender='masculine'] - Gender for numbers < 1000
+ * @param {object} [options] - Conversion options
+ * @param {string} [options.gender] - Gender for numbers < 1000
  * @returns {string} The number in Polish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(1)                          // 'jeden'
  * toCardinal(1, { gender: 'feminine' })  // 'jedna'
@@ -356,7 +350,6 @@ function toCardinal(value, options) {
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
  * Returns ordinal form: "pierwszy", "dwudziesty pierwszy", etc.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -391,7 +384,6 @@ function buildOrdinalTensOnes(n) {
  *
  * In Polish ordinals, only the LAST component becomes ordinal.
  * E.g., 121 = "sto dwudziesty pierwszy" (one hundred twenty-first)
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Polish words
  */
@@ -443,7 +435,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Polish words
  */
@@ -524,12 +515,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Polish ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "pierwszy", "czterdziesty drugi")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'pierwszy'
  * toOrdinal(2)    // 'drugi'
@@ -550,12 +539,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Polish currency words (Polish Złoty).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Polish currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'czterdzieści dwa złote'
  * toCurrency(1)      // 'jeden złoty'

--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -62,8 +62,8 @@ const DEFAULT_CURRENCY_WORDS = { major: ['unidade', 'unidades'], minor: ['centav
 /**
  * Builds segment word for 0-999 with Portuguese "e" rules.
  * Returns the word and whether it's an exact hundred (for "cem" handling).
- *
  * @param {number} n - Number 0-999
+ * @returns {{word: string, isExactHundred: boolean, startsWithHundreds?: boolean}} The segment word and hundred-related flags
  */
 function buildSegment(n) {
   if (n === 0) return { word: '', isExactHundred: false }
@@ -142,7 +142,6 @@ const SCALE_WORDS_PLURAL = [
 
 /**
  * Converts a non-negative integer to Portuguese words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Portuguese words
  */
@@ -189,7 +188,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Portuguese words
  */
@@ -261,7 +259,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Portuguese words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Portuguese words for decimal part
  */
@@ -288,7 +285,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Portuguese words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Portuguese words
  */
@@ -316,7 +312,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal words for 0-999.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Portuguese ordinal words
  */
@@ -354,7 +349,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Builds ordinal words for large numbers.
- *
  * @param {bigint} n - Non-negative integer
  * @returns {string} Portuguese ordinal words
  */
@@ -432,7 +426,6 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a number to Portuguese ordinal words.
- *
  * @param {number | string | bigint} value - The number to convert
  * @returns {string} Portuguese ordinal words
  */
@@ -474,13 +467,11 @@ function toOrdinal(value) {
 
 /**
  * Converts a number to Brazilian Portuguese currency words.
- *
  * @param {number | string | bigint} value - The amount to convert
- * @param {Object} [options]
- * @param {boolean} [options.and=true] - Include "e" between major and minor units
+ * @param {object} [options] Currency formatting options
+ * @param {boolean} [options.and] - Include "e" between major and minor units
  * @param {string} [options.currency] - Currency code (e.g., 'BRL', 'USD')
  * @returns {string} Brazilian Portuguese currency words
- *
  * @example
  * toCurrency(42.50)                    // 'quarenta e dois reais e cinquenta centavos'
  * toCurrency(42.50, {currency: 'USD'}) // 'quarenta e dois dólares e cinquenta centavos'

--- a/src/pt-PT.js
+++ b/src/pt-PT.js
@@ -51,8 +51,8 @@ const CENTIMOS = 'cêntimos'
 /**
  * Builds segment word for 0-999 with Portuguese "e" rules.
  * Returns the word and whether it's an exact hundred (for "cem" handling).
- *
  * @param {number} n - Number 0-999
+ * @returns {{ word: string, isExactHundred: boolean, startsWithHundreds?: boolean }} The segment word and "e"/"cem" handling flags
  */
 function buildSegment(n) {
   if (n === 0) return { word: '', isExactHundred: false }
@@ -131,7 +131,6 @@ const SCALE_WORDS_PLURAL = [
 
 /**
  * Converts a non-negative integer to Portuguese words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Portuguese words
  */
@@ -178,7 +177,6 @@ function integerToWords(n) {
 /**
  * Builds words for numbers >= 1,000,000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Portuguese words
  */
@@ -252,7 +250,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Portuguese words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Portuguese words for decimal part
  */
@@ -282,12 +279,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Portuguese words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)           // 'vinte e um'
  * toCardinal(100)          // 'cem'
@@ -317,7 +312,6 @@ function toCardinal(value) {
 
 /**
  * Builds ordinal words for 0-999.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Portuguese ordinal words
  */
@@ -355,7 +349,6 @@ function buildOrdinalSegment(n) {
 
 /**
  * Builds ordinal words for large numbers.
- *
  * @param {bigint} n - Non-negative integer
  * @returns {string} Portuguese ordinal words
  */
@@ -433,10 +426,8 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a number to Portuguese ordinal words.
- *
  * @param {number | string | bigint} value - The number to convert
  * @returns {string} Portuguese ordinal words
- *
  * @example
  * toOrdinal(1)     // 'primeiro'
  * toOrdinal(21)    // 'vigésimo primeiro'
@@ -480,12 +471,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a number to Portuguese currency words (Euro).
- *
  * @param {number | string | bigint} value - The amount to convert
- * @param {Object} [options]
- * @param {boolean} [options.and=true] - Include "e" between euros and cents
+ * @param {object} [options] Currency formatting options
+ * @param {boolean} [options.and] - Include "e" between euros and cents
  * @returns {string} Portuguese currency words
- *
  * @example
  * toCurrency(42.50)  // 'quarenta e dois euros e cinquenta cêntimos'
  * toCurrency(1)      // 'um euro'

--- a/src/ro-RO.js
+++ b/src/ro-RO.js
@@ -71,10 +71,10 @@ const SCALE_META = [
 
 /**
  * Spells number under 100.
- *
  * @param {number} n - Number 0-99
  * @param {boolean} [feminine] - Use feminine forms
  * @param {boolean} [masculineTeens] - Use masculine teen forms
+ * @returns {string} The number 0-99 in words
  */
 function spellUnder100(n, feminine = false, masculineTeens = false) {
   if (n === 0) return ''
@@ -95,10 +95,10 @@ function spellUnder100(n, feminine = false, masculineTeens = false) {
 
 /**
  * Spells number under 1000.
- *
  * @param {number} n - Number 0-999
  * @param {boolean} [feminine] - Use feminine forms
  * @param {boolean} [masculineTeens] - Use masculine teen forms
+ * @returns {string} The number 0-999 in words
  */
 function spellUnder1000(n, feminine = false, masculineTeens = false) {
   if (n === 0) return ''
@@ -115,9 +115,9 @@ function spellUnder1000(n, feminine = false, masculineTeens = false) {
 /**
  * Builds scale word with proper pluralization and "de" insertion.
  * Romanian always uses feminine forms (două, not doi) when counting scale words.
- *
  * @param {number} segment - Three-digit segment value (1-999)
  * @param {number} scaleIndex - Scale position (1 = thousands, 2 = millions, ...)
+ * @returns {string} The scale phrase in words
  */
 function buildScalePhrase(segment, scaleIndex) {
   const meta = SCALE_META[scaleIndex - 1]
@@ -148,7 +148,6 @@ function buildScalePhrase(segment, scaleIndex) {
 
 /**
  * Converts a non-negative integer to Romanian words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {string | {gender?: string}} gender - Gender for numbers ('feminine'/'masculine')
  * @returns {string} Romanian words
@@ -168,7 +167,6 @@ function integerToWords(n, gender) {
 /**
  * Builds words for numbers >= 1000.
  * Uses BigInt division for faster segment extraction.
- *
  * @param {bigint} n - Number >= 1000
  * @param {string | {gender?: string}} gender - Gender for numbers ('feminine'/'masculine')
  * @returns {string} Romanian words
@@ -215,7 +213,6 @@ function buildLargeNumberWords(n, gender) {
 /**
  * Converts decimal digits to Romanian words.
  * Decimals always use masculine forms.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Romanian words for decimal part
  */
@@ -248,14 +245,12 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Romanian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Conversion options
- * @param {string} [options.gender='masculine'] - Gender for numbers
+ * @param {object} [options] - Conversion options
+ * @param {string} [options.gender] - Gender for numbers
  * @returns {string} The number in Romanian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)                        // 'douăzeci și unu'
  * toCardinal(1, { gender: 'feminine' }) // 'una'
@@ -289,7 +284,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal for tens and ones (0-99).
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal word
  */
@@ -310,7 +304,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a non-negative integer to Romanian ordinal words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Romanian ordinal words
  */
@@ -393,12 +386,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Romanian ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The ordinal in Romanian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
- *
  * @example
  * toOrdinal(1)   // 'primul'
  * toOrdinal(21)  // 'douăzeci și primul'
@@ -414,12 +405,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Romanian Leu currency words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The currency in Romanian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)     // 'un leu'
  * toCurrency(2.50)  // 'doi lei cincizeci de bani'

--- a/src/ru-RU.js
+++ b/src/ru-RU.js
@@ -96,7 +96,6 @@ const KOPECK_FORMS = ['копейка', 'копейки', 'копеек']
 
 /**
  * Selects the correct plural form based on Russian pluralization rules.
- *
  * @param {number | bigint} n - The count
  * @param {string[]} forms - [one, few, many] forms
  * @returns {string} The matching plural form
@@ -117,7 +116,6 @@ function pluralize(n, forms) {
 
 /**
  * Builds masculine cardinal words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Masculine cardinal words
  */
@@ -150,7 +148,6 @@ function buildSegmentMasc(n) {
 
 /**
  * Builds feminine cardinal words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Feminine cardinal words
  */
@@ -187,7 +184,6 @@ function buildSegmentFem(n) {
 
 /**
  * Converts a non-negative integer to Russian cardinal words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} Cardinal Russian words
@@ -223,7 +219,6 @@ function integerToWords(n, gender) {
 
 /**
  * Builds cardinal words for numbers >= 1,000,000 via scale decomposition.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} Cardinal Russian words
@@ -275,7 +270,6 @@ function buildLargeNumberWords(n, gender) {
 
 /**
  * Converts the fractional digit string to Russian words.
- *
  * @param {string} decimalPart - The fractional digits
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} Cardinal Russian words for the decimal part
@@ -301,10 +295,9 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Russian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Russian words
  */
 function toCardinal(value, options) {
@@ -336,7 +329,6 @@ function toCardinal(value, options) {
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
  * Returns ordinal form: "первый", "двадцать первый", etc.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -371,7 +363,6 @@ function buildOrdinalTensOnes(n) {
  *
  * In Russian ordinals, only the LAST component becomes ordinal.
  * E.g., 121 = "сто двадцать первый" (one hundred twenty first)
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Russian words
  */
@@ -426,7 +417,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Russian words
  */
@@ -506,12 +496,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Russian ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "первый", "сорок второй")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'первый'
  * toOrdinal(2)    // 'второй'
@@ -533,14 +521,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Russian currency words (Russian Ruble).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "и" between rubles and kopecks
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "и" between rubles and kopecks
  * @returns {string} The amount in Russian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'сорок два рубля и пятьдесят копеек'
  * toCurrency(1)                        // 'один рубль'

--- a/src/sr-Cyrl-RS.js
+++ b/src/sr-Cyrl-RS.js
@@ -88,7 +88,6 @@ const SCALE_FORMS = [
 
 /**
  * Selects the correct plural form for a count.
- *
  * @param {number | bigint} n - The count
  * @param {string[]} forms - Plural forms [one, few, many]
  * @returns {string} The selected plural form
@@ -109,7 +108,6 @@ function pluralize(n, forms) {
 
 /**
  * Builds the masculine word form for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} The segment words
  */
@@ -142,7 +140,6 @@ function buildSegmentMasc(n) {
 
 /**
  * Builds the feminine word form for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} The segment words
  */
@@ -179,7 +176,6 @@ function buildSegmentFem(n) {
 
 /**
  * Converts a non-negative integer to Serbian words.
- *
  * @param {bigint} n - The integer to convert
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The integer in words
@@ -196,7 +192,6 @@ function integerToWords(n, gender) {
 
 /**
  * Builds words for integers >= 1000 using scale decomposition.
- *
  * @param {bigint} n - The integer to convert (>= 1000)
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The integer in words
@@ -247,7 +242,6 @@ function buildLargeNumberWords(n, gender) {
 
 /**
  * Converts the decimal-part digit string to Serbian words.
- *
  * @param {string} decimalPart - The decimal digits as a string
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The decimal part in words
@@ -273,10 +267,9 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Serbian (Cyrillic) words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Serbian Cyrillic words
  */
 function toCardinal(value, options) {
@@ -308,7 +301,6 @@ function toCardinal(value, options) {
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
  * Returns ordinal form: "први", "двадесет први", etc.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -343,7 +335,6 @@ function buildOrdinalTensOnes(n) {
  *
  * In Serbian ordinals, only the LAST component becomes ordinal.
  * E.g., 121 = "сто двадесет први" (one hundred twenty first)
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Serbian words
  */
@@ -395,7 +386,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Serbian words
  */
@@ -475,12 +465,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Serbian ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "први", "четрдесет други")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'први'
  * toOrdinal(2)    // 'други'
@@ -501,14 +489,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Serbian currency words (Serbian Dinar).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "и" between dinars and para
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "и" between dinars and para
  * @returns {string} The amount in Serbian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'четрдесет два динара и педесет пара'
  * toCurrency(1)                        // 'један динар'

--- a/src/sr-Latn-RS.js
+++ b/src/sr-Latn-RS.js
@@ -88,7 +88,6 @@ const SCALE_FORMS = [
 
 /**
  * Selects the correct plural form based on Serbian grammar rules.
- *
  * @param {number | bigint} n - The count
  * @param {string[]} forms - Plural forms [one, few, many]
  * @returns {string} The selected plural form
@@ -109,7 +108,6 @@ function pluralize(n, forms) {
 
 /**
  * Builds the masculine word form for a 0-999 segment.
- *
  * @param {number} n - Segment value 0-999
  * @returns {string} The segment words
  */
@@ -142,7 +140,6 @@ function buildSegmentMasc(n) {
 
 /**
  * Builds the feminine word form for a 0-999 segment.
- *
  * @param {number} n - Segment value 0-999
  * @returns {string} The segment words
  */
@@ -179,7 +176,6 @@ function buildSegmentFem(n) {
 
 /**
  * Converts a non-negative integer to Serbian words.
- *
  * @param {bigint} n - The integer to convert
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The integer in Serbian words
@@ -196,7 +192,6 @@ function integerToWords(n, gender) {
 
 /**
  * Builds words for numbers >= 1000 using scale decomposition.
- *
  * @param {bigint} n - The integer to convert (>= 1000)
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The number in Serbian words
@@ -247,7 +242,6 @@ function buildLargeNumberWords(n, gender) {
 
 /**
  * Converts the decimal-part digit string to Serbian words.
- *
  * @param {string} decimalPart - The fractional digits as a string
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The decimal part in Serbian words
@@ -273,10 +267,9 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Serbian (Latin) words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Serbian Latin words
  */
 function toCardinal(value, options) {
@@ -308,7 +301,6 @@ function toCardinal(value, options) {
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
  * Returns ordinal form: "prvi", "dvadeset prvi", etc.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -343,7 +335,6 @@ function buildOrdinalTensOnes(n) {
  *
  * In Serbian ordinals, only the LAST component becomes ordinal.
  * E.g., 121 = "sto dvadeset prvi" (one hundred twenty first)
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Serbian words
  */
@@ -395,7 +386,6 @@ function integerToOrdinal(n) {
 /**
  * Builds ordinal words for numbers >= 1,000,000.
  * All segments except the final one are cardinal; final segment is ordinal.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Serbian words
  */
@@ -475,12 +465,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Serbian ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words (e.g., "prvi", "četrdeset drugi")
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'prvi'
  * toOrdinal(2)    // 'drugi'
@@ -501,14 +489,12 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Serbian currency words (Serbian Dinar).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.and=true] - Use "i" between dinars and para
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "i" between dinars and para
  * @returns {string} The amount in Serbian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // 'četrdeset dva dinara i pedeset para'
  * toCurrency(1)                        // 'jedan dinar'

--- a/src/sv-SE.js
+++ b/src/sv-SE.js
@@ -70,8 +70,8 @@ const ORE = 'öre' // same singular and plural
 /**
  * Builds segment word for 0-999.
  * Returns object with word and metadata for "och" logic.
- *
  * @param {number} n - Integer in range 0-999
+ * @returns {{word: string, hasHundred: boolean, lessThan100: boolean}} Segment word with "och" metadata
  */
 function buildSegment(n) {
   if (n === 0) return { word: '', hasHundred: false, lessThan100: false }
@@ -129,7 +129,6 @@ function buildSegment(n) {
 
 /**
  * Converts a non-negative integer to Swedish words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Swedish words
  */
@@ -169,7 +168,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Swedish words
  */
@@ -245,7 +243,6 @@ function buildLargeNumberWords(n) {
 /**
  * Joins parts with Swedish "och" rules.
  * Insert "och" before final segment if it follows a scale word and doesn't have "hundra".
- *
  * @param {Array<{word: string, hasHundred: boolean, isScale: boolean}>} parts - Parts with metadata
  * @returns {string} Joined string
  */
@@ -275,7 +272,6 @@ function joinSwedishParts(parts) {
 
 /**
  * Converts decimal digits to Swedish words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Swedish words for decimal part
  */
@@ -302,12 +298,10 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Swedish words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Swedish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)       // 'fyrtio-två'
  * toCardinal(101)      // 'hundra och ett'
@@ -340,7 +334,6 @@ function toCardinal(value) {
  *
  * Swedish ordinals: första (1st), andra (2nd), tredje (3rd), etc.
  * Most use cardinal + de suffix, with special forms 1-12.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Swedish ordinal words
  */
@@ -361,12 +354,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Swedish ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'första'
  * toOrdinal(2)    // 'andra'
@@ -385,12 +376,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Swedish currency words (Swedish Krona).
  *
  * Uses krona/kronor and öre (100 öre = 1 krona).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Swedish currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(1)      // 'en krona'
  * toCurrency(42)     // 'fyrtio-två kronor'

--- a/src/sw-KE.js
+++ b/src/sw-KE.js
@@ -59,8 +59,8 @@ const CENT = 'senti'
 // ============================================================================
 
 /**
- * @param {number} n
- * @returns {string}
+ * @param {number} n The integer (0-99) to convert
+ * @returns {string} The number in Swahili words
  */
 function wordsUnder100(n) {
   if (n < 10) return ONES[n]
@@ -76,8 +76,8 @@ function wordsUnder100(n) {
 }
 
 /**
- * @param {number} n
- * @returns {string}
+ * @param {number} n The integer (0-999) to convert
+ * @returns {string} The number in Swahili words
  */
 function wordsUnder1000(n) {
   if (n < 100) return wordsUnder100(n)
@@ -101,8 +101,8 @@ function wordsUnder1000(n) {
 }
 
 /**
- * @param {bigint} n
- * @returns {number[]}
+ * @param {bigint} n The integer to split into 3-digit segments
+ * @returns {number[]} The segments, least-significant first
  */
 function extractSegments(n) {
   const segments = []
@@ -115,8 +115,8 @@ function extractSegments(n) {
 }
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer to convert
+ * @returns {string} The number in Swahili words
  */
 function integerToWords(n) {
   if (n === 0n) return ZERO
@@ -154,8 +154,8 @@ function integerToWords(n) {
 }
 
 /**
- * @param {string} decimalPart
- * @returns {string}
+ * @param {string} decimalPart The digits after the decimal point
+ * @returns {string} The decimal digits in Swahili words
  */
 function decimalPartToWords(decimalPart) {
   let result = ''
@@ -178,7 +178,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Swahili words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Swahili words
  */
@@ -208,7 +207,6 @@ function toCardinal(value) {
  * Converts a non-negative integer to Swahili ordinal words.
  *
  * Swahili ordinals: wa kwanza (1st), wa pili (2nd), wa tatu (3rd), etc.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Swahili ordinal words
  */
@@ -224,12 +222,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Swahili ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'wa kwanza'
  * toOrdinal(2)    // 'wa pili'
@@ -248,12 +244,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Swahili currency words (Kenyan Shilling).
  *
  * Uses shilingi and senti (100 senti = 1 shilingi).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Swahili currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'shilingi arobaini na mbili'
  * toCurrency(1.50)   // 'shilingi moja na senti hamsini'

--- a/src/ta-IN.js
+++ b/src/ta-IN.js
@@ -76,7 +76,6 @@ const SCALE_WORDS = ['', 'ஆயிரம்', 'லட்சம்', 'கோட�
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Tamil words for the segment
  */
@@ -104,7 +103,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Tamil words
  */
@@ -151,7 +149,6 @@ function integerToWords(n) {
 
 /**
  * Converts the decimal portion of a number to Tamil words (per-digit reading).
- *
  * @param {string} decimalPart - The fractional digits as a string
  * @returns {string} Tamil words for each decimal digit
  */
@@ -167,7 +164,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Tamil words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Tamil words
  */
@@ -197,7 +193,6 @@ function toCardinal(value) {
  * Converts a positive integer to Tamil ordinal words.
  *
  * Tamil ordinals: First has special form, 2-6 have special suffixes, then -ஆவது suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Tamil ordinal words
  */
@@ -214,12 +209,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Tamil ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'முதல்'
  * toOrdinal(2)    // 'இரண்டாவது'
@@ -236,12 +229,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Tamil currency words (Indian Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Tamil currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'நாற்பத்திரண்டு ரூபாய் ஐம்பது பைசா'
  * toCurrency(1)      // 'ஒன்று ரூபாய்'

--- a/src/te-IN.js
+++ b/src/te-IN.js
@@ -72,7 +72,6 @@ const SCALE_WORDS = ['', 'వెయ్యి', 'లక్ష', 'కోటి', '
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Telugu words for the segment
  */
@@ -98,7 +97,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Telugu words
  */
@@ -145,7 +143,6 @@ function integerToWords(n) {
 
 /**
  * Reads a decimal fraction digit-by-digit in Telugu.
- *
  * @param {string} decimalPart - Fractional digits as a string
  * @returns {string} Telugu words for each digit
  */
@@ -161,7 +158,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Telugu words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Telugu words
  */
@@ -191,7 +187,6 @@ function toCardinal(value) {
  * Converts a positive integer to Telugu ordinal words.
  *
  * Telugu ordinals: First 6 are irregular, then add -వ suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Telugu ordinal words
  */
@@ -208,12 +203,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Telugu ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'మొదటి'
  * toOrdinal(2)    // 'రెండవ'
@@ -230,12 +223,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Telugu currency words (Indian Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Telugu currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'నలభై రెండు రూపాయలు యాభై పైసలు'
  * toCurrency(1)      // 'ఒకటి రూపాయి'

--- a/src/th-TH.js
+++ b/src/th-TH.js
@@ -44,8 +44,8 @@ const BAHT_ONLY = 'ถ้วน' // "exactly" suffix when no satang
 // ============================================================================
 
 /**
- * @param {number} n
- * @returns {string}
+ * @param {number} n A value below one million to convert.
+ * @returns {string} The number in Thai words.
  */
 function convertBelowMillion(n) {
   if (n === 0) return ''
@@ -111,8 +111,8 @@ function convertBelowMillion(n) {
 }
 
 /**
- * @param {bigint} n
- * @returns {number[]}
+ * @param {bigint} n The integer to split into million-based groups.
+ * @returns {number[]} The groups in most-significant-first order.
  */
 function splitMillionGroups(n) {
   const groups = []
@@ -129,8 +129,8 @@ function splitMillionGroups(n) {
 }
 
 /**
- * @param {bigint} n
- * @returns {string}
+ * @param {bigint} n The integer to convert.
+ * @returns {string} The integer in Thai words.
  */
 function integerToWords(n) {
   if (n === 0n) return ZERO
@@ -153,8 +153,8 @@ function integerToWords(n) {
 }
 
 /**
- * @param {string} decimalPart
- * @returns {string}
+ * @param {string} decimalPart The fractional digits to read.
+ * @returns {string} The decimal digits in Thai words.
  */
 function decimalPartToWords(decimalPart) {
   // Per-digit decimal reading
@@ -168,7 +168,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Thai words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Thai words
  */
@@ -198,7 +197,6 @@ function toCardinal(value) {
  * Converts a non-negative integer to Thai ordinal words.
  *
  * Thai ordinals use "ที่" prefix + cardinal number.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Thai ordinal words
  */
@@ -208,12 +206,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Thai ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'ที่หนึ่ง'
  * toOrdinal(2)    // 'ที่สอง'
@@ -233,12 +229,10 @@ function toOrdinal(value) {
  *
  * Thai Baht uses satang as subunit (100 satang = 1 baht).
  * When whole amounts, adds "ถ้วน" (exactly) suffix.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Thai currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'สี่สิบสองบาทถ้วน'
  * toCurrency(1.50)   // 'หนึ่งบาทห้าสิบสตางค์'

--- a/src/tr-TR.js
+++ b/src/tr-TR.js
@@ -67,9 +67,8 @@ const KURUS = 'kuruş' // subunit (100 kuruş = 1 lira)
 /**
  * Builds segment word for 0-999.
  * Omits "bir" before "yüz" (hundred).
- *
  * @param {number} n - Segment value (0-999)
- * @param {string} [separator=' '] - Separator between words
+ * @param {string} [separator] - Separator between words
  * @returns {string} Segment words
  */
 function buildSegment(n, separator = ' ') {
@@ -119,7 +118,6 @@ function buildSegment(n, separator = ' ') {
 
 /**
  * Converts a non-negative integer to Turkish words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} dropSpaces - Remove spaces for compound form
  * @returns {string} Turkish words
@@ -161,7 +159,6 @@ function integerToWords(n, dropSpaces) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @param {boolean} dropSpaces - Remove spaces for compound form
  * @returns {string} Turkish words
@@ -225,7 +222,6 @@ function buildLargeNumberWords(n, dropSpaces) {
 
 /**
  * Converts decimal digits to Turkish words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @param {boolean} dropSpaces - Remove spaces for compound form
  * @returns {string} Turkish words for decimal part
@@ -254,14 +250,12 @@ function decimalPartToWords(decimalPart, dropSpaces) {
 
 /**
  * Converts a numeric value to Turkish words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Conversion options
- * @param {boolean} [options.dropSpaces=false] - Remove spaces for compound form
+ * @param {object} [options] - Conversion options
+ * @param {boolean} [options.dropSpaces] - Remove spaces for compound form
  * @returns {string} The number in Turkish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(21)                        // 'yirmi bir'
  * toCardinal(21, { dropSpaces: true })  // 'yirmibir'
@@ -327,7 +321,6 @@ function getOrdinalSuffix(word) {
  *
  * Turkish ordinals: birinci (1st), ikinci (2nd), üçüncü (3rd), etc.
  * Uses vowel harmony for suffix selection.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Turkish ordinal words
  */
@@ -345,12 +338,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Turkish ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'birinci'
  * toOrdinal(2)    // 'ikinci'
@@ -369,12 +360,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Turkish currency words (Turkish Lira).
  *
  * Uses lira and kuruş (100 kuruş = 1 lira).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Turkish currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'kırk iki lira'
  * toCurrency(1.50)   // 'bir lira elli kuruş'

--- a/src/uk-UA.js
+++ b/src/uk-UA.js
@@ -80,7 +80,6 @@ const SCALE_FORMS = [
 
 /**
  * Selects the correct plural form for a count.
- *
  * @param {number | bigint} n - The count
  * @param {string[]} forms - Plural forms [one, few, many]
  * @returns {string} The selected plural form
@@ -101,7 +100,6 @@ function pluralize(n, forms) {
 
 /**
  * Builds the masculine words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Segment words
  */
@@ -134,7 +132,6 @@ function buildSegmentMasc(n) {
 
 /**
  * Builds the feminine words for a 0-999 segment.
- *
  * @param {number} n - Number 0-999
  * @returns {string} Segment words
  */
@@ -171,7 +168,6 @@ function buildSegmentFem(n) {
 
 /**
  * Converts a non-negative integer to Ukrainian words.
- *
  * @param {bigint} n - The integer to convert
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The integer in Ukrainian words
@@ -188,7 +184,6 @@ function integerToWords(n, gender) {
 
 /**
  * Builds Ukrainian words for numbers >= 1000.
- *
  * @param {bigint} n - The integer to convert
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The integer in Ukrainian words
@@ -239,7 +234,6 @@ function buildLargeNumberWords(n, gender) {
 
 /**
  * Converts a decimal fractional string to Ukrainian words.
- *
  * @param {string} decimalPart - The fractional digits
  * @param {('masculine'|'feminine')} gender - Grammatical gender
  * @returns {string} The fractional part in Ukrainian words
@@ -265,10 +259,9 @@ function decimalPartToWords(decimalPart, gender) {
 
 /**
  * Converts a numeric value to Ukrainian words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender='masculine'] - Grammatical gender
+ * @param {object} [options] - Optional configuration
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
  * @returns {string} The number in Ukrainian words
  */
 function toCardinal(value, options) {
@@ -299,7 +292,6 @@ function toCardinal(value, options) {
 
 /**
  * Builds ordinal for a 0-99 segment when it's the final (ordinal) part.
- *
  * @param {number} n - Number 0-99
  * @returns {string} Ordinal words
  */
@@ -326,7 +318,6 @@ function buildOrdinalTensOnes(n) {
 
 /**
  * Converts a positive integer to Ukrainian ordinal words (masculine nominative).
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Ordinal Ukrainian words
  */
@@ -368,7 +359,6 @@ function integerToOrdinal(n) {
 
 /**
  * Builds ordinal words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Ordinal Ukrainian words
  */
@@ -441,12 +431,10 @@ function buildLargeOrdinal(n) {
 
 /**
  * Converts a numeric value to Ukrainian ordinal words (masculine nominative).
- *
  * @param {number | string | bigint} value - The numeric value to convert (must be a positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'перший'
  * toOrdinal(2)    // 'другий'
@@ -465,12 +453,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Ukrainian currency words (Hryvnia).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Ukrainian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'сорок двi гривнi'
  * toCurrency(1)      // 'одна гривня'

--- a/src/ur-PK.js
+++ b/src/ur-PK.js
@@ -67,7 +67,6 @@ const SCALE_WORDS = ['', 'ہزار', 'لاکھ', 'کروڑ', 'ارب', 'کھرب
 
 /**
  * Builds words for a 0-999 segment.
- *
  * @param {number} n - Segment value (0-999)
  * @returns {string} Urdu words for the segment
  */
@@ -93,7 +92,6 @@ function buildSegment(n) {
  *
  * Uses BigInt modulo for segment extraction (faster than string slicing).
  * South Asian 3-2-2 grouping: first 3 digits, then groups of 2.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Urdu words
  */
@@ -138,7 +136,6 @@ function integerToWords(n) {
 
 /**
  * Converts the fractional digit string to Urdu words.
- *
  * @param {string} decimalPart - Digits after the decimal separator
  * @returns {string} Urdu words for the decimal part
  */
@@ -163,7 +160,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Urdu words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Urdu words
  */
@@ -193,7 +189,6 @@ function toCardinal(value) {
  * Converts a positive integer to Urdu ordinal words.
  *
  * Urdu ordinals: First 6 are irregular, then add -واں suffix.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Urdu ordinal words
  */
@@ -210,12 +205,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Urdu ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'پہلا'
  * toOrdinal(2)    // 'دوسرا'
@@ -233,12 +226,10 @@ function toOrdinal(value) {
 
 /**
  * Converts a numeric value to Urdu currency words (Pakistani Rupee).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Urdu currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)  // 'بیالیس روپے پچاس پیسے'
  * toCurrency(1)      // 'ایک روپیہ'

--- a/src/utils/expand-scientific.js
+++ b/src/utils/expand-scientific.js
@@ -7,10 +7,8 @@
 /**
  * Expands scientific notation to full decimal form.
  * Handles arbitrarily large exponents without precision loss.
- *
  * @param {string} str - String in scientific notation (e.g., "1e21", "1.5e-3")
  * @returns {string} Full decimal representation (e.g., "1000000000000000000000", "0.0015")
- *
  * @example
  * expandScientificNotation("1e21")    // "1000000000000000000000"
  * expandScientificNotation("1.5e3")   // "1500"
@@ -47,7 +45,6 @@ export function expandScientificNotation(str) {
 
 /**
  * Converts a number to decimal string, expanding scientific notation if needed.
- *
  * @param {number} value - The number to convert
  * @returns {string} Decimal string representation
  */
@@ -58,7 +55,6 @@ export function numberToString(value) {
 
 /**
  * Checks if a string contains scientific notation.
- *
  * @param {string} str - String to check
  * @returns {boolean} True if string contains 'e' or 'E'
  */

--- a/src/utils/is-plain-object.js
+++ b/src/utils/is-plain-object.js
@@ -6,9 +6,8 @@
  * - Object.create(null): null-prototype object
  *
  * This excludes arrays, class instances, Map, Set, and other object types.
- *
- * @param {*} value Value to check
- * @returns {boolean} True if value is a plain object
+ * @param {unknown} value Value to check
+ * @returns {value is object} True if value is a plain object
  */
 export function isPlainObject(value) {
   if (value === null || typeof value !== 'object') return false

--- a/src/utils/parse-cardinal.js
+++ b/src/utils/parse-cardinal.js
@@ -10,9 +10,8 @@ import { expandScientificNotation, hasScientificNotation, numberToString } from 
 /**
  * Parses a value for cardinal conversion.
  * Cardinals accept any numeric value: integers, decimals, negatives.
- *
  * @param {number|string|bigint} value - The value to parse
- * @returns {{isNegative: boolean, integerPart: bigint, decimalPart?: string}}
+ * @returns {{isNegative: boolean, integerPart: bigint, decimalPart?: string}} The parsed cardinal components
  * @throws {TypeError} If value is not number, string, or bigint
  * @throws {RangeError} If value is not finite
  */
@@ -51,7 +50,6 @@ export function parseCardinalValue(value) {
 
 /**
  * Validates and normalizes a string numeric input.
- *
  * @param {string} value - The string to normalize
  * @returns {string} The normalized numeric string
  */
@@ -65,9 +63,8 @@ function normalizeString(value) {
 
 /**
  * Parses a normalized numeric string into components.
- *
  * @param {string} str - The normalized numeric string
- * @returns {{isNegative: boolean, integerPart: bigint, decimalPart?: string}}
+ * @returns {{isNegative: boolean, integerPart: bigint, decimalPart?: string}} The parsed numeric components
  */
 function parseNumericString(str) {
   const isNegative = str[0] === '-'

--- a/src/utils/parse-currency.js
+++ b/src/utils/parse-currency.js
@@ -9,9 +9,8 @@ import { expandScientificNotation, hasScientificNotation, numberToString } from 
 /**
  * Parses a value for currency conversion.
  * Returns dollars and cents as separate bigints, plus negative flag.
- *
  * @param {number|string|bigint} value - The value to parse
- * @returns {{isNegative: boolean, dollars: bigint, cents: bigint}}
+ * @returns {{isNegative: boolean, dollars: bigint, cents: bigint}} The parsed dollars and cents with a negative flag.
  * @throws {TypeError} If value is not number, string, or bigint
  * @throws {RangeError} If value is not finite
  */
@@ -51,9 +50,8 @@ export function parseCurrencyValue(value) {
 
 /**
  * Parses a string for currency conversion.
- *
  * @param {string} value - The string to parse
- * @returns {{isNegative: boolean, dollars: bigint, cents: bigint}}
+ * @returns {{isNegative: boolean, dollars: bigint, cents: bigint}} The parsed dollars and cents with a negative flag.
  */
 function parseCurrencyString(value) {
   let str = value.trim()

--- a/src/utils/parse-ordinal.js
+++ b/src/utils/parse-ordinal.js
@@ -9,7 +9,6 @@ import { expandScientificNotation, hasScientificNotation } from './expand-scient
 /**
  * Parses a value for ordinal conversion.
  * Ordinals require positive integers only (no zero, negatives, or decimals).
- *
  * @param {number|string|bigint} value - The value to parse
  * @returns {bigint} The positive integer value
  * @throws {TypeError} If value is not number, string, or bigint
@@ -52,7 +51,6 @@ export function parseOrdinalValue(value) {
 
 /**
  * Parses a string for ordinal conversion.
- *
  * @param {string} value - The string to parse
  * @returns {bigint} The positive integer value
  * @throws {RangeError} If string is not a valid positive integer

--- a/src/utils/validate-options.js
+++ b/src/utils/validate-options.js
@@ -2,9 +2,8 @@ import { isPlainObject } from './is-plain-object.js'
 
 /**
  * Validates and normalizes the options parameter.
- *
- * @param {*} options The options value to validate
- * @returns {Object} A valid options object (empty object if undefined)
+ * @param {unknown} options The options value to validate
+ * @returns {object} A valid options object (empty object if undefined)
  * @throws {TypeError} If options is not undefined or a plain object
  */
 export function validateOptions(options) {

--- a/src/vi-VN.js
+++ b/src/vi-VN.js
@@ -59,7 +59,6 @@ const LAM = 'lăm' // 5 in tens position (25, 35, etc.)
 
 /**
  * Builds word for 0-99 with special forms (mốt, lăm).
- *
  * @param {number} n - Integer in range 0-99
  * @returns {string} Vietnamese words
  */
@@ -88,7 +87,6 @@ function buildBelowHundred(n) {
 
 /**
  * Builds segment word for 0-999.
- *
  * @param {number} n - Integer in range 0-999
  * @returns {string} Vietnamese words
  */
@@ -128,7 +126,6 @@ function buildSegment(n) {
 
 /**
  * Builds "lẻ" prefixed word for small remainders (1-99) after scale words.
- *
  * @param {number} n - Integer in range 0-99
  * @returns {string} Vietnamese words
  */
@@ -147,7 +144,6 @@ function buildLeSegment(n) {
 
 /**
  * Converts a non-negative integer to Vietnamese words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Vietnamese words
  */
@@ -189,7 +185,6 @@ function integerToWords(n) {
 
 /**
  * Builds words for numbers >= 1,000,000.
- *
  * @param {bigint} n - Number >= 1,000,000
  * @returns {string} Vietnamese words
  */
@@ -258,7 +253,6 @@ function buildLargeNumberWords(n) {
 
 /**
  * Converts decimal digits to Vietnamese words.
- *
  * @param {string} decimalPart - Decimal digits (without the point)
  * @returns {string} Vietnamese words for decimal part
  */
@@ -288,12 +282,10 @@ function decimalPartToWords(decimalPart) {
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Vietnamese words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCardinal(42)           // 'bốn mươi hai'
  * toCardinal(101)          // 'một trăm lẻ một'
@@ -326,7 +318,6 @@ function toCardinal(value) {
  *
  * Vietnamese ordinals use "thứ" prefix + cardinal number.
  * Special case: "thứ nhất" for 1st (not "thứ một").
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Vietnamese ordinal words
  */
@@ -342,12 +333,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Vietnamese ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'thứ nhất'
  * toOrdinal(2)    // 'thứ hai'
@@ -367,12 +356,10 @@ function toOrdinal(value) {
  *
  * Vietnamese Dong has no subunit in modern usage (xu are historical).
  * Amounts are rounded to whole đồng.
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Vietnamese currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'bốn mươi hai đồng'
  * toCurrency(1000)   // 'một nghìn đồng'

--- a/src/yo-NG.js
+++ b/src/yo-NG.js
@@ -138,7 +138,6 @@ const KOBO = 'kọ́bọ̀'
 
 /**
  * Builds word for numbers 0-99
- *
  * @param {number} n - Integer in the range 0-99
  * @returns {string} Yoruba words for the number
  */
@@ -175,7 +174,6 @@ function buildUnder100(n) {
 
 /**
  * Converts hundreds (100-999)
- *
  * @param {number} n - Integer in the range 0-999
  * @returns {string} Yoruba words for the number
  */
@@ -219,7 +217,6 @@ function convertHundreds(n) {
 
 /**
  * Converts a non-negative integer to Yoruba words.
- *
  * @param {bigint} n - Non-negative integer to convert
  * @returns {string} Yoruba words
  */
@@ -299,7 +296,6 @@ function integerToWords(n) {
 
 /**
  * Converts decimal digits to Yoruba words.
- *
  * @param {string} decimalPart - Decimal digits
  * @returns {string} Yoruba words for decimal
  */
@@ -316,7 +312,6 @@ function decimalPartToWords(decimalPart) {
 
 /**
  * Converts a numeric value to Yoruba words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
  * @returns {string} The number in Yoruba words
  */
@@ -346,7 +341,6 @@ function toCardinal(value) {
  * Converts a non-negative integer to Yoruba ordinal words.
  *
  * Yoruba ordinals: àkọ́kọ́ (1st), ìkejì (2nd), ìkẹta (3rd), ìkẹrin (4th), etc.
- *
  * @param {bigint} n - Positive integer to convert
  * @returns {string} Yoruba ordinal words
  */
@@ -361,12 +355,10 @@ function integerToOrdinal(n) {
 
 /**
  * Converts a numeric value to Yoruba ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)    // 'àkọ́kọ́'
  * toOrdinal(2)    // 'ìkejì'
@@ -385,12 +377,10 @@ function toOrdinal(value) {
  * Converts a numeric value to Yoruba currency words (Nigerian Naira).
  *
  * Uses náírà (naira) and kọ́bọ̀ (kobo).
- *
  * @param {number | string | bigint} value - The currency amount to convert
  * @returns {string} The amount in Yoruba currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)     // 'èjì lé lógójì náírà'
  * toCurrency(1.50)   // 'ọ̀kan náírà àti àádọ́ta kọ́bọ̀'

--- a/src/zh-Hans-CN.js
+++ b/src/zh-Hans-CN.js
@@ -69,13 +69,12 @@ const ZHENG = '整'
 
 /**
  * Convert number below 万 (10,000) to words using direct string concatenation.
- *
- * @param {bigint} value
- * @param {string[]} ones
- * @param {string} ten
- * @param {string} hundred
- * @param {string} thousand
- * @returns {string}
+ * @param {bigint} value The integer (0-9999) to convert
+ * @param {string[]} ones Digit words for 0-9
+ * @param {string} ten Word for the tens place
+ * @param {string} hundred Word for the hundreds place
+ * @param {string} thousand Word for the thousands place
+ * @returns {string} The number in words
  */
 function convertBelowWan(value, ones, ten, hundred, thousand) {
   if (value === 0n) return ''
@@ -126,13 +125,12 @@ function convertBelowWan(value, ones, ten, hundred, thousand) {
 
 /**
  * Convert number below 亿 (100 million) to words.
- *
- * @param {bigint} value
- * @param {string[]} ones
- * @param {string} ten
- * @param {string} hundred
- * @param {string} thousand
- * @returns {string}
+ * @param {bigint} value The integer to convert
+ * @param {string[]} ones Digit words for 0-9
+ * @param {string} ten Word for the tens place
+ * @param {string} hundred Word for the hundreds place
+ * @param {string} thousand Word for the thousands place
+ * @returns {string} The number in words
  */
 function convertBelowYi(value, ones, ten, hundred, thousand) {
   if (value === 0n) return ''
@@ -157,10 +155,9 @@ function convertBelowYi(value, ones, ten, hundred, thousand) {
 
 /**
  * Convert an integer to Simplified Chinese words.
- *
- * @param {bigint} n
- * @param {boolean} [formal]
- * @returns {string}
+ * @param {bigint} n The integer to convert
+ * @param {boolean} [formal] Use formal/financial numerals
+ * @returns {string} The integer in Simplified Chinese words
  */
 function integerToWords(n, formal = true) {
   if (n === 0n) return ZERO
@@ -190,10 +187,9 @@ function integerToWords(n, formal = true) {
 
 /**
  * Convert decimal digits to words using direct concatenation.
- *
- * @param {string} decimalString
- * @param {string[]} ones
- * @returns {string}
+ * @param {string} decimalString The decimal digits to convert
+ * @param {string[]} ones Digit words for 0-9
+ * @returns {string} The decimal digits in words
  */
 function decimalDigitsToWords(decimalString, ones) {
   let result = ''
@@ -205,10 +201,9 @@ function decimalDigitsToWords(decimalString, ones) {
 
 /**
  * Converts a numeric value to Simplified Chinese words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.formal=true] - Use formal/financial numerals
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.formal] - Use formal/financial numerals
  * @returns {string} The number in Simplified Chinese words
  */
 function toCardinal(value, options) {
@@ -238,7 +233,6 @@ function toCardinal(value, options) {
  * Converts a positive integer to Simplified Chinese ordinal words.
  *
  * Chinese ordinals: 第 prefix + cardinal number.
- *
  * @param {bigint} n - Positive integer to convert
  * @param {boolean} formal - Use formal numerals
  * @returns {string} Simplified Chinese ordinal words
@@ -249,14 +243,12 @@ function integerToOrdinal(n, formal) {
 
 /**
  * Converts a numeric value to Simplified Chinese ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.formal=true] - Use formal/financial numerals
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.formal] - Use formal/financial numerals
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)                    // '第壹'
  * toOrdinal(1, { formal: false }) // '第一'
@@ -275,14 +267,12 @@ function toOrdinal(value, options) {
 
 /**
  * Converts a numeric value to Simplified Chinese currency words (Yuan/Renminbi).
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.formal=true] - Use formal/financial numerals
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.formal] - Use formal/financial numerals
  * @returns {string} The amount in Simplified Chinese currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42.50)                    // '肆拾贰圆伍角整'
  * toCurrency(1)                        // '壹圆整'

--- a/src/zh-Hant-TW.js
+++ b/src/zh-Hant-TW.js
@@ -68,9 +68,8 @@ const YUAN_COMMON = '元'
 
 /**
  * Converts a non-negative integer to Traditional Chinese words.
- *
  * @param {bigint} n - The integer value to convert
- * @param {boolean} [formal=true] - Use formal/financial numerals
+ * @param {boolean} [formal] - Use formal/financial numerals
  * @returns {string} The integer in Traditional Chinese words
  */
 function integerToWords(n, formal = true) {
@@ -83,8 +82,8 @@ function integerToWords(n, formal = true) {
 
   // Convert number below 萬 (10,000)
   /**
-   * @param {bigint} value
-   * @returns {string}
+   * @param {bigint} value The number below 10,000 to convert
+   * @returns {string} The number in Traditional Chinese words
    */
   function convertBelowWan(value) {
     if (value === 0n) return ''
@@ -141,8 +140,8 @@ function integerToWords(n, formal = true) {
 
   // Convert number below 億 (100 million)
   /**
-   * @param {bigint} value
-   * @returns {string}
+   * @param {bigint} value The number below 100,000,000 to convert
+   * @returns {string} The number in Traditional Chinese words
    */
   function convertBelowYi(value) {
     if (value === 0n) return ''
@@ -199,9 +198,8 @@ function integerToWords(n, formal = true) {
 
 /**
  * Converts each digit of a decimal string to Traditional Chinese words.
- *
  * @param {string} decimalString - The decimal digits to convert
- * @param {boolean} [formal=true] - Use formal/financial numerals
+ * @param {boolean} [formal] - Use formal/financial numerals
  * @returns {string[]} The decimal digits as Traditional Chinese words
  */
 function decimalDigitsToWords(decimalString, formal = true) {
@@ -215,10 +213,9 @@ function decimalDigitsToWords(decimalString, formal = true) {
 
 /**
  * Converts a numeric value to Traditional Chinese words.
- *
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.formal=true] - Use formal/financial numerals
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.formal] - Use formal/financial numerals
  * @returns {string} The number in Traditional Chinese words
  */
 function toCardinal(value, options) {
@@ -251,7 +248,6 @@ function toCardinal(value, options) {
  * Converts a non-negative integer to Traditional Chinese ordinal words.
  *
  * Traditional Chinese ordinals use "第" prefix + cardinal number.
- *
  * @param {bigint} n - Positive integer to convert
  * @param {boolean} formal - Use formal/financial numerals
  * @returns {string} Traditional Chinese ordinal words
@@ -262,14 +258,12 @@ function integerToOrdinal(n, formal = true) {
 
 /**
  * Converts a numeric value to Traditional Chinese ordinal words.
- *
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.formal=true] - Use formal/financial numerals
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.formal] - Use formal/financial numerals
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
- *
  * @example
  * toOrdinal(1)                    // '第壹'
  * toOrdinal(2)                    // '第貳'
@@ -291,14 +285,12 @@ function toOrdinal(value, options) {
  *
  * Uses 圓 (yuan), 角 (jiao, 1/10), 分 (fen, 1/100).
  * Formal writing adds 整 (zheng) for whole amounts.
- *
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {Object} [options] - Optional configuration
- * @param {boolean} [options.formal=true] - Use formal/financial numerals
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.formal] - Use formal/financial numerals
  * @returns {string} The amount in Traditional Chinese currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
- *
  * @example
  * toCurrency(42)                    // '肆拾貳圓整'
  * toCurrency(1.50)                  // '壹圓伍角整'


### PR DESCRIPTION
## What

The 6th and final ESLint-10 hardening plugin: **`eslint-plugin-jsdoc`**, adopting `flat/recommended-typescript-flavor-error` on `src/` **as-published — no preference disables** (per the principle that we take recommended rulesets wholesale and only disable for substantive reasons). JSDoc is the type source for the generated `.d.ts`, so its accuracy is now linted + enforced.

## How the 1,052 findings were resolved

- **Autofixed (~899):** `tag-lines` (781, blank-line formatting), `check-types` (55, e.g. `{Object}`→`{object}`), `no-defaults` (63 — this **strips `[options.and=false]`-style defaults from public JSDoc**, accepted as part of taking full recommended).
- **Manual (153), via a 33-agent workflow (one per file):** `require-param-description` (66) + `require-returns-description` (53) → concise accurate descriptions; `require-returns` (32) → `@returns` with the correct type; `reject-any-type` (2) → `{*}`→`{unknown}` on the `isPlainObject`/`validateOptions` guards.

## Verification

- `npm run lint` **0** · `npm run typecheck` **0** (proves every added `@returns` type is correct) · `npm test` **264 pass** · `npm run build` OK.
- **The entire src diff is JSDoc-only** — confirmed zero non-comment code lines changed, so no runtime behavior could have shifted.
- Spot-checked description quality and `@returns` shapes (e.g. `buildSegment` → `{{word: string, hasHundred: boolean}}`) — accurate, not filler.

## Follow-up (separate PR)

Now that jsdoc lint + strict checkJs cover JSDoc correctness, the brittle ~100-line regex JSDoc validator (`getJSDocForFunction`/`validateJSDoc`) in `test/conversions.test.js` is redundant and can be retired. That touches only that one file, so it's a focused follow-up rather than part of this 81-file diff.

This completes the ESLint thread: ESLint 10 + @stylistic + compat + es-x + n + import-x + ava + eslint-comments + jsdoc, all on recommended rulesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)