### PR TITLE
fix(fr): guard scale ceilings in fr-FR, fr-BE (+ retrofit da-DK to entry-point guards)

### DIFF
--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -39,6 +39,13 @@ const DECIMAL_SEP = 'komma'
 // Long scale: millioner, millarder, billioner, etc.
 const SCALES = ['millioner', 'millarder', 'billioner', 'billarder', 'trillioner', 'trillarder', 'quadrillioner', 'quadrillarder']
 
+// Supported magnitude ceiling (checked at the public entry points). Segments
+// are [units, thousands, then one per SCALES entry], so cardinals span at most
+// SCALES.length + 2 groups of 3 digits — they must stay below 10^30. Ordinals
+// and currency build on the cardinal, so they share the same ceiling.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+
 // ============================================================================
 // Ordinal Vocabulary
 // ============================================================================
@@ -183,14 +190,8 @@ function buildLargeNumberWords(n) {
     pos += segmentSize
   }
 
-  // Past the largest named scale word the number cannot be spelled. Segments
-  // are [units, thousands, then one per SCALES entry], so the ceiling is
-  // SCALES.length + 2 segments (10^30 - 1). Throw rather than emit "undefined".
-  if (segments.length > SCALES.length + 2) {
-    throw tooLargeError((SCALES.length + 2) * 3)
-  }
-
   // Convert segments to words with scale tracking
+  // Callers guard the magnitude (MAX_CARDINAL) before reaching here.
   // scaleIndex: 0 = units, 1 = thousands, 2 = millions, etc.
   const parts = []
   let scaleIndex = segments.length - 1
@@ -297,6 +298,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
 
@@ -349,6 +351,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -371,6 +374,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: kroner, cents: ore } = parseCurrencyValue(value)
+  if (kroner >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {

--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -298,7 +298,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 

--- a/src/fr-BE.js
+++ b/src/fr-BE.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -26,6 +27,14 @@ const TENS = ['', '', 'vingt', 'trente', 'quarante', 'cinquante', 'soixante', 's
 // Scale words (long scale with -ard forms)
 const SCALES = ['million', 'billion', 'trillion', 'quadrillion']
 const SCALES_ARD = ['milliard', 'billiard', 'trilliard', 'quadrilliard']
+
+// Supported magnitude ceiling (checked at the public entry points). Long scale:
+// each SCALES entry has a base and an "-ard" form spanning two segment groups,
+// so with the units group that's 2 * SCALES.length + 2 groups of 3 digits.
+// Cardinals must stay below 10^30; ordinals and currency build on the cardinal,
+// so they share the same ceiling.
+const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const THOUSAND = 'mille'
 const HUNDRED = 'cent'
@@ -336,6 +345,7 @@ function decimalPartToWords(decimalPart, withHyphen) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { withHyphenSeparator = false } = options
@@ -439,6 +449,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -464,6 +475,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimes } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/fr-BE.js
+++ b/src/fr-BE.js
@@ -345,7 +345,11 @@ function decimalPartToWords(decimalPart, withHyphen) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { withHyphenSeparator = false } = options

--- a/src/fr-FR.js
+++ b/src/fr-FR.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -27,6 +28,14 @@ const TENS = ['', '', 'vingt', 'trente', 'quarante', 'cinquante', 'soixante']
 // Scale words (even indices: million, billion, trillion, quadrillion)
 const SCALES = ['million', 'billion', 'trillion', 'quadrillion']
 const SCALES_ARD = ['milliard', 'billiard', 'trilliard', 'quadrilliard']
+
+// Supported magnitude ceiling (checked at the public entry points). Long scale:
+// each SCALES entry has a base and an "-ard" form spanning two segment groups,
+// so with the units group that's 2 * SCALES.length + 2 groups of 3 digits.
+// Cardinals must stay below 10^30; ordinals and currency build on the cardinal,
+// so they share the same ceiling.
+const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const THOUSAND = 'mille'
 const HUNDRED = 'cent'
@@ -367,6 +376,7 @@ function decimalPartToWords(decimalPart, withHyphen) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { withHyphenSeparator = false } = options
@@ -474,6 +484,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -499,6 +510,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimes } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/fr-FR.js
+++ b/src/fr-FR.js
@@ -376,7 +376,11 @@ function decimalPartToWords(decimalPart, withHyphen) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { withHyphenSeparator = false } = options


### PR DESCRIPTION
Third in the **fix-then-gate** series (after da-DK #347, es #348).

## French family (fr-FR, fr-BE)

Both are long-scale (`SCALES` + `-ard` variants), so the ceiling is uniform across all three forms at **10³⁰** — ordinal and currency build on the cardinal (`integerToWords` → `cardinalToOrdinal`), so they share it rather than capping lower the way Spanish ordinals did (10⁹). Past the ceiling: cardinal `"un "`, ordinal/currency double-space.

Fix follows the **entry-point pattern** from #348: declare `MAX_CARDINAL` up front (derived from `SCALES`, so it can't drift) and short-circuit in `toCardinal`/`toOrdinal`/`toCurrency` right after parsing — before any decomposition.

## da-DK retrofit (consistency)

da-DK (#347) predates the entry-point pattern and guarded the ceiling *inside* `buildLargeNumberWords`. Hoisted it to `MAX_CARDINAL` up front + the three entry points, matching every other language. **Behavior unchanged** — same 10³⁰ ceiling, just relocated so the builder stays free of contract logic and out-of-range rejects before any work.

## Verification

Per locale, 1500 runs/form: **well-formed string or `RangeError`** across `±10⁴⁰`; boundary checks confirm `10³⁰−1` well-formed / `10³⁰` throws for all three forms. da-DK's existing fixtures (incl. the multi-scale-group regressions from #347) stay green. Lint clean, 269 tests.

Out-of-range enforcement remains owned by the upcoming fast-check gate, so no per-language error fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)