### PR TITLE
fix(az-AZ,tr-TR): guard scale ceiling in Turkic pair

### DIFF
--- a/src/az-AZ.js
+++ b/src/az-AZ.js
@@ -12,6 +12,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary
@@ -30,6 +31,14 @@ const DECIMAL_SEP = 'nöqtə'
 
 // Short scale
 const SCALE_WORDS = ['', THOUSAND, 'milyon', 'milyar', 'trilyon', 'katrilyon', 'kentilyon']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALE_WORDS
+// reaches index SCALE_WORDS.length-1 (kentilyon, 10^18), so values must stay
+// below 10^(SCALE_WORDS.length * 3) = 10^21. Ordinal builds on the cardinal
+// (integerToWords + suffix) and currency too, so all three share the ceiling —
+// and the decimal is also spelled via integerToWords, so it's guarded as well.
+const MAX_CARDINAL_EXPONENT = SCALE_WORDS.length * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -200,6 +209,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -280,6 +294,10 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  // Ordinal builds on the cardinal (integerToWords + suffix), so it shares the
+  // ceiling — past it the cardinal's trailing-space artifact would be hidden by
+  // the space-stripping and emit a silently-wrong ordinal.
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -302,6 +320,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: manat, cents: qepik } = parseCurrencyValue(value)
+  if (manat >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {

--- a/src/tr-TR.js
+++ b/src/tr-TR.js
@@ -12,6 +12,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -32,6 +33,15 @@ const DECIMAL_SEP = 'virgül'
 
 // Short scale
 const SCALES = ['milyon', 'milyar', 'trilyon', 'katrilyon', 'kentilyon']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALES is
+// indexed [scaleIndex - 2] (units and thousands are separate), so segments are
+// [units, thousands, then one per SCALES entry] -> the ceiling is
+// 10^((SCALES.length + 2) * 3) = 10^21. Ordinal (integerToWords + suffix),
+// currency, and the decimal all route through the cardinal builder, so all
+// share the ceiling.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -264,6 +274,11 @@ function decimalPartToWords(decimalPart, dropSpaces) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { dropSpaces = false } = options
@@ -349,6 +364,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -371,6 +387,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: lira, cents: kurus } = parseCurrencyValue(value)
+  if (lira >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {


### PR DESCRIPTION
Ninth in the **fix-then-gate** series. The Turkic pair (az-AZ, tr-TR) — both cap at 10²¹.

## What fuzzing found (and a probe false-negative worth noting)

Both break past their 10²¹ scale vocabulary. Uniform ceiling across all three forms (ordinal builds on the cardinal via `integerToWords` + suffix; currency too) plus the decimal (spelled via `integerToWords(BigInt(remainder))`).

**az-AZ exposed a probe blind spot.** Its ordinal does `integerToWords(n).replace(/ /g, '') + suffix`. Past 10²¹ the cardinal is the broken `"bir "` (trailing space, missing scale word) — and the space-strip turns it into `"bir"` → `"birinci"`: **well-formed but wrong** (it looks like "1st"). The well-formedness probe reported the az ordinal "clean through 10⁶⁶" because the malformation was stripped away — same silent-wrong class as es-US's truncation. Caught it by reading the code, not trusting the probe, and guarded the ordinal at the cardinal ceiling.

## Fix

Entry-point pattern. Ceilings derived from each file's scale table — az: `SCALE_WORDS.length * 3`; tr: `(SCALES.length + 2) * 3` (tr indexes `SCALES[scaleIndex - 2]`, with units/thousands separate, like da-DK). Decimal guarded (integer-spelled).

## Verification

Per variant: well-formed string or `RangeError` across `±10³⁰`; integer / **ordinal** / decimal boundary checks all confirm `10²¹−1` ok / `10²¹` throws (the az ordinal now throws instead of returning `"birinci"`). Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)