### PR TITLE
fix(pt): guard scale ceilings in pt-BR, pt-PT

### DIFF
--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -135,6 +136,20 @@ const SCALE_WORDS_PLURAL = [
   'sextilhões', // 7: 10^21
   'setilhões', // 8: 10^24
 ]
+
+// Scale ordinal words (short scale for pt-BR). Module-scope so its length can
+// derive the ordinal ceiling and so it isn't rebuilt on every call.
+const SCALE_ORDINAL = ['', 'milésimo', 'milionésimo', 'bilionésimo', 'trilionésimo', 'quatrilionésimo', 'quintilionésimo', 'sextilionésimo']
+
+// Supported magnitude ceilings (checked at the public entry points). Cardinal
+// scale words reach index SCALE_WORDS_SINGULAR.length-1 (setilhão, 10^24), so
+// cardinals/currency must stay below 10^27. The ordinal of a number whose
+// lowest non-zero group is a scale group uses SCALE_ORDINAL, which is shorter,
+// so ordinals must stay below 10^(SCALE_ORDINAL.length * 3).
+const MAX_CARDINAL_EXPONENT = SCALE_WORDS_SINGULAR.length * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = SCALE_ORDINAL.length * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 // ============================================================================
 // Conversion Functions
@@ -290,6 +305,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -370,9 +390,6 @@ function buildLargeOrdinal(n) {
     }
   }
 
-  // Scale ordinal words (singular forms - short scale for pt-BR)
-  const SCALE_ORDINAL = ['', 'milésimo', 'milionésimo', 'bilionésimo', 'trilionésimo', 'quatrilionésimo', 'quintilionésimo', 'sextilionésimo']
-
   let result = ''
 
   for (let i = segments.length - 1; i >= 0; i--) {
@@ -431,6 +448,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
+  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
 
   // Fast path: 1-9
   if (n < 10n) {
@@ -479,6 +497,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: majorUnits, cents: minorUnits } = parseCurrencyValue(value)
+  if (majorUnits >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and = true } = options
 
   // 1. Descobre a moeda informada ou busca automaticamente a padrão do país (pt-BR = BRL)

--- a/src/pt-PT.js
+++ b/src/pt-PT.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -124,6 +125,20 @@ const SCALE_WORDS_PLURAL = [
   'mil triliões', // 7: 10^21 (compound, same)
   'quatriliões', // 8: 10^24
 ]
+
+// Scale ordinal words (long scale for pt-PT). Module-scope so its length can
+// derive the ordinal ceiling and so it isn't rebuilt on every call.
+const SCALE_ORDINAL = ['', 'milésimo', 'milionésimo', 'mil milionésimo', 'bilionésimo', 'mil bilionésimo', 'trilionésimo']
+
+// Supported magnitude ceilings (checked at the public entry points). Cardinal
+// scale words reach index SCALE_WORDS_SINGULAR.length-1 (quatrilião, 10^24), so
+// cardinals/currency must stay below 10^27. The ordinal of a number whose
+// lowest non-zero group is a scale group uses SCALE_ORDINAL, which is shorter,
+// so ordinals must stay below 10^(SCALE_ORDINAL.length * 3).
+const MAX_CARDINAL_EXPONENT = SCALE_WORDS_SINGULAR.length * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = SCALE_ORDINAL.length * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 // ============================================================================
 // Conversion Functions
@@ -290,6 +305,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -370,9 +390,6 @@ function buildLargeOrdinal(n) {
     }
   }
 
-  // Scale ordinal words (singular forms)
-  const SCALE_ORDINAL = ['', 'milésimo', 'milionésimo', 'mil milionésimo', 'bilionésimo', 'mil bilionésimo', 'trilionésimo']
-
   let result = ''
 
   for (let i = segments.length - 1; i >= 0; i--) {
@@ -435,6 +452,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
+  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
 
   // Fast path: 1-9
   if (n < 10n) {
@@ -483,6 +501,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and = true } = options
 
   let result = ''


### PR DESCRIPTION
Fourth in the **fix-then-gate** series (after da-DK #347, es #348, fr #349, es-decimal #350).

## What fuzzing found

Both Portuguese locales emit `"um undefined"` past their scale vocabulary. The per-form ceilings differ, so each is derived from that file's own scale table:

| | cardinal | ordinal | currency | decimal |
|---|---|---|---|---|
| pt-BR (short scale) | 10²⁷ | **10²⁴** | 10²⁷ | 10²⁷ |
| pt-PT (long scale) | 10²⁷ | **10²¹** | 10²⁷ | 10²⁷ |

The ordinal ceiling is lower and differs between locales: when a number's *lowest* non-zero group is itself a scale group, the ordinal uses `SCALE_ORDINAL` (pt-BR 8 entries, pt-PT 7), which is shorter than the cardinal scale table. A conservative magnitude guard at `10^(SCALE_ORDINAL.length*3)` keeps everything below it well-formed.

## Fix

Entry-point pattern (from #348/#349): `MAX_CARDINAL`/`MAX_ORDINAL` declared up front, derived from the scale tables; short-circuit in `toCardinal`/`toOrdinal`/`toCurrency` after parsing. Currency inherits the cardinal ceiling; the **decimal** part is guarded too (spelled via `integerToWords(BigInt(remainder))` — the bug class from #349/#350).

Also **hoisted `SCALE_ORDINAL` to module scope** — it was a function-local `const` rebuilt on every `toOrdinal` call; at module scope its `.length` derives the ordinal ceiling (can't drift) and the array is built once.

## Verification

Per locale: well-formed string or `RangeError` across `±10⁴⁰`; integer, ordinal, and decimal boundary checks all confirm `ceil−1` well-formed / `ceil` throws. Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)