### PR TITLE
fix(it-IT,ja-JP,vi-VN,cs-CZ,ro-RO): guard scale ceilings

### DIFF
--- a/src/cs-CZ.js
+++ b/src/cs-CZ.js
@@ -14,6 +14,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -44,6 +45,11 @@ const PLURAL_FORMS = {
   8: ['kvadrilion', 'kvadriliony', 'kvadrilionů'], // 10^24
   9: ['kvadriliarda', 'kvadriliardy', 'kvadriliard'], // 10^27
 }
+
+// PLURAL_FORMS is keyed by 1000-power; past its largest key the builder drops the
+// scale word (cardinal) or dereferences undefined (ordinal), so cap there.
+const MAX_CARDINAL_EXPONENT = 3 * (Math.max(...Object.keys(PLURAL_FORMS).map(Number)) + 1)
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const ZERO = 'nula'
 const NEGATIVE = 'mínus'
@@ -339,6 +345,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -505,6 +516,8 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  // Ordinals reuse the cardinal scale table, so they share its ceiling.
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -526,6 +539,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: koruny, cents: halere } = parseCurrencyValue(value)
+  if (koruny >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {

--- a/src/it-IT.js
+++ b/src/it-IT.js
@@ -15,6 +15,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -41,6 +42,11 @@ const THOUSAND_PLURAL_SUFFIX = 'mila'
 
 // Scale word generation
 const SCALE_PREFIXES = ['m', 'b', 'tr', 'quadr', 'quint', 'sest', 'sett', 'ott', 'nov', 'dec']
+
+// Long scale: each prefix yields an -ilione (10^6k) and an -iliardo (10^6k+3),
+// so the table spans 6 powers of ten per prefix; past it the scale word is empty.
+const MAX_CARDINAL_EXPONENT = 6 * (SCALE_PREFIXES.length + 1)
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -352,6 +358,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -445,6 +456,8 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  // Ordinals are derived from the cardinal speller, so they share its ceiling.
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -470,6 +483,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centesimi } = parseCurrencyValue(value)
+  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/ja-JP.js
+++ b/src/ja-JP.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -42,6 +43,11 @@ const SCALES = [
   '不可思議', // 10^64 (fukashigi)
   '無量大数', // 10^68 (muryōtaisū)
 ]
+
+// Myriad (4-digit) grouping: each scale word covers a power of 10,000, so the
+// table reaches 10^(4 * SCALES.length); the next group has no scale word.
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 4
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const ZERO = '零'
 const NEGATIVE = 'マイナス'
@@ -247,6 +253,8 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // The fraction is spelled digit by digit, so only the integer part has a ceiling.
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
 
@@ -291,6 +299,8 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  // Ordinals prefix the cardinal speller, so they share its ceiling.
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -315,6 +325,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: yen, cents: sen } = parseCurrencyValue(value)
+  if (yen >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   // Build result
   let result = ''

--- a/src/ro-RO.js
+++ b/src/ro-RO.js
@@ -13,6 +13,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -64,6 +65,14 @@ const SCALE_META = [
   { singular: 'septilion', plural: 'septilioane', article: 'un', feminine: false, needsDe: true },
   { singular: 'octilion', plural: 'octilioane', article: 'un', feminine: false, needsDe: true },
 ]
+
+// Cardinal scale words run thousand..octilion; past SCALE_META the builder drops
+// the scale word. The ordinal spells its millions multiplier via spellUnder1000
+// (0-999), so it overflows once that multiplier reaches 1000 — n must stay below 10^9.
+const MAX_CARDINAL_EXPONENT = 3 * (SCALE_META.length + 1)
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_ORDINAL_EXPONENT = 9
+const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
 
 // ============================================================================
 // Helper Functions
@@ -259,6 +268,11 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -396,6 +410,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
+  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
   return integerToOrdinal(n)
 }
 
@@ -415,6 +430,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
+  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   const parts = []
 

--- a/src/vi-VN.js
+++ b/src/vi-VN.js
@@ -12,6 +12,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -28,6 +29,11 @@ const SCALES = [
   'Tredecillion', 'Quattuordecillion', 'Sexdecillion',
   'Septendecillion', 'Octodecillion', 'Novemdecillion', 'Vigintillion',
 ]
+
+// 3-digit grouping with SCALES[0] = '' (units); the table reaches
+// 10^(3 * (SCALES.length - 1)), so values from 10^(3 * SCALES.length) up have no scale word.
+const MAX_CARDINAL_EXPONENT = 3 * SCALES.length
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const HUNDRED = 'trăm'
 const ZERO = 'không'
@@ -293,6 +299,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -344,6 +355,8 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
+  // Ordinals are built from the cardinal speller, so they share its ceiling.
+  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(integerPart)
 }
 
@@ -367,6 +380,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: dong } = parseCurrencyValue(value)
+  if (dong >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   let result = ''
   if (isNegative) {


### PR DESCRIPTION
## Summary

The final five contract-violators in the scale-ceiling series. Each gets entry-point guards that throw a uniform `RangeError` (via the shared `too-large-error` helper) past the ceiling **derived from its own scale table**. Builders are untouched and still assume in-range input.

Their break modes differ — and **three were invisible to well-formedness fuzzing**: they returned *well-formed-but-wrong* strings (silently dropped scale words) and were caught only by reading the builders.

| Lang | Structure | Ceiling | Notes |
|---|---|---|---|
| `it-IT` | long-scale prefixes (`-ilione`/`-iliardo`) | `6*(SCALE_PREFIXES.length+1)` = **10^66** | Cardinal left a trailing space; ordinal reuses the cardinal speller and munged it into a plausible `"<x> esimo"` (scale word dropped). Both guarded at the cardinal ceiling. |
| `ja-JP` | myriad (4-digit) groups | `(SCALES.length+1)*4` = **10^72** | `"undefined"` past 無量大数. Decimal is digit-by-digit → only the integer part is guarded. |
| `vi-VN` | 3-digit groups (`SCALES[0]=''`) | `3*SCALES.length` = **10^63** | `"undefined"` past the table. Integer-spelled decimal → decimal guard. |
| `cs-CZ` | object-keyed `PLURAL_FORMS` | `3*(max key+1)` = **10^30** | Cardinal dropped the scale word past 10^27 (silently wrong); ordinal dereferenced an undefined entry → `TypeError` at 10^30. Single ceiling. |
| `ro-RO` | `SCALE_META`-driven | card `3*(SCALE_META.length+1)` = **10^30**, ord **10^9** | Cardinal dropped the scale word past octilion. Ordinal spells its millions multiplier via `spellUnder1000` (0-999), overflowing at a 1000+ multiplier → lower separate ceiling (`MAX_ORDINAL`). Currency spells via the cardinal path → shares the cardinal ceiling. |

## Verification

- Per-language boundary checks: throws at the ceiling, well-formed at ceiling−1, for all three forms; decimal guard fires where the fraction is integer-spelled; ja-JP's digit-by-digit decimals are **not** over-restricted (200-digit fractions still spell).
- fast-check property (cardinal/decimal/ordinal/currency) across −10^309..10^309 for each.
- `npm test`: 269 passing; lint clean.

With this, all 21 remaining contract-violators are fixed (16 `en-*` in #363 + these 5). The fast-check **gate** lands next to enforce the contract permanently and auto-cover new languages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)