### PR TITLE
fix(da-DK): correct scale-group joining and guard the scale ceiling

### DIFF
--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -182,6 +182,15 @@ function buildLargeNumberWords(n) {
     pos += segmentSize
   }
 
+  // Past the largest named scale word the number cannot be spelled. Segments
+  // are [units, thousands, then one per SCALES entry], so the ceiling is
+  // SCALES.length + 2 segments (10^30 - 1). Throw rather than emit "undefined".
+  if (segments.length > SCALES.length + 2) {
+    throw new RangeError(
+      `da-DK cannot convert numbers >= 10^${(SCALES.length + 2) * 3} (largest supported scale word exceeded)`,
+    )
+  }
+
   // Convert segments to words with scale tracking
   // scaleIndex: 0 = units, 1 = thousands, 2 = millions, etc.
   const parts = []
@@ -229,37 +238,25 @@ function buildLargeNumberWords(n) {
  */
 function joinDanishParts(parts) {
   if (parts.length === 0) return ZERO
-  if (parts.length === 1) return parts[0].word
 
-  const result = []
+  const tokens = []
 
   for (let i = 0; i < parts.length; i++) {
     const part = parts[i]
     const nextPart = parts[i + 1]
 
     if (part.type === 'thousand' && nextPart && nextPart.type === 'units') {
-      // Thousands followed by units: add "e og"
-      result.push(part.word + 'e og ' + nextPart.word)
-      i++ // Skip the units part
-    }
-    else if (part.type === 'million') {
-      if (result.length > 0) {
-        result.push(' ')
-      }
-      result.push(part.word)
-      if (nextPart) {
-        result.push(' ')
-      }
+      // Thousands directly followed by the units segment: compound "…tusinde og …"
+      tokens.push(part.word + 'e og ' + nextPart.word)
+      i++ // consumed the units part
     }
     else {
-      if (result.length > 0 && !result[result.length - 1].endsWith(' ')) {
-        result.push(' ')
-      }
-      result.push(part.word)
+      tokens.push(part.word)
     }
   }
 
-  return result.join('')
+  // Every remaining boundary (between scale groups) is a single space.
+  return tokens.join(' ')
 }
 
 /**

--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -186,9 +187,7 @@ function buildLargeNumberWords(n) {
   // are [units, thousands, then one per SCALES entry], so the ceiling is
   // SCALES.length + 2 segments (10^30 - 1). Throw rather than emit "undefined".
   if (segments.length > SCALES.length + 2) {
-    throw new RangeError(
-      `da-DK cannot convert numbers >= 10^${(SCALES.length + 2) * 3} (largest supported scale word exceeded)`,
-    )
+    throw tooLargeError((SCALES.length + 2) * 3)
   }
 
   // Convert segments to words with scale tracking

--- a/src/utils/too-large-error.js
+++ b/src/utils/too-large-error.js
@@ -1,0 +1,27 @@
+/**
+ * Out-of-range error for numbers beyond a language's largest scale word.
+ *
+ * Spelling an arbitrary BigInt requires infinitely many scale words, so every
+ * language has a ceiling. Past it, conversion throws rather than emitting
+ * malformed output. This builds that error with a uniform message so every
+ * language reports the condition identically — complementing the RangeErrors
+ * that parse-cardinal / parse-currency / parse-ordinal already throw for
+ * non-finite or out-of-domain input.
+ * @module too-large-error
+ */
+
+/**
+ * Builds the RangeError thrown when a value exceeds the largest scale word a
+ * language can express.
+ * @param {number} maxExponent The language can express values up to
+ *   `10^maxExponent - 1`; values `>= 10^maxExponent` throw this error.
+ * @returns {RangeError} A RangeError with a uniform, descriptive message.
+ * @example
+ * if (segments.length > SCALES.length + 2) throw tooLargeError(30)
+ * // RangeError: Number too large to convert: the largest supported value is 10^30 - 1
+ */
+export function tooLargeError(maxExponent) {
+  return new RangeError(
+    `Number too large to convert: the largest supported value is 10^${maxExponent} - 1`,
+  )
+}

--- a/test/conversions.test.js
+++ b/test/conversions.test.js
@@ -13,7 +13,6 @@ import { isValidCardinalInput, isValidOrdinalInput, safeStringify } from './help
  * Fixture format (test/fixtures/{code}.js):
  *   export const cardinal = [[input, expected, options?], ...]
  *   export const ordinal = [[input, expected, options?], ...]
- *   export const cardinalErrors = [[input, ErrorClass], ...]  // optional: inputs that must throw
  *
  * Validates:
  * - BCP 47 file naming convention
@@ -342,26 +341,6 @@ for (const file of fixtureFiles) {
       const formChecks = planFormChecks(t, file, languageCode, formName, config, fn, fixtureData)
       for (const check of formChecks) {
         check()
-      }
-    }
-
-    // ========================================================================
-    // Out-of-range cases (e.g. scale ceilings): assert they throw
-    // ========================================================================
-
-    // A fixture may export `<form>Errors` as an array of [input, ErrorClass],
-    // e.g. `export const cardinalErrors = [[10n ** 30n, RangeError]]`, for
-    // inputs the form rejects (too large to spell, out of domain, …). Iterated
-    // in a plain loop (not an if) so ava/no-conditional-assertion stays happy.
-    for (const [formName, config] of Object.entries(FORMS)) {
-      const fn = languageModule[config.functionName]
-      const errorCases = fixtureModule[formName + 'Errors'] ?? []
-      for (const [input, expectedError] of errorCases) {
-        t.throws(
-          () => fn(input),
-          { instanceOf: expectedError },
-          `${languageCode} ${config.functionName}(${input}) should throw ${expectedError.name}`,
-        )
       }
     }
 

--- a/test/conversions.test.js
+++ b/test/conversions.test.js
@@ -13,6 +13,7 @@ import { isValidCardinalInput, isValidOrdinalInput, safeStringify } from './help
  * Fixture format (test/fixtures/{code}.js):
  *   export const cardinal = [[input, expected, options?], ...]
  *   export const ordinal = [[input, expected, options?], ...]
+ *   export const cardinalErrors = [[input, ErrorClass], ...]  // optional: inputs that must throw
  *
  * Validates:
  * - BCP 47 file naming convention
@@ -341,6 +342,26 @@ for (const file of fixtureFiles) {
       const formChecks = planFormChecks(t, file, languageCode, formName, config, fn, fixtureData)
       for (const check of formChecks) {
         check()
+      }
+    }
+
+    // ========================================================================
+    // Out-of-range cases (e.g. scale ceilings): assert they throw
+    // ========================================================================
+
+    // A fixture may export `<form>Errors` as an array of [input, ErrorClass],
+    // e.g. `export const cardinalErrors = [[10n ** 30n, RangeError]]`, for
+    // inputs the form rejects (too large to spell, out of domain, …). Iterated
+    // in a plain loop (not an if) so ava/no-conditional-assertion stays happy.
+    for (const [formName, config] of Object.entries(FORMS)) {
+      const fn = languageModule[config.functionName]
+      const errorCases = fixtureModule[formName + 'Errors'] ?? []
+      for (const [input, expectedError] of errorCases) {
+        t.throws(
+          () => fn(input),
+          { instanceOf: expectedError },
+          `${languageCode} ${config.functionName}(${input}) should throw ${expectedError.name}`,
+        )
       }
     }
 

--- a/test/fixtures/da-DK.js
+++ b/test/fixtures/da-DK.js
@@ -69,6 +69,11 @@ export const cardinal = [
   [1_000_000, 'en millioner'],
   [1_000_001, 'en millioner et'],
   [4_000_000, 'fire millioner'],
+  // Numbers spanning multiple scale groups (regression: these used to emit a
+  // double space between groups — see joinDanishParts).
+  [1_001_000_000, 'en millarder en millioner'],
+  [1_001_001, 'en millioner ettusinde og et'],
+  [2_000_002_000_000n, 'to billioner to millioner'],
   [10_000_000_000_000, 'ti billioner'],
   [100_000_000_000_000, 'ethundrede billioner'],
   [1_000_000_000_000_000_000n, 'en trillioner'],

--- a/test/fixtures/da-DK.js
+++ b/test/fixtures/da-DK.js
@@ -68,15 +68,23 @@ export const cardinal = [
   [9539, 'nitusinde og femhundrede og niogtredive'],
   [1_000_000, 'en millioner'],
   [1_000_001, 'en millioner et'],
-  [4_000_000, 'fire millioner'],
-  // Numbers spanning multiple scale groups (regression: these used to emit a
-  // double space between groups — see joinDanishParts).
-  [1_001_000_000, 'en millarder en millioner'],
+  // Multi-scale-group numbers (regression: these used to emit a double space
+  // between groups — see joinDanishParts).
   [1_001_001, 'en millioner ettusinde og et'],
+  [4_000_000, 'fire millioner'],
+  [1_001_000_000, 'en millarder en millioner'],
   [2_000_002_000_000n, 'to billioner to millioner'],
   [10_000_000_000_000, 'ti billioner'],
   [100_000_000_000_000, 'ethundrede billioner'],
   [1_000_000_000_000_000_000n, 'en trillioner'],
+]
+
+/**
+ * Out-of-range inputs that must throw (scale ceiling: da-DK names scales up to
+ * 10^30 - 1, beyond which all three forms throw rather than emit "undefined").
+ */
+export const cardinalErrors = [
+  [10n ** 30n, RangeError],
 ]
 
 /**
@@ -118,6 +126,11 @@ export const ordinal = [
   [1001, 'ettusinde og etde'],
 ]
 
+/** Ordinals share the cardinal scale ceiling. */
+export const ordinalErrors = [
+  [10n ** 30n, RangeError],
+]
+
 /**
  * Currency test cases (Danish Krone)
  * Format: [input, expected_output, options?]
@@ -154,4 +167,9 @@ export const currency = [
 
   // Edge cases
   ['5.00', 'fem kroner'],
+]
+
+/** Currency shares the cardinal scale ceiling. */
+export const currencyErrors = [
+  [10n ** 30n, RangeError],
 ]

--- a/test/fixtures/da-DK.js
+++ b/test/fixtures/da-DK.js
@@ -80,14 +80,6 @@ export const cardinal = [
 ]
 
 /**
- * Out-of-range inputs that must throw (scale ceiling: da-DK names scales up to
- * 10^30 - 1, beyond which all three forms throw rather than emit "undefined").
- */
-export const cardinalErrors = [
-  [10n ** 30n, RangeError],
-]
-
-/**
  * Ordinal number test cases
  * Format: [input, expected_output, options?]
  */
@@ -126,11 +118,6 @@ export const ordinal = [
   [1001, 'ettusinde og etde'],
 ]
 
-/** Ordinals share the cardinal scale ceiling. */
-export const ordinalErrors = [
-  [10n ** 30n, RangeError],
-]
-
 /**
  * Currency test cases (Danish Krone)
  * Format: [input, expected_output, options?]
@@ -167,9 +154,4 @@ export const currency = [
 
   // Edge cases
   ['5.00', 'fem kroner'],
-]
-
-/** Currency shares the cardinal scale ceiling. */
-export const currencyErrors = [
-  [10n ** 30n, RangeError],
 ]

--- a/test/utils/too-large-error.test.js
+++ b/test/utils/too-large-error.test.js
@@ -1,0 +1,29 @@
+import test from 'ava'
+import { tooLargeError } from '../../src/utils/too-large-error.js'
+
+/**
+ * Unit Tests for too-large-error.js
+ *
+ * Tests the tooLargeError helper, which builds the uniform RangeError thrown
+ * when a value exceeds a language's largest scale word.
+ */
+
+test('returns a RangeError instance', (t) => {
+  t.true(tooLargeError(30) instanceof RangeError)
+})
+
+test('message reports the supported ceiling', (t) => {
+  t.is(
+    tooLargeError(30).message,
+    'Number too large to convert: the largest supported value is 10^30 - 1',
+  )
+})
+
+test('embeds the given exponent', (t) => {
+  t.true(tooLargeError(12).message.includes('10^12'))
+  t.true(tooLargeError(66).message.includes('10^66'))
+})
+
+test('does not throw on its own (returns the error to throw)', (t) => {
+  t.notThrows(() => tooLargeError(24))
+})


### PR DESCRIPTION
First in the **fix-then-gate** series: fixing the malformed-output defects that property-based fuzzing surfaced, one language at a time (each file is self-contained by design), before adding the fast-check gate as the contract enforcer.

da-DK was the only language with an **everyday-magnitude** bug, so it goes first. This PR also introduces the shared **`tooLargeError`** helper that every subsequent per-language ceiling fix will reuse.

## Defects

**1. Connector double-space (any number ≥ 10⁹).** `joinDanishParts` pushed a *trailing* space after each million-scale group **and** a *leading* space before the next, so adjacent groups doubled up:

```
1,001,000,000  ->  "en millarder  en millioner"   (double space)
```

This broke essentially every realistic large number, yet the fixtures only tested **clean powers of ten** (which land in a single scale group) and passed — the bug lived in the gaps between examples. The same join backs the ordinal path, so ordinals were broken too.

Fix: build tokens and join with a single space, preserving the thousands+units `…tusinde og …` compound.

**2. Scale ceiling (≥ 10³⁰).** Past the largest `SCALES` word the lookup returned `undefined` and got concatenated (`"… undefined"`). Now throws `RangeError`.

## Shared `tooLargeError` helper (`src/utils/too-large-error.js`)

A **composable API-contract util** (a function each language *calls*, not a wrapper that wraps them — keeps the FP/self-contained design intact) that builds the out-of-range `RangeError` with one uniform message. This is **not a new error type** — `parse-cardinal`/`parse-currency`/`parse-ordinal` already throw `RangeError` for `NaN`/`Infinity`/out-of-domain input; "too large" simply joins those existing conditions, consistent with JS semantics. Unit-tested in `test/utils/too-large-error.test.js`.

## Enforcement lives in the gate, not fixtures

Out-of-range behavior (throws `RangeError`, never emits garbage) is enforced by the upcoming **fast-check gate** — one universal property (*well-formed string or `RangeError`, for any input, every language*) rather than hand-written per-language error cases. So this PR adds the **source** guard but no `[10n**30n, RangeError]` fixtures.

## Verification

- Existing da-DK fixtures unchanged and still green; added ascending multi-scale-group cardinals (`1_001_001`, `1_001_000_000`, `2_000_002_000_000`) locking the single-space join.
- Focused fast-check pass (2000 runs/property, all three forms): **well-formed for every in-range input**, **`RangeError` for ≥ 10³⁰**.
- Full suite: lint clean, 269 tests.

## Scope note

Restores **well-formed output** (the class the fuzzer flags) using da-DK's existing fixture-locked convention (`en millioner`, single-spaced). It does **not** change that convention — that's a separate correctness question with no oracle, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)