### PR TITLE
test: gate fixture coverage at a floor instead of a no-op warning

### DIFF
--- a/test/conversions.test.js
+++ b/test/conversions.test.js
@@ -236,9 +236,10 @@ function runTestCases(t, fn, testCases, form) {
 }
 
 /**
- * Minimum fixture cases required per form. The corpus floor is currently 8;
- * gating at 5 fails nothing today but trips a new or regressed fixture that
- * drops below a real smoke test (more than a token value or two).
+ * Minimum fixture cases required per form — a low, deliberate floor that
+ * demands more than a token value or two (a real smoke test) without pinning
+ * languages to an arbitrary count. Acts as a tripwire: a new or regressed
+ * fixture that drops below it fails the build.
  */
 const MIN_TEST_CASES_PER_FORM = 5
 

--- a/test/conversions.test.js
+++ b/test/conversions.test.js
@@ -236,13 +236,19 @@ function runTestCases(t, fn, testCases, form) {
 }
 
 /**
- * Builds the ordered list of checks (assertion thunks and logs) for one form.
+ * Minimum fixture cases required per form. The corpus floor is currently 8;
+ * gating at 5 fails nothing today but trips a new or regressed fixture that
+ * drops below a real smoke test (more than a token value or two).
+ */
+const MIN_TEST_CASES_PER_FORM = 5
+
+/**
+ * Builds the ordered list of checks (assertion thunks) for one form.
  *
  * Each returned entry is a zero-argument function. Running them in order
  * reproduces the original form-test control flow exactly, including the
  * early-skip behavior: a missing export or an invalid fixture short-circuits
- * the form (no later checks are produced). Warnings/coverage notes are emitted
- * as `t.log` side effects here (logs are not assertions and are not planned).
+ * the form (no later checks are produced).
  *
  * Returning thunks keeps the assertions out of `if` conditionals at the call
  * site (they run inside a plain loop), satisfying ava/no-conditional-assertion
@@ -275,10 +281,11 @@ function planFormChecks(t, file, languageCode, formName, config, fn, fixtureData
   // Conversion tests: one assertion per fixture case (handled in runTestCases).
   checks.push(() => runTestCases(t, fn, fixtureData, formName))
 
-  // Coverage note (log, not an assertion).
-  if (fixtureData.length < 25) {
-    t.log(`Warning: ${languageCode} has only ${fixtureData.length} ${formName} test cases.`)
-  }
+  // Coverage floor: every form must exercise more than a token value or two.
+  checks.push(() => t.true(
+    fixtureData.length >= MIN_TEST_CASES_PER_FORM,
+    `${languageCode} ${formName} has only ${fixtureData.length} test cases (minimum ${MIN_TEST_CASES_PER_FORM})`,
+  ))
 
   // Error cases (form-specific): one t.throws per case.
   for (const { input, error, desc } of config.errorCases ?? []) {


### PR DESCRIPTION
## What

Replaces the `<25`-cases coverage **warning** with a real coverage **gate** at a low, meaningful floor (`MIN_TEST_CASES_PER_FORM = 5`).

## Why

The old check was a `t.log`, not an assertion — it could never fail the build. And it fired for **101 of 216 form-combos (47%)**, so it was pure output noise that nobody could read or act on. The "25" was also arbitrary.

Distribution across the corpus (per language × form):

| cases | combos |
|---|---|
| 1–4 | **0** |
| 5–9 | 6 |
| 10–14 | 23 |
| 15–19 | 23 |
| 20–24 | 49 |
| 25+ | 115 |

Nothing is genuinely undertested — the real floor is **8** (a handful of `en-*` ordinals). That's why a "baseline allowlist at 25" would just freeze 101 arbitrary entries; a low gate is the better tool.

## How

- New module constant `MIN_TEST_CASES_PER_FORM = 5`.
- The coverage check becomes a planned assertion thunk (`t.true(fixtureData.length >= 5, ...)`), pushed alongside the other per-form checks so it still satisfies `ava/no-conditional-assertion`.
- Drops the arbitrary `25` threshold and the 101 `ℹ Warning:` log lines.
- Fixed the now-stale `planFormChecks` docstring (no more `t.log` side effects).

At **5**, this fails nothing today (corpus floor is 8) — it's a tripwire: a new or regressed fixture that drops below a real smoke test now fails the build with an actionable message.

## Verification

- `lint:js` clean, full suite green (**264 tests**), and **0** residual `has only` warnings.
- Negative test: truncating `en-GH` ordinal to 4 cases fails with `en-GH ordinal has only 4 test cases (minimum 5)`. Fixture restored after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)