### PR TITLE
fix(es): guard scale ceilings in es-ES, es-MX, es-US

### DIFF
--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -20,6 +20,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -229,6 +230,14 @@ function buildLargeNumberWords(n, feminine) {
     temp = temp / 1000n
   }
 
+  // Past the largest named scale (mil cuatrillones, 10^30 - 1) the lookup runs
+  // out. Each SCALES entry spans two segment indices (X and "mil X"), so the
+  // ceiling is 2 * SCALES.length + 2 segments. Throw rather than emit "un …".
+  const maxSegments = 2 * SCALES.length + 2
+  if (segmentValues.length > maxSegments) {
+    throw tooLargeError(maxSegments * 3)
+  }
+
   // Build result string directly
   let result = ''
 
@@ -407,6 +416,12 @@ function buildOrdinalSegment(n, feminine) {
  * @returns {string} Spanish ordinal words
  */
 function integerToOrdinal(n, feminine) {
+  // Ordinal scale words stop at "millonésimo" (10^6); the millions multiplier
+  // is built with buildOrdinalSegment (0-999), so support ends below 10^9.
+  if (n >= 1_000_000_000n) {
+    throw tooLargeError(9)
+  }
+
   const thousandWord = feminine ? ORDINAL_THOUSAND_FEM : ORDINAL_THOUSAND_MASC
   const millionWord = feminine ? ORDINAL_MILLION_FEM : ORDINAL_MILLION_MASC
 

--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -46,6 +46,16 @@ const HUNDREDS_FEM = ['', 'cienta', 'doscientas', 'trescientas', 'cuatrocientas'
 const SCALES = ['millón', 'billón', 'trillón', 'cuatrillón']
 const SCALES_PLURAL = ['millones', 'billones', 'trillones', 'cuatrillones']
 
+// Supported magnitude ceilings (checked at the public entry points). Each
+// SCALES entry spans two segment groups (X and "mil X"); with the units group
+// that's 2 * SCALES.length + 2 groups of 3 digits, so cardinals must stay below
+// 10^30. Ordinals are bounded lower: the millions multiplier uses
+// buildOrdinalSegment (0-999), so n must stay below 10^9.
+const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = 9
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+
 const THOUSAND = 'mil'
 const ZERO = 'cero'
 const NEGATIVE = 'menos'
@@ -223,19 +233,12 @@ function integerToWords(n, feminine) {
 function buildLargeNumberWords(n, feminine) {
   // Extract segments using BigInt division (faster than string slicing)
   // Segments stored least-significant first (index 0 = ones, 1 = thousands, etc.)
+  // Callers guard the magnitude (MAX_CARDINAL) before reaching here.
   const segmentValues = []
   let temp = n
   while (temp > 0n) {
     segmentValues.push(temp % 1000n)
     temp = temp / 1000n
-  }
-
-  // Past the largest named scale (mil cuatrillones, 10^30 - 1) the lookup runs
-  // out. Each SCALES entry spans two segment indices (X and "mil X"), so the
-  // ceiling is 2 * SCALES.length + 2 segments. Throw rather than emit "un …".
-  const maxSegments = 2 * SCALES.length + 2
-  if (segmentValues.length > maxSegments) {
-    throw tooLargeError(maxSegments * 3)
   }
 
   // Build result string directly
@@ -334,6 +337,7 @@ function decimalPartToWords(decimalPart, feminine) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -416,12 +420,6 @@ function buildOrdinalSegment(n, feminine) {
  * @returns {string} Spanish ordinal words
  */
 function integerToOrdinal(n, feminine) {
-  // Ordinal scale words stop at "millonésimo" (10^6); the millions multiplier
-  // is built with buildOrdinalSegment (0-999), so support ends below 10^9.
-  if (n >= 1_000_000_000n) {
-    throw tooLargeError(9)
-  }
-
   const thousandWord = feminine ? ORDINAL_THOUSAND_FEM : ORDINAL_THOUSAND_MASC
   const millionWord = feminine ? ORDINAL_MILLION_FEM : ORDINAL_MILLION_MASC
 
@@ -492,6 +490,7 @@ function integerToOrdinal(n, feminine) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
 
   const { gender = 'masculine' } = options
   const feminine = gender === 'feminine'
@@ -523,6 +522,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimos } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   let result = ''

--- a/src/es-MX.js
+++ b/src/es-MX.js
@@ -20,6 +20,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -229,6 +230,14 @@ function buildLargeNumberWords(n, feminine) {
     temp = temp / 1000n
   }
 
+  // Past the largest named scale (mil cuatrillones, 10^30 - 1) the lookup runs
+  // out. Each SCALES entry spans two segment indices (X and "mil X"), so the
+  // ceiling is 2 * SCALES.length + 2 segments. Throw rather than emit "un …".
+  const maxSegments = 2 * SCALES.length + 2
+  if (segmentValues.length > maxSegments) {
+    throw tooLargeError(maxSegments * 3)
+  }
+
   // Build result string directly
   let result = ''
 
@@ -396,6 +405,12 @@ function buildOrdinalSegment(n, feminine) {
  * @returns {string} Spanish ordinal words
  */
 function integerToOrdinal(n, feminine) {
+  // Ordinal scale words stop at "millonésimo" (10^6); the millions multiplier
+  // is built with buildOrdinalSegment (0-999), so support ends below 10^9.
+  if (n >= 1_000_000_000n) {
+    throw tooLargeError(9)
+  }
+
   const thousandWord = feminine ? ORDINAL_THOUSAND_FEM : ORDINAL_THOUSAND_MASC
   const millionWord = feminine ? ORDINAL_MILLION_FEM : ORDINAL_MILLION_MASC
 

--- a/src/es-MX.js
+++ b/src/es-MX.js
@@ -46,6 +46,16 @@ const HUNDREDS_FEM = ['', 'cienta', 'doscientas', 'trescientas', 'cuatrocientas'
 const SCALES = ['millón', 'billón', 'trillón', 'cuatrillón']
 const SCALES_PLURAL = ['millones', 'billones', 'trillones', 'cuatrillones']
 
+// Supported magnitude ceilings (checked at the public entry points). Each
+// SCALES entry spans two segment groups (X and "mil X"); with the units group
+// that's 2 * SCALES.length + 2 groups of 3 digits, so cardinals must stay below
+// 10^30. Ordinals are bounded lower: the millions multiplier uses
+// buildOrdinalSegment (0-999), so n must stay below 10^9.
+const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = 9
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+
 const THOUSAND = 'mil'
 
 const ZERO = 'cero'
@@ -223,19 +233,12 @@ function integerToWords(n, feminine) {
 function buildLargeNumberWords(n, feminine) {
   // Extract segments using BigInt division (faster than string slicing)
   // Segments stored least-significant first (index 0 = ones, 1 = thousands, etc.)
+  // Callers guard the magnitude (MAX_CARDINAL) before reaching here.
   const segmentValues = []
   let temp = n
   while (temp > 0n) {
     segmentValues.push(temp % 1000n)
     temp = temp / 1000n
-  }
-
-  // Past the largest named scale (mil cuatrillones, 10^30 - 1) the lookup runs
-  // out. Each SCALES entry spans two segment indices (X and "mil X"), so the
-  // ceiling is 2 * SCALES.length + 2 segments. Throw rather than emit "un …".
-  const maxSegments = 2 * SCALES.length + 2
-  if (segmentValues.length > maxSegments) {
-    throw tooLargeError(maxSegments * 3)
   }
 
   // Build result string directly
@@ -331,6 +334,7 @@ function decimalPartToWords(decimalPart, feminine) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -405,12 +409,6 @@ function buildOrdinalSegment(n, feminine) {
  * @returns {string} Spanish ordinal words
  */
 function integerToOrdinal(n, feminine) {
-  // Ordinal scale words stop at "millonésimo" (10^6); the millions multiplier
-  // is built with buildOrdinalSegment (0-999), so support ends below 10^9.
-  if (n >= 1_000_000_000n) {
-    throw tooLargeError(9)
-  }
-
   const thousandWord = feminine ? ORDINAL_THOUSAND_FEM : ORDINAL_THOUSAND_MASC
   const millionWord = feminine ? ORDINAL_MILLION_FEM : ORDINAL_MILLION_MASC
 
@@ -476,6 +474,7 @@ function integerToOrdinal(n, feminine) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
 
   const { gender = 'masculine' } = options
   const feminine = gender === 'feminine'
@@ -507,6 +506,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: pesos, cents: centavos } = parseCurrencyValue(value)
+  if (pesos >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   let result = ''

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -20,6 +20,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -182,8 +183,10 @@ function integerToWords(n, feminine) {
       // Millions and above: "un millón", "dos millones", etc.
       const scaleIndex = i - 1 // SCALES[1] = millón, SCALES[2] = billón, etc.
       if (scaleIndex >= SCALES.length) {
-        // Beyond our scale vocabulary
-        result += buildSegment(Number(segment), false)
+        // Beyond our scale vocabulary: emitting the segment without its scale
+        // would silently drop the magnitude (10^60 -> "uno"). Throw instead.
+        // SCALES covers units + 10^3..10^18, so the ceiling is 10^21 - 1.
+        throw tooLargeError((SCALES.length + 1) * 3)
       }
       else if (segment === 1n) {
         // "un millón" not "uno millón"
@@ -315,6 +318,12 @@ function buildOrdinalSegment(n, feminine) {
  * @returns {string} Spanish ordinal words
  */
 function integerToOrdinal(n, feminine) {
+  // Ordinal scale words stop at "millonésimo" (10^6); the millions multiplier
+  // is built with buildOrdinalSegment (0-999), so support ends below 10^9.
+  if (n >= 1_000_000_000n) {
+    throw tooLargeError(9)
+  }
+
   const thousandWord = feminine ? ORDINAL_THOUSAND_FEM : ORDINAL_THOUSAND_MASC
   const millionWord = feminine ? ORDINAL_MILLION_FEM : ORDINAL_MILLION_MASC
 

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -46,6 +46,15 @@ const HUNDREDS_FEM = ['', 'cienta', 'doscientas', 'trescientas', 'cuatrocientas'
 const SCALES = ['mil', 'millón', 'billón', 'trillón', 'cuatrillón', 'quintillón']
 const SCALES_PLURAL = ['mil', 'millones', 'billones', 'trillones', 'cuatrillones', 'quintillones']
 
+// Supported magnitude ceilings (checked at the public entry points). Short
+// scale: SCALES covers 10^3..10^18, plus the units group, so cardinals span at
+// most SCALES.length + 1 groups of 3 digits (below 10^21). Ordinals are bounded
+// lower: the millions multiplier uses buildOrdinalSegment (0-999), so n < 10^9.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = 9
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+
 const ZERO = 'cero'
 const NEGATIVE = 'menos'
 const DECIMAL_SEP = 'punto'
@@ -181,14 +190,9 @@ function integerToWords(n, feminine) {
     }
     else {
       // Millions and above: "un millón", "dos millones", etc.
+      // Callers guard the magnitude (MAX_CARDINAL) so scaleIndex stays in range.
       const scaleIndex = i - 1 // SCALES[1] = millón, SCALES[2] = billón, etc.
-      if (scaleIndex >= SCALES.length) {
-        // Beyond our scale vocabulary: emitting the segment without its scale
-        // would silently drop the magnitude (10^60 -> "uno"). Throw instead.
-        // SCALES covers units + 10^3..10^18, so the ceiling is 10^21 - 1.
-        throw tooLargeError((SCALES.length + 1) * 3)
-      }
-      else if (segment === 1n) {
+      if (segment === 1n) {
         // "un millón" not "uno millón"
         result += 'un ' + SCALES[scaleIndex]
       }
@@ -244,6 +248,7 @@ function decimalPartToWords(decimalPart, feminine) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -318,12 +323,6 @@ function buildOrdinalSegment(n, feminine) {
  * @returns {string} Spanish ordinal words
  */
 function integerToOrdinal(n, feminine) {
-  // Ordinal scale words stop at "millonésimo" (10^6); the millions multiplier
-  // is built with buildOrdinalSegment (0-999), so support ends below 10^9.
-  if (n >= 1_000_000_000n) {
-    throw tooLargeError(9)
-  }
-
   const thousandWord = feminine ? ORDINAL_THOUSAND_FEM : ORDINAL_THOUSAND_MASC
   const millionWord = feminine ? ORDINAL_MILLION_FEM : ORDINAL_MILLION_MASC
 
@@ -389,6 +388,7 @@ function integerToOrdinal(n, feminine) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
 
   const { gender = 'masculine' } = options
   const feminine = gender === 'feminine'
@@ -420,6 +420,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars, cents: centavos } = parseCurrencyValue(value)
+  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   let result = ''


### PR DESCRIPTION
Second in the **fix-then-gate** series (after da-DK #347). The Spanish locales, one file at a time — they share a family but are *not* identical (long vs short scale), which is exactly why each was checked individually.

## What property fuzzing found

| locale | cardinal | ordinal | currency |
|---|---|---|---|
| es-ES (long scale) | `"un "` at 10³⁰ | `"undefinedcentésimo millonésimo"` at 10⁹ | `"un  euros"` at 10³⁰ |
| es-MX (long scale) | `"un "` at 10³⁰ | same at 10⁹ | `"un  pesos"` at 10³⁰ |
| es-US (**short scale**) | **silently wrong** — `"uno"` at 10⁶⁰ | same at 10⁹ | (inherits cardinal) |

## Fixes (all via the shared `tooLargeError` helper)

- **es-ES / es-MX** — `getScaleWord` returned `''` past `cuatrillón`. Guard `buildLargeNumberWords` at `2 * SCALES.length + 2` segments → `RangeError` at 10³⁰. Currency routes through `integerToWords`, so it's covered automatically.
- **es-US** — short scale (billón = 10⁹). It had an explicit *"beyond our scale vocabulary"* branch that appended the segment **without** its scale word, silently dropping the magnitude (`10⁶⁰ → "uno"`). That's the subtler, *well-formed-but-wrong* failure a pure well-formedness check would miss — now throws at its real 10²¹ ceiling.
- **All three** — ordinal builds the millions multiplier with `buildOrdinalSegment` (0–999), so `n ≥ 10⁹` overflowed to `"undefined…"`. Guard `integerToOrdinal` at 10⁹.

## Verification

Per locale, 1500 runs/form: **well-formed string or `RangeError`** across `±10⁴⁰`; boundary checks confirm `10^ceil − 1` is well-formed and `10^ceil` throws (es-ES/es-MX cardinal 10³⁰, es-US 10²¹, all ordinals 10⁹). In-range output is unchanged — **existing fixtures stay green** (269 tests), lint clean.

Out-of-range enforcement is owned by the upcoming **fast-check gate** (the series capstone), so this adds source guards but no per-language error fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)