### PR TITLE
chore(core): make coverage thresholds a single source of truth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      # Strict checkJs over src (tsconfig.typecheck.json, noEmit) — fast type
+      # Strict checkJs over src (tsconfig.build.json, noEmit) — fast type
       # gate that fails in the cheap lint job before the test matrix. The
       # shipped declarations are independently gated by build:types
       # (checkJs + noEmitOnError) in the test job and prepack.
@@ -101,7 +101,7 @@ jobs:
 
       - name: Check coverage thresholds
         if: ${{ matrix.coverage }}
-        run: npx c8 check-coverage --lines 90 --functions 90 --branches 85 --statements 90
+        run: npm run coverage:check
 
       - name: Generate coverage summary
         if: ${{ matrix.coverage }}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "clean:dist": "rimraf dist",
     "clean:types": "rimraf \"src/**/*.d.ts\" --glob",
     "coverage": "c8 node --run test:unit",
+    "coverage:check": "c8 check-coverage",
     "docs:languages": "node scripts/generate-languages-md.js",
     "lang:add": "node scripts/add-language.js",
     "lint": "node --run lint:js && node --run lint:md",
@@ -111,7 +112,11 @@
       "lcov",
       "text",
       "json-summary"
-    ]
+    ],
+    "lines": 90,
+    "statements": 90,
+    "functions": 90,
+    "branches": 85
   },
   "lint-staged": {
     "*.{js,cjs,mjs}": [


### PR DESCRIPTION
## Why

From the end-to-end coverage-pipeline audit: thresholds lived **only** as inline flags in the CI "Check coverage thresholds" step (`npx c8 check-coverage --lines 90 …`). So `npm run coverage` locally neither enforced nor displayed the bar — CI and local could drift, and the gate was invisible to contributors.

## What

- Move the thresholds into the `c8` block in `package.json` (`lines`/`statements`/`functions` 90, `branches` 85) — one source of truth.
- Add `"coverage:check": "c8 check-coverage"` (reads the thresholds from config).
- CI's threshold step now runs `npm run coverage:check` instead of repeating the numbers.
- `npm run coverage` stays **report-only** (no `check-coverage: true`), so the gate is opt-in locally (`npm run coverage:check`) and identical to CI.

Bycatch: fixed a stale comment in `ci.yml` that referenced a nonexistent `tsconfig.typecheck.json` — typecheck actually uses `tsconfig.build.json --noEmit`.

## Verified

- `c8 check-coverage` genuinely reads the config thresholds: a temporary `lines: 99` produced `ERROR: Coverage for lines (97.23%) does not meet global threshold (99%)`; the committed `90` passes at ~97%.
- `npm run coverage` still exits 0 (report-only, not gated).
- No behavior change to the Coveralls upload, badge, or the actual numbers gated.

Follow-up to the coverage-pipeline audit (the audit's only substantive finding; its "permissions blocker" was a false positive — the `coverage/coveralls` status posts via Coveralls' GitHub App, verified `SUCCESS` on recent PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)