### PR TITLE
docs(core): align CLAUDE.md with the scale-ceiling contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,8 +25,9 @@ src/
 
 ## Language File Pattern
 
-Every language exports all three forms: `toCardinal`, `toOrdinal`, `toCurrency`. Each must
-uphold the **conversion contract** (enforced by `test/contract.test.js`): for *any* input,
+A language exports one, two, or all three forms — `toCardinal`, `toOrdinal`, `toCurrency`
+(at least one; forms are added incrementally, so export only what you implement). Each form
+it exports must uphold the **conversion contract** (enforced by `test/contract.test.js`): for *any* input,
 return a well-formed string **or** throw `RangeError` — never malformed output. Past the
 largest scale word your tables can name, throw `tooLargeError(maxExponent)` — don't invent
 vocabulary. Derive the ceiling from the scale table so it can't drift, and guard at the
@@ -99,11 +100,11 @@ function toCardinal (value, options) {
 npm run lang:add -- <code>  # Creates stub + fixture + type tests
 ```
 
-Then: implement all three forms (`toCardinal`, `toOrdinal`, `toCurrency`) in `src/{code}.js` — **including the scale-ceiling guards** (see Language File Pattern) — add cases to `test/fixtures/{code}.js`, run `npm test`.
+Then: implement the form(s) you're adding (`toCardinal`, `toOrdinal`, and/or `toCurrency` — at least one) in `src/{code}.js` — **including the scale-ceiling guards** (see Language File Pattern) — add cases to `test/fixtures/{code}.js`, run `npm test`.
 
 A new language must clear three enforced gates (in `test/`):
 
-- **Contract** (`contract.test.js`): every form returns a well-formed string or throws `RangeError` for any input.
+- **Contract** (`contract.test.js`): every exported form returns a well-formed string or throws `RangeError` for any input.
 - **Coverage** (`conversions.test.js`): ≥5 fixture cases per form.
 - **Canonical code** (`conversions.test.js`): the filename is canonical BCP 47 (`en-US`, not `en-us`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ src/
     ├── parse-cardinal.js    # Cardinal form parsing (decimals, negatives)
     ├── parse-ordinal.js     # Ordinal form parsing (positive integers only)
     ├── parse-currency.js    # Currency form parsing (dollars, cents)
+    ├── too-large-error.js   # RangeError for values past a language's scale ceiling
     ├── expand-scientific.js # Scientific notation expansion
     ├── is-plain-object.js   # Object type checking
     └── validate-options.js  # Options validation
@@ -24,30 +25,54 @@ src/
 
 ## Language File Pattern
 
-Every language exports all three forms: `toCardinal`, `toOrdinal`, `toCurrency`.
+Every language exports all three forms: `toCardinal`, `toOrdinal`, `toCurrency`. Each must
+uphold the **conversion contract** (enforced by `test/contract.test.js`): for *any* input,
+return a well-formed string **or** throw `RangeError` — never malformed output. Past the
+largest scale word your tables can name, throw `tooLargeError(maxExponent)` — don't invent
+vocabulary. Derive the ceiling from the scale table so it can't drift, and guard at the
+entry point (O(1), before building).
 
 ```javascript
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
+
+const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 3 // derive from your own table
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 function toCardinal (value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Guard the decimal part too when the fraction routes through the scale builder
+  // (omit that clause for digit-by-digit languages, which have no decimal ceiling).
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
   // integerPart is bigint, handle isNegative prefix and decimalPart suffix
 }
 
 function toOrdinal (value) {
   const integerPart = parseOrdinalValue(value)
+  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT) // define likewise; often lower
   // positive integers only
 }
 
 function toCurrency (value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
+  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT) // cents are ≤ 99, safe
   // dollars/cents are bigints
 }
 
 export { toCardinal, toOrdinal, toCurrency }
 ```
+
+Beware **silently-wrong** builders: if yours drops the scale word past its table (e.g.
+`if (SCALES[i - 1])`, `if (!meta) return …`) it returns well-formed-but-wrong output that
+fuzzing can't catch — derive the ceiling by reading the table, not by probing for garbage.
+
+Language files are **self-contained**: duplicate small helpers rather than share them.
+Extract a util only for the API contract (parsing, options, the too-large error) or
+genuinely universal single-purpose logic.
 
 ## Options Pattern
 
@@ -74,7 +99,13 @@ function toCardinal (value, options) {
 npm run lang:add -- <code>  # Creates stub + fixture + type tests
 ```
 
-Then: implement all three forms (`toCardinal`, `toOrdinal`, `toCurrency`) in `src/{code}.js`, add cases to `test/fixtures/{code}.js`, run `npm test`.
+Then: implement all three forms (`toCardinal`, `toOrdinal`, `toCurrency`) in `src/{code}.js` — **including the scale-ceiling guards** (see Language File Pattern) — add cases to `test/fixtures/{code}.js`, run `npm test`.
+
+A new language must clear three enforced gates (in `test/`):
+
+- **Contract** (`contract.test.js`): every form returns a well-formed string or throws `RangeError` for any input.
+- **Coverage** (`conversions.test.js`): ≥5 fixture cases per form.
+- **Canonical code** (`conversions.test.js`): the filename is canonical BCP 47 (`en-US`, not `en-us`).
 
 **Reference implementations by pattern**:
 
@@ -102,11 +133,12 @@ npm run bench -- en-US --full    # Longer run (more iterations)
 
 ## Commits
 
-Conventional Commits required. Scopes: BCP 47 codes (`en-US`, `fr-BE`) or project areas (`core`, `types`, `umd`).
+Conventional Commits required. Scopes: BCP 47 codes — one (`en-US`), comma-separated (`az-AZ,tr-TR`), or a bare primary subtag for a variant family (`en`, `es`) — or project areas (`core`, `esm`, `umd`, `types`, `deps`). Family names like `slavic`/`turkic` are **not** valid scopes.
 
 ```bash
 feat(pt-BR): add Brazilian Portuguese
 fix(en-US): correct thousand handling
+fix(az-AZ,tr-TR): guard scale ceilings
 perf(ja-JP): optimize BigInt handling
 ```
 


### PR DESCRIPTION
## Why

After the scale-ceiling series (#347–#365), `CLAUDE.md` drifted out of sync with what CI now enforces. Most notably, following the **Language File Pattern** stub verbatim produced a language that **fails the new contract gate** (`test/contract.test.js`) — the stub had no `tooLargeError` guard. This realigns the doc.

## Changes

- **Language File Pattern** — states the conversion contract (well-formed string or `RangeError` for any input) and shows the ceiling guards in the stub (derive `MAX_*` from the scale table, guard at the entry point; decimal clause only when the fraction routes through the builder). Adds a warning about *silently-wrong* builders that drop the scale word past their table (well-formed but wrong → invisible to fuzzing) — the recurring trap of this whole series.
- **Self-contained principle** — written down for the first time: duplicate small helpers rather than share; extract a util only for the API contract or universal single-purpose logic.
- **Adding a Language** — lists the three enforced gates a new language must clear: contract, ≥5 fixture cases per form, canonical BCP 47 filename.
- **Project Structure** — adds the `too-large-error.js` util.
- **Commits** — documents comma-separated code scopes (`az-AZ,tr-TR`) and bare primary-subtag family scopes (`en`, `es`); notes family names (`slavic`/`turkic`) are invalid.

Doc-only; no source or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)