### PR TITLE
fix(he): guard scale ceilings in he-IL, hbo-IL

### DIFF
--- a/src/hbo-IL.js
+++ b/src/hbo-IL.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -38,6 +39,16 @@ const HUNDREDS_FEM = ['', 'מאה', 'מאתיים', 'שלש מאות', 'ארבע
 // Scale words (index 1 = thousands, 2 = millions, etc.)
 const SCALE = ['', 'אלף', 'מיליון', 'מיליארד', 'טריליון', 'קוודרליון', 'קווינטיליון']
 const SCALE_PLURAL = ['', 'אלפים', 'מיליונים', 'מיליארדים', 'טריליונים', 'קוודרליונים', 'קווינטיליונים']
+
+// Supported magnitude ceilings (checked at the public entry points). Cardinal
+// SCALE reaches index SCALE.length-1 (10^18), so cardinals/currency must stay
+// below 10^(SCALE.length * 3) = 10^21. Ordinals are bounded lower: past 10^6
+// the millions multiplier is built with buildScaleSegment (0-999), so n must
+// stay below 10^9. Decimals are read digit-by-digit (no ceiling).
+const MAX_CARDINAL_EXPONENT = SCALE.length * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = 9
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 const ZERO = 'אפס'
 const NEGATIVE = 'מינוס'
@@ -294,6 +305,7 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const {
@@ -435,6 +447,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
+  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(n)
 }
 
@@ -454,6 +467,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
+  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   const parts = []
 

--- a/src/he-IL.js
+++ b/src/he-IL.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -32,6 +33,16 @@ const THOUSANDS_SPECIAL = ['', 'אלף', 'אלפיים', 'שלשת אלפים', 
 // Scale words (index 1 = thousands, 2 = millions, etc.)
 const SCALE = ['', 'אלף', 'מיליון', 'מיליארד', 'טריליון', 'קוודרליון', 'קווינטיליון']
 const SCALE_PLURAL = ['', 'אלפים', 'מיליונים', 'מיליארדים', 'טריליונים', 'קוודרליונים', 'קווינטיליונים']
+
+// Supported magnitude ceilings (checked at the public entry points). Cardinal
+// SCALE reaches index SCALE.length-1 (10^18), so cardinals/currency must stay
+// below 10^(SCALE.length * 3) = 10^21. Ordinals are bounded lower: past 10^6
+// the millions multiplier is built with buildScaleSegment (0-999), so n must
+// stay below 10^9. Decimals are read digit-by-digit (no ceiling).
+const MAX_CARDINAL_EXPONENT = SCALE.length * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = 9
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 const ZERO = 'אפס'
 const NEGATIVE = 'מינוס'
@@ -273,6 +284,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Apply option defaults
   const { andWord = 'ו' } = options
@@ -422,6 +434,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
+  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(n)
 }
 
@@ -515,6 +528,7 @@ function integerToCurrencyWords(n) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
+  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   const parts = []
 


### PR DESCRIPTION
Eighth in the **fix-then-gate** series. Modern + Biblical Hebrew.

## What fuzzing found

Both emit `"undefined"` past their scale vocabulary, with **per-form ceilings**:

| form | ceiling | cause |
|---|---|---|
| cardinal / currency | 10²¹ | `SCALE` reaches 10¹⁸ (7 entries) |
| ordinal | **10⁹** | past 10⁶ the millions multiplier uses `buildScaleSegment` (0–999) → `"undefined מיליונים"` at 10⁹, same shape as the Spanish ordinal |

## Fix

Entry-point pattern: `MAX_CARDINAL` (derived from `SCALE.length`) + `MAX_ORDINAL` (10⁹) up front, short-circuit in `toCardinal`/`toOrdinal`/`toCurrency` after parsing. **No decimal guard** — Hebrew reads the fraction digit-by-digit (a 40-digit decimal still converts). `hbo-IL` (Biblical Hebrew) shares `he-IL`'s structure — and is also the corpus's one valid-BCP-47-but-not-in-CLDR tag.

## Verification

Per variant: well-formed string or `RangeError` across `±10³⁰`; integer/ordinal boundary (`10²¹`/`10⁹`); long decimals confirmed still clean. Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)