### PR TITLE
test: drop computeAssertionPlan/t.plan from conversions (loop structure satisfies lint)

### DIFF
--- a/test/conversions.test.js
+++ b/test/conversions.test.js
@@ -299,80 +299,6 @@ function planFormChecks(t, file, languageCode, formName, config, fn, fixtureData
 }
 
 // ============================================================================
-// Assertion Planning
-// ============================================================================
-
-/**
- * Computes the exact number of assertions the language test will run.
- *
- * This mirrors the control flow of the language test body one-to-one so that
- * `t.plan()` can verify every assertion path executed. It reuses the same
- * validation functions the test does, so its branch decisions are identical.
- *
- * Assertion sources (in test order):
- * - BCP 47 validation: always 1 (t.true).
- * - Per form with a fixture:
- *   - missing export: 1 (t.fail), then skipped (no further assertions).
- *   - else: either an invalid-fixture failure (1, then skipped) or the
- *     per-case conversion assertions plus error cases.
- * - hasAtLeastOneForm: always 1 (t.true).
- * - Cross-validation: 1 (t.fail) per exported function that lacks a fixture.
- *
- * @param {string} languageCode Language code under test
- * @param {Object} languageModule Imported language module
- * @param {Object} fixtureModule Imported fixture module
- * @returns {number} Exact assertion count
- */
-function computeAssertionPlan(languageCode, languageModule, fixtureModule) {
-  // BCP 47 validation (always one assertion).
-  let count = 1
-
-  for (const [formName, config] of Object.entries(FORMS)) {
-    const fixtureData = fixtureModule[formName]
-    const fn = languageModule[config.functionName]
-
-    // Skip if no fixture for this form.
-    if (!fixtureData) continue
-
-    // Missing export: a single t.fail, then the form is skipped.
-    if (typeof fn !== 'function') {
-      count += 1
-      continue
-    }
-
-    // Fixture validation: a single t.fail then the form is skipped.
-    const validation = validateFixture(fixtureData, languageCode, formName, config)
-    if (!validation.valid) {
-      count += 1
-      continue
-    }
-
-    // Conversion tests: one assertion (t.is or t.fail) per test case.
-    count += fixtureData.length
-
-    // Error cases: one t.throws each.
-    if (config.errorCases) {
-      count += config.errorCases.length
-    }
-  }
-
-  // hasAtLeastOneForm (always one assertion).
-  count += 1
-
-  // Cross-validation: one t.fail per exported function missing its fixture.
-  for (const [formName, config] of Object.entries(FORMS)) {
-    const fn = languageModule[config.functionName]
-    const fixtureData = fixtureModule[formName]
-
-    if (typeof fn === 'function' && !fixtureData) {
-      count += 1
-    }
-  }
-
-  return count
-}
-
-// ============================================================================
 // Language Tests
 // ============================================================================
 
@@ -385,11 +311,6 @@ for (const file of fixtureFiles) {
     // Import modules
     const languageModule = await import('../src/' + file)
     const fixtureModule = await import('./fixtures/' + file)
-
-    // Plan the exact assertion count up front. This satisfies
-    // ava/no-conditional-assertion (assertions live inside the fixture-driven
-    // loops/conditionals below) and verifies every planned path actually runs.
-    t.plan(computeAssertionPlan(languageCode, languageModule, fixtureModule))
 
     // ========================================================================
     // BCP 47 Validation


### PR DESCRIPTION
## What

Removes `computeAssertionPlan` (~70 lines) and the `t.plan()` call from `conversions.test.js`. I added these in #338 to satisfy `ava/no-conditional-assertion` — but that was a misread: the rule is satisfied by the **loop restructure** (assertions run in `for…of` loops via thunks; loops aren't flagged), **not** by `t.plan`. Verified: removing `t.plan` keeps lint green.

So `computeAssertionPlan` was pure overhead — a parallel function that *mirrored the test's control flow* purely to feed `t.plan` a dynamic count, meaning any change to the test had to be mirrored in two places or the plan silently broke. Net: **474 → 395 lines.**

## Safety

`t.plan` did add one thing: verifying the exact assertion count (catching a vacuous pass). That risk is already covered without it:
- `validateFixture` rejects empty fixtures (and now duplicates, via #343).
- The test always asserts BCP 47 validity + `hasAtLeastOneForm`, so there are always ≥2 assertions.
- **Mutation test confirms teeth**: breaking an `fr-FR` fixture value still fails the suite (`fr-FR cardinal case 1/88`), green again on restore.

## Verification

- `npm run lint` 0 · `npm test` **264 pass** · no leftover `computeAssertionPlan`/`t.plan` references.

Independent of #343 (touches different regions of the file), so it merges cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)