### PR TITLE
fix(core): repoint the western batch's exceedsMax import (main is broken)

### DIFF
--- a/src/ar-SA.js
+++ b/src/ar-SA.js
@@ -15,7 +15,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/az-AZ.js
+++ b/src/az-AZ.js
@@ -12,7 +12,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/de-DE.js
+++ b/src/de-DE.js
@@ -15,7 +15,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 

--- a/src/id-ID.js
+++ b/src/id-ID.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/ka-GE.js
+++ b/src/ka-GE.js
@@ -15,7 +15,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/ms-MY.js
+++ b/src/ms-MY.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/nb-NO.js
+++ b/src/nb-NO.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/sv-SE.js
+++ b/src/sv-SE.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/sw-KE.js
+++ b/src/sw-KE.js
@@ -12,7 +12,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================

--- a/src/tr-TR.js
+++ b/src/tr-TR.js
@@ -12,7 +12,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { exceedsMax, western } from './utils/scale.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 import { validateOptions } from './utils/validate-options.js'
 


### PR DESCRIPTION
## Urgent — main is red

#374 (western batch) and #375 (move `exceedsMax` out of `scale.js`) each passed CI on their own base, but merging both broke `main`: #374's 11 files import `exceedsMax` from `scale.js`, which #375 removed. They fail to import:

```text
The requested module './utils/scale.js' does not provide an export named 'exceedsMax'
```

(A merge-order hazard — disjoint files, so git merged clean, but the combination wasn't tested.)

## Fix

Repoint the 11 western files (`de-DE`, `sv-SE`, `da-DK`, `nb-NO`, `tr-TR`, `ar-SA`, `az-AZ`, `sw-KE`, `id-ID`, `ms-MY`, `ka-GE`) to `./utils/exceeds-max.js` — exactly the split #375 already applied to the other 18.

`npm test`: **373 passing**; lint clean. Please merge to green `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)