### PR TITLE
fix(ru-RU,uk-UA,pl-PL,hr-HR): guard scale ceilings in the Slavic group

### DIFF
--- a/src/hr-HR.js
+++ b/src/hr-HR.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -257,6 +258,14 @@ function decimalPartToWords(decimalPart, gender) {
   return result
 }
 
+// Supported magnitude ceilings (checked at the public entry points). Both
+// tables are indexed [scaleIndex - 1] (units separate), so the ceiling is
+// 10^((length + 1) * 3): cardinal/currency 10^30, ordinal 10^15.
+const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+
 /**
  * Converts a numeric value to Croatian words.
  * @param {number | string | bigint} value - The numeric value to convert
@@ -267,6 +276,11 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -444,6 +458,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -465,6 +480,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {

--- a/src/pl-PL.js
+++ b/src/pl-PL.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -304,6 +305,16 @@ function decimalPartToWords(decimalPart, gender) {
   return result
 }
 
+// Supported magnitude ceilings (checked at the public entry points). PLURAL_FORMS
+// is keyed 1..N (units separate), so cardinal/currency reach 10^((keys + 1) * 3)
+// = 10^33; the shorter ORDINAL_SCALES bounds ordinals at 10^((length + 1) * 3) =
+// 10^24. (Past the cardinal ceiling the fraction would spell silently-wrong, so
+// the decimal is guarded too.)
+const MAX_CARDINAL_EXPONENT = (Object.keys(PLURAL_FORMS).length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+
 /**
  * Converts a numeric value to Polish words.
  *
@@ -324,6 +335,11 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -530,6 +546,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -551,6 +568,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: zloty, cents: grosze } = parseCurrencyValue(value)
+  if (zloty >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {

--- a/src/pl-PL.js
+++ b/src/pl-PL.js
@@ -306,11 +306,13 @@ function decimalPartToWords(decimalPart, gender) {
 }
 
 // Supported magnitude ceilings (checked at the public entry points). PLURAL_FORMS
-// is keyed 1..N (units separate), so cardinal/currency reach 10^((keys + 1) * 3)
-// = 10^33; the shorter ORDINAL_SCALES bounds ordinals at 10^((length + 1) * 3) =
-// 10^24. (Past the cardinal ceiling the fraction would spell silently-wrong, so
-// the decimal is guarded too.)
-const MAX_CARDINAL_EXPONENT = (Object.keys(PLURAL_FORMS).length + 1) * 3
+// is keyed by scale level (1 = thousands, …), units separate, so cardinal/
+// currency reach 10^((maxScaleKey + 1) * 3) = 10^33; the shorter ORDINAL_SCALES
+// bounds ordinals at 10^((length + 1) * 3) = 10^24. (Past the cardinal ceiling
+// the fraction would spell silently-wrong, so the decimal is guarded too.)
+// Derive from the max numeric key (robust to gaps / non-scale keys).
+const MAX_SCALE_KEY = Math.max(...Object.keys(PLURAL_FORMS).map(Number))
+const MAX_CARDINAL_EXPONENT = (MAX_SCALE_KEY + 1) * 3
 const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
 const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)

--- a/src/ru-RU.js
+++ b/src/ru-RU.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -293,6 +294,14 @@ function decimalPartToWords(decimalPart, gender) {
   return result
 }
 
+// Supported magnitude ceilings (checked at the public entry points). Both
+// tables are indexed [scaleIndex - 1] (units separate), so the ceiling is
+// 10^((length + 1) * 3): cardinal/currency 10^33, ordinal 10^33.
+const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+
 /**
  * Converts a numeric value to Russian words.
  * @param {number | string | bigint} value - The numeric value to convert
@@ -303,6 +312,11 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -512,6 +526,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -537,6 +552,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: rubles, cents: kopecks } = parseCurrencyValue(value)
+  if (rubles >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/uk-UA.js
+++ b/src/uk-UA.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -257,6 +258,14 @@ function decimalPartToWords(decimalPart, gender) {
   return result
 }
 
+// Supported magnitude ceilings (checked at the public entry points). Both
+// tables are indexed [scaleIndex - 1] (units separate), so the ceiling is
+// 10^((length + 1) * 3): cardinal/currency 10^30, ordinal 10^15.
+const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+
 /**
  * Converts a numeric value to Ukrainian words.
  * @param {number | string | bigint} value - The numeric value to convert
@@ -267,6 +276,11 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -444,6 +458,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -465,6 +480,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: hryvnia, cents: kopiyky } = parseCurrencyValue(value)
+  if (hryvnia >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {


### PR DESCRIPTION
Twelfth in the **fix-then-gate** series. Four Slavic languages, each verified individually (their ceilings genuinely differ).

| | cardinal/currency | ordinal | notes |
|---|---|---|---|
| ru-RU | 10³³ | 10³³ | TypeError crasher |
| uk-UA | 10³⁰ | 10¹⁵ | TypeError crasher |
| pl-PL | 10³³ | 10²⁴ | object-keyed scale; **silently-wrong** decimal |
| hr-HR | 10³⁰ | 10¹⁵ | TypeError crasher |

## Notable: pl-PL decimal (another probe false-negative)

pl's decimal *looked* clean to the well-formedness probe even at 40 digits — but above 10³³ it's **silently wrong** (spelled via `integerToWords` past its scale words, dropping magnitude rather than emitting `undefined`), the same class as the az ordinal. Guarded by **code analysis**, not the probe's verdict.

## Fix

Entry-point pattern; ceilings derived from each table (`(length + 1) * 3`, units separate; pl uses `Object.keys(PLURAL_FORMS).length`). Decimal guarded in all four (integer-spelled fractions). The 3 SCALE_FORMS/ORDINAL_SCALES tables were already module-scope.

## Verification

Per locale: well-formed string or `RangeError` across `±10⁴⁰`; integer/ordinal/decimal boundaries confirm `ceil−1` ok / `ceil` throws. Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)