### PR TITLE
fix(es): guard the decimal part against the scale ceiling

### DIFF
--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -337,7 +337,11 @@ function decimalPartToWords(decimalPart, feminine) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options

--- a/src/es-MX.js
+++ b/src/es-MX.js
@@ -334,7 +334,11 @@ function decimalPartToWords(decimalPart, feminine) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -248,7 +248,11 @@ function decimalPartToWords(decimalPart, feminine) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options


### PR DESCRIPTION
Follow-up to **#348** — fixes the same decimal-bypass bug Copilot flagged on #349, which the merged Spanish PR shipped with.

## The bug

The entry-point ceiling guard checked only `integerPart`. But es-* spell the decimal's significant digits via `integerToWords(BigInt(remainder))` — the same scale builder — so a string like:

```
es-ES / es-MX:  "0." + 31 non-zero digits   ->  integerPart 0, passes guard -> double-space output
es-US:          "0." + 22 non-zero digits   ->  integerPart 0, passes guard -> "...undefined..."
```

slipped past (`integerPart = 0`) and fed an over-ceiling integer into the builder.

## Fix

Same one applied to fr-FR/fr-BE/da-DK in #349: also reject when `BigInt(decimalPart) >= MAX_CARDINAL`. Leading zeros are spelled separately and don't change `BigInt(decimalPart)`, so it's exactly the magnitude the builder receives. Currency is unaffected (cents ≤ 99).

## Verification

Per locale, boundary checks: an `N`-significant-digit decimal is well-formed, `N+1` throws `RangeError` (es-ES/MX at 30/31, es-US at 21/22). Normal decimals unchanged (`"3.14"` → `"tres punto catorce"`). `scratch-probe` (now fuzzing long decimal strings) reports clean through 70 digits. Lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)