### PR TITLE
fix(nb-NO,sv-SE,fi-FI): guard scale ceilings in the Nordic group

### DIFF
--- a/src/fi-FI.js
+++ b/src/fi-FI.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -35,6 +36,14 @@ const DECIMAL_SEP = 'pilkku'
 
 // Long scale
 const SCALES = ['miljoona', 'miljardi', 'biljoona', 'triljoona']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALES is
+// indexed [scaleIndex - 2] (units and thousands separate), so the ceiling is
+// 10^((SCALES.length + 2) * 3) = 10^18. Ordinal (cardinal + suffix) and currency
+// build on the cardinal, so they share it. Decimals are read digit-by-digit
+// (no ceiling).
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -247,6 +256,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
 
@@ -329,6 +339,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -352,6 +363,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {

--- a/src/nb-NO.js
+++ b/src/nb-NO.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -32,6 +33,14 @@ const DECIMAL_SEP = 'komma'
 
 // Short scale: million, milliard, billion, etc.
 const SCALES = ['million', 'milliard', 'billion', 'billiard', 'kvintillion', 'sekstillion', 'septillion', 'oktillion']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALES is
+// indexed [scaleIndex - 2] (units and thousands separate), so segments are
+// [units, thousands, then one per SCALES entry] -> ceiling 10^((SCALES.length +
+// 2) * 3) = 10^30. Ordinal (cardinal + suffix) and currency build on the
+// cardinal, and the decimal is spelled via integerToWords, so all share it.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 2) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -300,6 +309,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -375,6 +389,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -397,6 +412,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: kroner, cents: ore } = parseCurrencyValue(value)
+  if (kroner >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {

--- a/src/sv-SE.js
+++ b/src/sv-SE.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -32,6 +33,14 @@ const DECIMAL_SEP = 'komma'
 
 // Scale words (long scale with -ard forms)
 const SCALES = ['tusen', 'miljon', 'miljard', 'biljon', 'biljard', 'triljon', 'triljard', 'kvadriljon']
+
+// Supported magnitude ceiling (checked at the public entry points). SCALES is
+// indexed [scaleIndex - 1] from 'tusen' (10^3), so segments are [units, then
+// one per SCALES entry] -> ceiling 10^((SCALES.length + 1) * 3) = 10^27.
+// Ordinal (cardinal + suffix) and currency build on the cardinal, and the
+// decimal is spelled via integerToWords, so all share it.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 3
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -309,6 +318,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -365,6 +379,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -387,6 +402,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: kronor, cents: ore } = parseCurrencyValue(value)
+  if (kronor >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {


### PR DESCRIPTION
Thirteenth in the **fix-then-gate** series. Three Nordic languages, each verified individually (distinct ceilings).

| | ceiling | decimal guard | SCALES |
|---|---|---|---|
| nb-NO | 10³⁰ | yes | `[scaleIndex-2]`, 8 entries |
| sv-SE | 10²⁷ | yes | `[scaleIndex-1]` from `tusen`, 8 entries |
| fi-FI | 10¹⁸ | **no** | `[scaleIndex-2]`, 4 entries |

All three: ordinal (cardinal + suffix) and currency build on the cardinal, so one `MAX_CARDINAL` guards every form. **fi-FI** reads its fraction digit-by-digit, so a long decimal has no ceiling and is correctly *not* guarded (a 40-digit decimal still converts); nb/sv spell the fraction via `integerToWords`, so they are.

## Verification

Per locale: well-formed string or `RangeError` across `±10⁴⁰`; integer/ordinal/decimal boundaries confirm `ceil−1` ok / `ceil` throws. Existing fixtures green, lint clean, 269 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)