### PR TITLE
docs(core): correct README range and per-language form claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **Multiple Forms** — Cardinal ("forty-two"), ordinal ("forty-second"), and currency ("forty-two dollars")
 - **70+ Languages** — European, Asian, Middle Eastern, African, and regional variants
 - **Zero Dependencies** — Works everywhere: Node.js, browsers, Deno, Bun
-- **BigInt Support** — Handle arbitrarily large numbers without precision loss
+- **BigInt Support** — Convert large numbers as `BigInt` without precision loss
 - **Type-Safe** — Full TypeScript support with generated `.d.ts` declarations
 
 ## Quick Start
@@ -52,7 +52,9 @@ toOrdinal(1234)       // 'one thousand two hundred thirty-fourth'
 toCurrency(1234.56)   // 'one thousand two hundred thirty-four dollars and fifty-six cents'
 ```
 
-All languages support all three forms. See [LANGUAGES.md](LANGUAGES.md) for details.
+Each language implements one or more of these forms — see [LANGUAGES.md](LANGUAGES.md) for per-language coverage.
+
+> **Range:** each language spells values up to its largest named scale word and throws a `RangeError` beyond that, rather than inventing vocabulary (`en-US`, for instance, handles up to 10^66 − 1). Cardinal and currency accept negatives and decimals; ordinal is positive integers only.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - **Multiple Forms** — Cardinal ("forty-two"), ordinal ("forty-second"), and currency ("forty-two dollars")
 - **70+ Languages** — European, Asian, Middle Eastern, African, and regional variants
 - **Zero Dependencies** — Works everywhere: Node.js, browsers, Deno, Bun
-- **BigInt Support** — Convert large numbers as `BigInt` without precision loss
+- **BigInt Support** — Accepts `bigint` (and numeric-string) input, so large values keep full precision
 - **Type-Safe** — Full TypeScript support with generated `.d.ts` declarations
 
 ## Quick Start
@@ -54,7 +54,7 @@ toCurrency(1234.56)   // 'one thousand two hundred thirty-four dollars and fifty
 
 Each language implements one or more of these forms — see [LANGUAGES.md](LANGUAGES.md) for per-language coverage.
 
-> **Range:** each language spells values up to its largest named scale word and throws a `RangeError` beyond that, rather than inventing vocabulary (`en-US`, for instance, handles up to 10^66 − 1). Cardinal and currency accept negatives and decimals; ordinal is positive integers only.
+> **Range:** each form spells values up to the largest scale word it knows, then throws a `RangeError` rather than inventing vocabulary — and the ceiling varies by language *and* form (e.g. `es-ES` cardinals reach 10^30 − 1, ordinals only 10^9 − 1). Cardinal and currency accept negatives and decimals; ordinal is positive integers only.
 
 ## Usage
 


### PR DESCRIPTION
## What

Two README claims drifted out of sync with current behavior/policy after the scale-ceiling series and the incremental-forms clarification.

### 1. "Handle arbitrarily large numbers" → bounded, with a `RangeError`
Past a language's largest named scale word, **every** form now throws `RangeError` (e.g. `en-US` tops out at 10^66 − 1). Verified for cardinal, ordinal, and currency. Softens the BigInt bullet and adds a short **Range** note documenting the ceiling and the supported input domain (cardinal/currency take negatives and decimals; ordinal is positive integers only).

### 2. "All languages support all three forms" → per-language coverage
Contradicts the incremental-forms policy (a language may ship a subset; `conversions.test.js`/`contract.test.js` require only *at least one*). It's currently true (72/72) but brittle, and `LANGUAGES.md` already tracks per-form coverage with caveats (`ar-SA ✓*`). Reworded to point at that table.

## Not touched (verified correct)
The UMD global shape (`n2words.enUS`, `n2words.ordinal.enUS`, `n2words.currency.enUS`), the `dist/en-US.js` / `dist/en-US.umd.js` CDN paths, the ESM import examples, **and the Coveralls badge** (CI does upload via `coverallsapp/github-action`; the badge is live at 97%) all match reality.

Doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)