### PR TITLE
test: gate language files to canonical BCP 47 codes

### DIFF
--- a/test/conversions.test.js
+++ b/test/conversions.test.js
@@ -393,10 +393,12 @@ test('all language files use canonical BCP 47 codes', (t) => {
     .filter(f => f.endsWith('.js') && !f.startsWith('utils'))
     .map(f => f.replace('.js', ''))
 
-  // Only flag valid-but-mis-cased codes; invalid codes are the validity test's
-  // concern (and would report a confusing "code → null" here otherwise).
-  const nonCanonicalCodes = languageFiles
-    .filter(code => isValidLanguageCode(code) && code !== getCanonicalCode(code))
-    .map(code => `${code} → ${getCanonicalCode(code)}`)
+  // Only flag valid-but-mis-cased codes; invalid codes (getCanonicalCode is
+  // null) are the validity test's concern, so they're skipped here rather than
+  // reported as a confusing "code → null". Canonicalize once per code.
+  const nonCanonicalCodes = languageFiles.flatMap((code) => {
+    const canonical = getCanonicalCode(code)
+    return canonical && code !== canonical ? [`${code} → ${canonical}`] : []
+  })
   t.deepEqual(nonCanonicalCodes, [], `Non-canonical BCP 47 codes (rename to canonical form): ${nonCanonicalCodes.join(', ')}`)
 })

--- a/test/conversions.test.js
+++ b/test/conversions.test.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { readdirSync } from 'node:fs'
 import { isPlainObject } from '../src/utils/is-plain-object.js'
-import { isValidLanguageCode } from './helpers/language-naming.js'
+import { getCanonicalCode, isValidLanguageCode } from './helpers/language-naming.js'
 import { isValidCardinalInput, isValidOrdinalInput, safeStringify } from './helpers/value-utils.js'
 
 /**
@@ -382,4 +382,21 @@ test('all language files use valid BCP 47 codes', (t) => {
 
   const invalidCodes = languageFiles.filter(code => !isValidLanguageCode(code))
   t.deepEqual(invalidCodes, [], `Invalid BCP 47 codes: ${invalidCodes.join(', ')}`)
+})
+
+test('all language files use canonical BCP 47 codes', (t) => {
+  // Validity (above) accepts non-canonical casing: Intl.getCanonicalLocales
+  // treats 'en-us' and 'zh-hans-cn' as valid. The project convention is the
+  // canonical form (en-US, zh-Hans-CN), which lang:add produces. Guard against
+  // a manually-added, mis-cased file slipping past the validity gate.
+  const languageFiles = readdirSync('./src')
+    .filter(f => f.endsWith('.js') && !f.startsWith('utils'))
+    .map(f => f.replace('.js', ''))
+
+  // Only flag valid-but-mis-cased codes; invalid codes are the validity test's
+  // concern (and would report a confusing "code → null" here otherwise).
+  const nonCanonicalCodes = languageFiles
+    .filter(code => isValidLanguageCode(code) && code !== getCanonicalCode(code))
+    .map(code => `${code} → ${getCanonicalCode(code)}`)
+  t.deepEqual(nonCanonicalCodes, [], `Non-canonical BCP 47 codes (rename to canonical form): ${nonCanonicalCodes.join(', ')}`)
 })


### PR DESCRIPTION
## What

Adds a structural test asserting every `src/*.js` language code is in **canonical** BCP 47 form (`en-US`, `zh-Hans-CN`), as a companion to the existing validity test.

## Why

The existing `all language files use valid BCP 47 codes` test only checks *validity*, not *canonical case*. `Intl.getCanonicalLocales` happily accepts non-canonical casing as valid:

| code | valid? | canonical | matches convention? |
|---|---|---|---|
| `en-US` | ✅ | en-US | ✅ |
| `en-us` | ✅ | en-US | ❌ **passed anyway** |
| `zh-hans-cn` | ✅ | zh-Hans-CN | ❌ **passed anyway** |
| `EN_US` | ❌ | — | (rejected by validity test) |

`lang:add` canonicalizes for you, so scaffolded files are correct — but a **manually-added, mis-cased file** (`src/en-us.js`) would slip past the validity gate. This closes that gap.

## How

- Imports the existing `getCanonicalCode` helper (no new machinery).
- New test `all language files use canonical BCP 47 codes` flags any `src/*.js` code where `code !== getCanonicalCode(code)`, reporting an actionable `en-us → en-US` rename hint.
- Only flags **valid-but-mis-cased** codes; invalid codes remain the validity test's concern (avoids a confusing `code → null` and keeps the two failure modes — "not a real tag" vs "wrong case" — cleanly separated).

## Verification

- `lint:js` clean, full suite green (**265 tests**, +1 from the new structural test).
- Negative test: planting `src/en-us.js` makes **only** the new test fail with `en-us → en-US` (validity test stays green, confirming the separation). File removed after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)