### PR TITLE
refactor(core): migrate the digit-wise western batch to the range contract

### DIFF
--- a/src/am-ET.js
+++ b/src/am-ET.js
@@ -14,6 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
@@ -58,8 +60,9 @@ const SCALE_WORDS = ['', THOUSAND, 'ሚሊዮን', 'ቢሊዮን']
 // reaches index SCALE_WORDS.length-1 (ቢሊዮን, 10^9), so values must stay below
 // 10^(SCALE_WORDS.length * 3) = 10^12. Ordinal and currency build on the
 // cardinal, so they share it. Decimals are read digit-by-digit (no ceiling).
-const MAX_CARDINAL_EXPONENT = SCALE_WORDS.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_WORDS.length - 1)
+export const ordinalMax = western(SCALE_WORDS.length - 1)
+export const currencyMax = western(SCALE_WORDS.length - 1)
 
 // ============================================================================
 // Precomputed Lookup Table
@@ -182,7 +185,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, cardinalMax)) throw tooLargeError(cardinalMax)
 
   let result = ''
 
@@ -239,7 +242,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, ordinalMax)) throw tooLargeError(ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -261,7 +264,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: birr, cents: santim } = parseCurrencyValue(value)
-  if (birr >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(birr, currencyMax)) throw tooLargeError(currencyMax)
 
   // Build result
   let result = ''

--- a/src/am-Latn-ET.js
+++ b/src/am-Latn-ET.js
@@ -14,6 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
@@ -58,8 +60,9 @@ const SCALE_WORDS = ['', THOUSAND, 'miliyon', 'billiyon']
 // reaches index SCALE_WORDS.length-1 (billiyon, 10^9), so values must stay below
 // 10^(SCALE_WORDS.length * 3) = 10^12. Ordinal and currency build on the
 // cardinal, so they share it. Decimals are read digit-by-digit (no ceiling).
-const MAX_CARDINAL_EXPONENT = SCALE_WORDS.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_WORDS.length - 1)
+export const ordinalMax = western(SCALE_WORDS.length - 1)
+export const currencyMax = western(SCALE_WORDS.length - 1)
 
 // ============================================================================
 // Precomputed Lookup Table
@@ -186,7 +189,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, cardinalMax)) throw tooLargeError(cardinalMax)
 
   let result = ''
 
@@ -239,7 +242,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, ordinalMax)) throw tooLargeError(ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -260,7 +263,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: birr, cents: santim } = parseCurrencyValue(value)
-  if (birr >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(birr, currencyMax)) throw tooLargeError(currencyMax)
 
   // Build result
   let result = ''

--- a/src/fi-FI.js
+++ b/src/fi-FI.js
@@ -14,6 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
@@ -42,8 +44,9 @@ const SCALES = ['miljoona', 'miljardi', 'biljoona', 'triljoona']
 // 10^((SCALES.length + 2) * 3) = 10^18. Ordinal (cardinal + suffix) and currency
 // build on the cardinal, so they share it. Decimals are read digit-by-digit
 // (no ceiling).
-const MAX_CARDINAL_EXPONENT = (SCALES.length + 2) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = western(SCALES.length + 1)
+export const ordinalMax = western(SCALES.length + 1)
+export const currencyMax = western(SCALES.length + 1)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -256,7 +259,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, cardinalMax)) throw tooLargeError(cardinalMax)
 
   let result = ''
 
@@ -339,7 +342,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, ordinalMax)) throw tooLargeError(ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -363,7 +366,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(euros, currencyMax)) throw tooLargeError(currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/fil-PH.js
+++ b/src/fil-PH.js
@@ -13,6 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
@@ -35,8 +37,9 @@ const DECIMAL_SEP = 'punto'
 const SCALE_WORDS = ['', THOUSAND, 'milyong', 'bilyong', 'trilyong']
 
 // Supported magnitude ceiling (checked at the public entry points), derived from the scale table.
-const MAX_CARDINAL_EXPONENT = SCALE_WORDS.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_WORDS.length - 1)
+export const ordinalMax = western(SCALE_WORDS.length - 1)
+export const currencyMax = western(SCALE_WORDS.length - 1)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -237,7 +240,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, cardinalMax)) throw tooLargeError(cardinalMax)
 
   let result = ''
 
@@ -287,7 +290,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, ordinalMax)) throw tooLargeError(ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -310,7 +313,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: pesos, cents: sentimos } = parseCurrencyValue(value)
-  if (pesos >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(pesos, currencyMax)) throw tooLargeError(currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/ha-NG.js
+++ b/src/ha-NG.js
@@ -16,6 +16,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { exceedsMax } from './utils/exceeds-max.js'
+import { western } from './utils/scale.js'
 import { tooLargeError } from './utils/too-large-error.js'
 
 // ============================================================================
@@ -38,8 +40,9 @@ const DECIMAL_SEP = 'digo'
 const SCALE_WORDS = ['', THOUSAND, 'miliyan', 'biliyan']
 
 // Supported magnitude ceiling (checked at the public entry points), derived from the scale table.
-const MAX_CARDINAL_EXPONENT = SCALE_WORDS.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_WORDS.length - 1)
+export const ordinalMax = western(SCALE_WORDS.length - 1)
+export const currencyMax = western(SCALE_WORDS.length - 1)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -248,7 +251,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, cardinalMax)) throw tooLargeError(cardinalMax)
 
   let result = ''
 
@@ -297,7 +300,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(integerPart, ordinalMax)) throw tooLargeError(ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -320,7 +323,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: naira, cents: kobo } = parseCurrencyValue(value)
-  if (naira >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  if (exceedsMax(naira, currencyMax)) throw tooLargeError(currencyMax)
 
   let result = ''
   if (isNegative) {


### PR DESCRIPTION
## Summary

Third sweep batch — 5 **digit-wise** western languages move to the range contract: **fi-FI, am-ET, am-Latn-ET, fil-PH, ha-NG**.

These spell the fraction digit by digit, so:
- the cardinal guard **omits the decimal arg** — `if (exceedsMax(integerPart, cardinalMax)) throw …` — leaving long fractions valid (verified: a 100-digit fraction still spells);
- that makes the cardinal guard single-line and identical to the ordinal guard, so the three single-line guards were disambiguated by file order (cardinal → ordinal → currency).

All three forms share the ceiling. Each `cardinalMax` verified equal to its previous `MAX_CARDINAL`:

| lang | ceiling |
|---|---|
| fi-FI | 10¹⁸ |
| am-ET / am-Latn-ET | 10¹² |
| fil-PH | 10¹⁵ |
| ha-NG | 10¹² |

Behaviour-preserving; now gate-covered (35 in the range gate). `npm test`: **378 passing**; lint clean. Per `docs/range-contract.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)