### PR TITLE
fix(de-DE,nl-NL): guard scale ceilings in the Germanic pair

### DIFF
--- a/src/de-DE.js
+++ b/src/de-DE.js
@@ -15,6 +15,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -38,6 +39,14 @@ const SCALES = ['tausend', 'Million', 'Milliarde', 'Billion', 'Billiarde', 'Tril
 
 // Pluralized scale words (million+)
 const SCALES_PLURAL = ['tausend', 'Millionen', 'Milliarden', 'Billionen', 'Billiarden', 'Trillionen', 'Trilliarden', 'Quadrillionen', 'Quadrilliarden']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALES is
+// indexed [scaleIndex - 1] starting at 'tausend' (10^3), so segments are
+// [units, then one per SCALES entry] -> ceiling 10^((SCALES.length + 1) * 3) =
+// 10^30. Ordinal (cardinal + suffix) and currency build on the cardinal, and
+// the decimal is spelled via integerToWords, so all share the ceiling.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const HUNDRED = 'hundert'
 const ZERO = 'null'
@@ -326,6 +335,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -544,6 +558,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -569,6 +584,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/nl-NL.js
+++ b/src/nl-NL.js
@@ -16,6 +16,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -30,6 +31,20 @@ const HUNDRED = 'honderd'
 
 // Scale words (long scale with -ard forms)
 const SCALES = ['duizend', 'miljoen', 'miljard', 'biljoen', 'biljard', 'triljoen', 'triljard', 'quadriljoen', 'quadriljard']
+
+// Scale ordinal words. Module-scope so its length can derive the ordinal
+// ceiling and so it isn't rebuilt on every call.
+const SCALE_ORDINAL = ['', 'duizendste', 'miljoenste', 'miljardste', 'biljoenste', 'biljardste', 'triljoenste']
+
+// Supported magnitude ceilings (checked at the public entry points). SCALES is
+// indexed [scaleIndex - 1] from 'duizend' (10^3), so cardinals/currency reach
+// 10^((SCALES.length + 1) * 3) = 10^30. The ordinal of a number whose lowest
+// non-zero group is a scale group uses the shorter SCALE_ORDINAL, so ordinals
+// are bounded at 10^(SCALE_ORDINAL.length * 3) = 10^21.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = SCALE_ORDINAL.length * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 const ZERO = 'nul'
 const NEGATIVE = 'min'
@@ -315,6 +330,11 @@ function decimalPartToWords(decimalPart, options) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const {
@@ -418,6 +438,7 @@ function buildOrdinalSegment(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
+  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
 
   // Fast path: 1-9
   if (n < 10n) return ORDINAL_ONES[Number(n)]
@@ -459,9 +480,6 @@ function buildLargeOrdinal(n) {
       break
     }
   }
-
-  // Scale ordinal words
-  const SCALE_ORDINAL = ['', 'duizendste', 'miljoenste', 'miljardste', 'biljoenste', 'biljardste', 'triljoenste']
 
   let result = ''
 
@@ -539,6 +557,7 @@ function buildLargeOrdinal(n) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and = true } = options
 
   let result = ''


### PR DESCRIPTION
Tenth in the **fix-then-gate** series. German + Dutch.

## What fuzzing found

Both emit `"undefined"` past their long-scale vocabulary:

| | cardinal | ordinal | currency |
|---|---|---|---|
| de-DE | 10³⁰ | 10³⁰ (cardinal + `ste`) | 10³⁰ |
| nl-NL | 10³⁰ | **10²¹** | 10³⁰ |

de-DE is uniform (ordinal/currency build on the cardinal). nl-NL's ordinal caps lower because it uses a shorter `SCALE_ORDINAL` table (like pt) — for a number whose lowest non-zero group is a scale group.

## Fix

Entry-point pattern. Cardinal ceiling derived from `SCALES` (`(length + 1) * 3`, indexed from `duizend`/`tausend` at 10³). nl's `SCALE_ORDINAL` **hoisted to module scope** so its `.length` derives `MAX_ORDINAL` (and it's no longer rebuilt per call). Decimal guarded in both (integer-spelled fractions).

## Verification

Per locale: well-formed string or `RangeError` across `±10⁴⁰`; integer/ordinal/decimal boundaries confirm `ceil−1` ok / `ceil` throws (de ord 10³⁰, nl ord 10²¹). Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)