### PR TITLE
fix(ka-GE): guard scale ceiling

### DIFF
--- a/src/ka-GE.js
+++ b/src/ka-GE.js
@@ -15,6 +15,7 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -40,6 +41,12 @@ const THOUSAND_STEM = 'ათას' // Without final vowel
 
 // Scale words (short scale) - indexed by segment position
 const SCALES = ['', '', 'მილიონი', 'მილიარდი', 'ტრილიონი', 'კვადრილიონი', 'კვინტილიონი', 'სექსტილიონი']
+
+// 3-digit grouping; the table tops out at sextillion. Past it the builder clamps
+// to the last scale word (`SCALES[scaleIndex] || SCALES[SCALES.length - 1]`),
+// silently collapsing the magnitude — so cap there.
+const MAX_CARDINAL_EXPONENT = 3 * SCALES.length
+const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
 
 const ZERO = 'ნული'
 const NEGATIVE = 'მინუს'
@@ -281,6 +288,11 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
+  // Both the integer part and the decimal's significant digits are spelled via
+  // the scale builder, so both must clear the ceiling.
+  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
+    throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  }
 
   let result = ''
 
@@ -342,6 +354,8 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
+  // Ordinals build on the cardinal speller, so they share its ceiling.
+  if (n >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
   return integerToOrdinal(n)
 }
 
@@ -361,6 +375,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
+  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
 
   const parts = []
 


### PR DESCRIPTION
## What

Georgian capped its scale vocabulary at sextillion and **clamped everything above it**: the builder uses `SCALES[scaleIndex] || SCALES[SCALES.length - 1]`, so any 3-digit group past sextillion reuses "sextillion" and the magnitude collapses. `10²¹` and `10²⁴` both spelled to `ერთი სექსტილიონი` ("one sextillion") — well-formed but wrong, invisible to the contract gate.

Surfaced while computing per-language max ranges for `LANGUAGES.md`.

## Fix

Entry-point guards, ceiling `3 * SCALES.length = 10²⁴`. Cardinal guards the integer part plus the integer-spelled decimal; ordinal (`integerToOrdinal` → `integerToWords`) and currency (`integerToWords(dollars)`) build on the cardinal speller, so they share the ceiling. Builder untouched.

## Verified

Throws `RangeError` at 10²⁴ for all three forms, well-formed/magnitude-preserving at 10²⁴−1, decimal guard fires, fast-check sweep −10³⁰⁹..10³⁰⁹. `npm test`: 341 passing; lint clean.

Companion to #370 — together they close the silent-scale-drop class the original series missed (found via the max-range work). Next: the `LANGUAGES.md` max-range column itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)