### PR TITLE
refactor(ja-JP,ko-KR,zh-Hant-TW): migrate the myriad batch to the range contract

### DIFF
--- a/src/ja-JP.js
+++ b/src/ja-JP.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { myriad } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -45,9 +46,11 @@ const SCALES = [
 ]
 
 // Myriad (4-digit) grouping: each scale word covers a power of 10,000, so the
-// table reaches 10^(4 * SCALES.length); the next group has no scale word.
-const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 4
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+// first unsupported value is 10^((SCALES.length + 1) * 4). Ordinals (prefix) and
+// currency build on the cardinal speller, so they share its ceiling.
+export const cardinalMax = myriad(SCALES.length)
+export const ordinalMax = myriad(SCALES.length)
+export const currencyMax = myriad(SCALES.length)
 
 const ZERO = '零'
 const NEGATIVE = 'マイナス'
@@ -254,7 +257,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // The fraction is spelled digit by digit, so only the integer part has a ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   let result = ''
 
@@ -300,7 +303,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals prefix the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -325,7 +328,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: yen, cents: sen } = parseCurrencyValue(value)
-  if (yen >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(yen, currencyMax)
 
   // Build result
   let result = ''

--- a/src/ko-KR.js
+++ b/src/ko-KR.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { myriad } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -33,9 +34,12 @@ const DECIMAL_SEP = '점'
 // 만 (10^4), 억 (10^8), 조 (10^12), 경 (10^16), etc.
 const SCALES = ['만', '억', '조', '경', '해', '자', '양']
 
-// Supported magnitude ceiling (checked at the public entry points), derived from the scale table.
-const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 4
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+// Myriad (4-digit) grouping: each scale word covers a power of 10,000, so the
+// first unsupported value is 10^((SCALES.length + 1) * 4). Ordinals and currency
+// build on the cardinal speller, so they share its ceiling.
+export const cardinalMax = myriad(SCALES.length)
+export const ordinalMax = myriad(SCALES.length)
+export const currencyMax = myriad(SCALES.length)
 
 // ============================================================================
 // Ordinal Vocabulary
@@ -252,9 +256,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   const parts = []
 
@@ -300,7 +302,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -324,7 +326,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: won } = parseCurrencyValue(value)
-  if (won >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(won, currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/zh-Hant-TW.js
+++ b/src/zh-Hant-TW.js
@@ -17,7 +17,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -45,8 +46,9 @@ const YI_WORD = '億' // 100,000,000
 // itself only valid below 億. So the ceiling is 億² = 10^16. Ordinal (第 +
 // cardinal) and currency build on the cardinal, so they share it. Decimals are
 // spelled digit-by-digit, so they have no ceiling.
-const MAX_CARDINAL_EXPONENT = 16
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = bounded(16)
+export const ordinalMax = bounded(16)
+export const currencyMax = bounded(16)
 
 const ZERO = '零'
 const NEGATIVE = '負'
@@ -230,7 +232,7 @@ function decimalDigitsToWords(decimalString, formal = true) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   // Apply option defaults
   const { formal = true } = options
@@ -282,7 +284,7 @@ function integerToOrdinal(n, formal = true) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   const { formal = true } = options
   return integerToOrdinal(integerPart, formal)
 }
@@ -310,7 +312,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: yuan, cents } = parseCurrencyValue(value)
-  if (yuan >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(yuan, currencyMax)
   const { formal = true } = options
 
   const yuanWord = formal ? YUAN_FORMAL : YUAN_COMMON


### PR DESCRIPTION
Migrates the three myriad (CJK, 10,000-grouping) languages onto the range contract — bigint `*Max` exports + `checkMax` guards, replacing each `MAX_CARDINAL` block.

## Per language

| Lang | Ceiling | Helper | Decimals |
|---|---|---|---|
| `ja-JP` | 10^72 | `myriad(SCALES.length)` | digit-by-digit (no `decimalPart` arg) |
| `ko-KR` | 10^32 | `myriad(SCALES.length)` | integer-spelled (passes `decimalPart`) |
| `zh-Hant-TW` | 10^16 | `bounded(16)` (億² ) | digit-by-digit |

For all three, ordinal (prefix) and currency build on the cardinal speller, so they **share its ceiling** — each form still exports its own `*Max`. `zh-Hant-TW` mirrors the already-migrated `zh-Hans-CN` exactly.

## Verification

- Ceilings **unchanged** from the prior `MAX_CARDINAL` (ja 10^72, ko 10^32, zh-Hant 10^16) — derived now from the scale-table size via the helper.
- Two-sided boundary holds (`max` throws `RangeError`, `max - 1` well-formed); `ko-KR`'s integer-spelled fraction overflow still guarded.
- Full suite green (381 tests); the range-contract gate auto-covers all three.

Part of the family-by-family sweep. Next: South Asian native (`indian`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)