### PR TITLE
fix(sr): guard scale ceilings in sr-Cyrl-RS, sr-Latn-RS

### DIFF
--- a/src/sr-Cyrl-RS.js
+++ b/src/sr-Cyrl-RS.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -81,6 +82,14 @@ const SCALE_FORMS = [
   ['квадрилион', 'квадрилиона', 'квадрилиона'],
   ['квадрилијарда', 'квадрилијарде', 'квадрилијарда'],
 ]
+
+// Supported magnitude ceilings (checked at the public entry points). Both the
+// cardinal SCALE_FORMS and the ORDINAL_SCALES tables cover units + N scale
+// groups, so values must stay below 10^((length + 1) * 3) = 10^30.
+const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 // ============================================================================
 // Segment Building
@@ -275,6 +284,11 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -480,6 +494,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -505,6 +520,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: dinars, cents: para } = parseCurrencyValue(value)
+  if (dinars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/sr-Latn-RS.js
+++ b/src/sr-Latn-RS.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -81,6 +82,14 @@ const SCALE_FORMS = [
   ['kvadrilion', 'kvadriliona', 'kvadriliona'],
   ['kvadrilijarda', 'kvadrilijarde', 'kvadrilijarda'],
 ]
+
+// Supported magnitude ceilings (checked at the public entry points). Both the
+// cardinal SCALE_FORMS and the ORDINAL_SCALES tables cover units + N scale
+// groups, so values must stay below 10^((length + 1) * 3) = 10^30.
+const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 // ============================================================================
 // Segment Building
@@ -275,6 +284,11 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -480,6 +494,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -505,6 +520,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: dinars, cents: para } = parseCurrencyValue(value)
+  if (dinars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   // Build result


### PR DESCRIPTION
Fifth in the **fix-then-gate** series. The Serbian script pair — the "TypeError crashers" from the original triage.

## What fuzzing found

Past their scale vocabulary, both variants *crashed*: cardinal and currency threw a raw `TypeError` (`Cannot read properties of undefined (reading '0')` — indexing a missing `[singular, few, many]` scale-form array), and ordinal returned `""`. Now all three throw a clean `RangeError`.

Uniform **10³⁰** ceiling across all forms: the cardinal `SCALE_FORMS` and the `ORDINAL_SCALES` tables each have 9 entries (units + 9 scale groups → 10³⁰).

## Fix

Entry-point pattern: `MAX_CARDINAL`/`MAX_ORDINAL` derived from the respective scale tables (`(length + 1) * 3`), short-circuit in `toCardinal`/`toOrdinal`/`toCurrency` after parsing. Decimal part guarded too (spelled via `integerToWords(BigInt(remainder))`); currency inherits the cardinal ceiling.

## Verification

Per variant: well-formed string or `RangeError` across `±10⁴⁰`; integer/ordinal/decimal boundary checks confirm `10³⁰−1` well-formed / `10³⁰` throws. Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)