### PR TITLE
fix(am): guard scale ceiling in am-ET, am-Latn-ET

### DIFF
--- a/src/am-ET.js
+++ b/src/am-ET.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary
@@ -52,6 +53,13 @@ const SANTIM = 'ሳንቲም'
 
 // Short scale
 const SCALE_WORDS = ['', THOUSAND, 'ሚሊዮን', 'ቢሊዮን']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALE_WORDS
+// reaches index SCALE_WORDS.length-1 (ቢሊዮን, 10^9), so values must stay below
+// 10^(SCALE_WORDS.length * 3) = 10^12. Ordinal and currency build on the
+// cardinal, so they share it. Decimals are read digit-by-digit (no ceiling).
+const MAX_CARDINAL_EXPONENT = SCALE_WORDS.length * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Precomputed Lookup Table
@@ -174,6 +182,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
 
@@ -230,6 +239,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -251,6 +261,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: birr, cents: santim } = parseCurrencyValue(value)
+  if (birr >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Build result
   let result = ''

--- a/src/am-Latn-ET.js
+++ b/src/am-Latn-ET.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary
@@ -52,6 +53,13 @@ const SANTIM = 'santim'
 
 // Short scale
 const SCALE_WORDS = ['', THOUSAND, 'miliyon', 'billiyon']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALE_WORDS
+// reaches index SCALE_WORDS.length-1 (billiyon, 10^9), so values must stay below
+// 10^(SCALE_WORDS.length * 3) = 10^12. Ordinal and currency build on the
+// cardinal, so they share it. Decimals are read digit-by-digit (no ceiling).
+const MAX_CARDINAL_EXPONENT = SCALE_WORDS.length * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Precomputed Lookup Table
@@ -178,6 +186,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
 
@@ -230,6 +239,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -250,6 +260,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: birr, cents: santim } = parseCurrencyValue(value)
+  if (birr >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Build result
   let result = ''


### PR DESCRIPTION
Seventh in the **fix-then-gate** series. Amharic (Ge'ez + Latin transliteration) — the **lowest ceiling in the corpus** at 10¹², so the most everyday-reachable of the remaining bugs.

## What fuzzing found

`SCALE_WORDS` reaches ቢሊዮን/billiyon (10⁹), so past 10¹² the lookup falls back to `''` and emits trailing/double-space output (`"አንድ "`, `"አንድ  ብር"`). Now throws `RangeError` at 10¹². Ordinal (cardinal + ኛ suffix) and currency build on the cardinal, so all three share the ceiling.

## Fix

Entry-point pattern: `MAX_CARDINAL` derived from `SCALE_WORDS.length` (`* 3`), short-circuit in `toCardinal`/`toOrdinal`/`toCurrency` after parsing.

**No decimal guard** — Amharic reads the fraction digit-by-digit (not via `integerToWords`), so a long decimal has no ceiling and must not be rejected (a 40-digit decimal still converts).

## Verification

Per variant: well-formed string or `RangeError` across `±10¹⁸`; integer/ordinal boundary (`10¹²−1` ok / `10¹²` throws); long decimals confirmed still clean. Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)