### PR TITLE
refactor(core): move exceedsMax out of scale.js into its own util

### DIFF
--- a/docs/range-contract.md
+++ b/docs/range-contract.md
@@ -50,7 +50,7 @@ if (exceedsMax(integerPart, ordinalMax))               throw tooLargeError(ordin
 if (exceedsMax(dollars,     currencyMax))              throw tooLargeError(currencyMax)
 ```
 
-`exceedsMax(value, max, fraction?)` is a pure boolean compare (the language throws):
+`exceedsMax(value, max, fraction?)` (`src/utils/exceeds-max.js`) is a pure boolean compare (the language throws):
 
 - a `max` of `null` (unbounded) is never exceeded;
 - pass `fraction` (the decimal digit string) **only** when the fraction is spelled

--- a/src/en-AU.js
+++ b/src/en-AU.js
@@ -12,7 +12,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-BD.js
+++ b/src/en-BD.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, indian } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { indian } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-CA.js
+++ b/src/en-CA.js
@@ -22,7 +22,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-GB.js
+++ b/src/en-GB.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-GH.js
+++ b/src/en-GH.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-IE.js
+++ b/src/en-IE.js
@@ -23,7 +23,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-IN.js
+++ b/src/en-IN.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, indian } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { indian } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-KE.js
+++ b/src/en-KE.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-MY.js
+++ b/src/en-MY.js
@@ -23,7 +23,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-NG.js
+++ b/src/en-NG.js
@@ -23,7 +23,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-NZ.js
+++ b/src/en-NZ.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-PH.js
+++ b/src/en-PH.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-PK.js
+++ b/src/en-PK.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, indian } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { indian } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-SG.js
+++ b/src/en-SG.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-US.js
+++ b/src/en-US.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/en-ZA.js
+++ b/src/en-ZA.js
@@ -22,7 +22,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/it-IT.js
+++ b/src/it-IT.js
@@ -15,7 +15,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, longScale } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { longScale } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/utils/exceeds-max.js
+++ b/src/utils/exceeds-max.js
@@ -1,0 +1,24 @@
+/**
+ * Range check for a parsed value against a form's ceiling.
+ *
+ * The counterpart to the scale-range helpers (which *produce* a form's `*Max`):
+ * this *consumes* one. Pure — it returns a boolean and the caller throws, e.g.
+ * `if (exceedsMax(integerPart, cardinalMax, decimalPart)) throw tooLargeError(cardinalMax)`.
+ * @module exceeds-max
+ */
+
+/**
+ * Whether a parsed value is out of a form's range — pure; the caller throws.
+ * Pass `fraction` (the decimal digit string) only when the fraction is spelled
+ * via the scale builder; digit-by-digit forms omit it so long fractions stay
+ * valid. A `max` of `null` (unbounded) is never exceeded.
+ * @param {bigint} value The integer magnitude to test (integer part, dollars, …)
+ * @param {bigint | null} max The form's ceiling, or null for no limit
+ * @param {string} [fraction] The decimal digit string, when integer-spelled
+ * @returns {boolean} true if `value` — or its integer-spelled fraction — exceeds `max`
+ */
+export function exceedsMax(value, max, fraction) {
+  if (max === null) return false
+  if (value >= max) return true
+  return fraction ? BigInt(fraction) >= max : false
+}

--- a/src/utils/scale.js
+++ b/src/utils/scale.js
@@ -9,29 +9,13 @@
  * These helpers derive that bigint from a language's own scale-table size, so
  * the ceiling tracks the vocabulary and can't drift. A language whose shape
  * fits none of them declares the value directly (`bounded(n)` or a literal
- * bigint). They are pure — derivations and one comparison (`exceedsMax`) the
- * entry guards use. Nothing here throws; the language throws, and the
- * verification checks (boundary, gaps, injectivity) live in the gate.
+ * bigint). They only *produce* a max — the range check that consumes one lives
+ * in exceeds-max.js, and the verification checks (boundary, gaps, injectivity)
+ * live in the gate. Nothing here throws.
  */
 
 /** No fixed ceiling — recursive/compounding spellers (th-TH, fa-IR, …). */
 export const UNBOUNDED = null
-
-/**
- * Whether a parsed value is out of a form's range — pure; the caller throws.
- * Pass `fraction` (the decimal digit string) only when the fraction is spelled
- * via the scale builder; digit-by-digit forms omit it so long fractions stay
- * valid. A `max` of `null` (unbounded) is never exceeded.
- * @param {bigint} value The integer magnitude to test (integer part, dollars, …)
- * @param {bigint | null} max The form's ceiling, or null for no limit
- * @param {string} [fraction] The decimal digit string, when integer-spelled
- * @returns {boolean} true if `value` — or its integer-spelled fraction — exceeds `max`
- */
-export function exceedsMax(value, max, fraction) {
-  if (max === null) return false
-  if (value >= max) return true
-  return fraction ? BigInt(fraction) >= max : false
-}
 
 /**
  * 3-digit grouping, scale array starting at "thousand" (en-US, de-DE, ru-RU, …).

--- a/src/zh-Hans-CN.js
+++ b/src/zh-Hans-CN.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { bounded, exceedsMax } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { bounded } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 


### PR DESCRIPTION
## Why

`exceedsMax` doesn't belong in `scale.js`. The scale helpers all **produce** a max (`western`/`myriad`/`indian`/`longScale`/`bounded`/`UNBOUNDED`); `exceedsMax` **consumes** one — it's a range check, not a scale-table derivation. Different concern.

## What

- New `src/utils/exceeds-max.js` (single-purpose, matching the repo's util convention — `too-large-error.js`, `is-plain-object.js`, …).
- Removed `exceedsMax` from `scale.js`; updated its header.
- Repointed the 18 migrated languages' imports (`exceedsMax` now from `exceeds-max.js`; helpers stay in `scale.js`).
- Spec doc names the file.

Now the three concerns are cleanly separated:

| file | role |
|---|---|
| `scale.js` | **produces** a max (derive from a table, or `bounded`/`UNBOUNDED`) |
| `exceeds-max.js` | **checks** a value against a max |
| `too-large-error.js` | **reports** the failure |

Behaviour identical. `npm test`: **362 passing**; lint clean.

> Note: the open #374 (western batch) still imports `exceedsMax` from `scale.js`. Once this merges I'll rebase #374's 11 files onto the new location; future sweep batches import from `exceeds-max.js` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)