### PR TITLE
fix(zh): guard scale ceiling in zh-Hans-CN, zh-Hant-TW

### DIFF
--- a/src/zh-Hans-CN.js
+++ b/src/zh-Hans-CN.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -34,6 +35,14 @@ const THOUSAND_FORMAL = '仟'
 // Scale words
 const WAN_WORD = '万' // 10,000
 const YI_WORD = '亿' // 100,000,000
+
+// Supported magnitude ceiling (checked at the public entry points). Numbers
+// >= 亿 (10^8) split into n / 10^8, which is then spelled by convertBelowYi —
+// itself only valid below 亿. So the ceiling is 亿² = 10^16. Ordinal (第 +
+// cardinal) and currency build on the cardinal, so they share it. Decimals are
+// spelled digit-by-digit, so they have no ceiling.
+const MAX_CARDINAL_EXPONENT = 16
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const ZERO = '零'
 const NEGATIVE = '负'
@@ -209,6 +218,7 @@ function decimalDigitsToWords(decimalString, ones) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { formal = true } = options
@@ -257,6 +267,7 @@ function integerToOrdinal(n, formal) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { formal = true } = options
   return integerToOrdinal(integerPart, formal)
 }
@@ -282,6 +293,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: yuan, cents } = parseCurrencyValue(value)
+  if (yuan >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { formal = true } = options
 
   const ones = formal ? ONES_FORMAL : ONES_COMMON

--- a/src/zh-Hant-TW.js
+++ b/src/zh-Hant-TW.js
@@ -17,6 +17,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -38,6 +39,14 @@ const THOUSAND_FORMAL = '仟'
 // Scale words - Traditional forms
 const WAN_WORD = '萬' // 10,000
 const YI_WORD = '億' // 100,000,000
+
+// Supported magnitude ceiling (checked at the public entry points). Numbers
+// >= 億 (10^8) split into n / 10^8, which is then spelled by convertBelowYi —
+// itself only valid below 億. So the ceiling is 億² = 10^16. Ordinal (第 +
+// cardinal) and currency build on the cardinal, so they share it. Decimals are
+// spelled digit-by-digit, so they have no ceiling.
+const MAX_CARDINAL_EXPONENT = 16
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const ZERO = '零'
 const NEGATIVE = '負'
@@ -221,6 +230,7 @@ function decimalDigitsToWords(decimalString, formal = true) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { formal = true } = options
@@ -272,6 +282,7 @@ function integerToOrdinal(n, formal = true) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { formal = true } = options
   return integerToOrdinal(integerPart, formal)
 }
@@ -299,6 +310,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: yuan, cents } = parseCurrencyValue(value)
+  if (yuan >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { formal = true } = options
 
   const yuanWord = formal ? YUAN_FORMAL : YUAN_COMMON


### PR DESCRIPTION
Sixth in the **fix-then-gate** series. The CJK pair (myriad/万-based, spaceless).

## What fuzzing found

Both emit garbage (`"undefined仟万亿"`) past their scale. The implementation handles `n >= 亿/億 (10⁸)` by spelling `n / 10⁸` with `convertBelowYi`, which is itself only valid below 亿 — so the real ceiling is **亿² = 10¹⁶** (pinned exactly: `10¹⁶−1` well-formed, `10¹⁶` breaks). Ordinal (`第` + cardinal) and currency both build on the cardinal, so all three share it.

## Fix

Entry-point pattern: `MAX_CARDINAL = 10¹⁶`, short-circuit in `toCardinal`/`toOrdinal`/`toCurrency` after parsing.

**Notable per-language difference: no decimal guard here.** Unlike the Western families, zh spells the fraction **digit-by-digit** (not via `integerToWords`), so a long decimal has *no* ceiling and must **not** be rejected — a 50-digit decimal still converts fine. (My probe now fuzzes long decimal strings, which confirmed both the integer-spelled-decimal bug in earlier families *and* its absence here.)

## Verification

Per variant: well-formed string or `RangeError` across `±10²⁰`; integer/ordinal boundary checks (`10¹⁶−1` ok / `10¹⁶` throws); long decimals confirmed still clean. Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)