### PR TITLE
refactor(core): migrate the South Asian (indian) batch to the range contract

### DIFF
--- a/src/bn-BD.js
+++ b/src/bn-BD.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -63,8 +64,9 @@ const SCALE_WORDS = ['', 'হাজার', 'লাখ', 'কোটি', 'আর
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -180,9 +182,7 @@ function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   let result = ''
 
@@ -236,7 +236,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -257,7 +257,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: taka, cents: paisa } = parseCurrencyValue(value)
-  if (taka >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(taka, currencyMax)
 
   // Build result
   let result = ''

--- a/src/gu-IN.js
+++ b/src/gu-IN.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -66,8 +67,9 @@ const SCALE_WORDS = ['', 'હજાર', 'લાખ', 'કરોડ', 'અબજ
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -165,7 +167,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // The fraction is spelled digit by digit, so only the integer part has a ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   let result = ''
 
@@ -218,7 +220,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -239,7 +241,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''

--- a/src/hi-IN.js
+++ b/src/hi-IN.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -66,8 +67,9 @@ const SCALE_WORDS = ['', 'हज़ार', 'लाख', 'करोड़', 'अ
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -183,9 +185,7 @@ function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   let result = ''
 
@@ -239,7 +239,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -260,7 +260,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''

--- a/src/kn-IN.js
+++ b/src/kn-IN.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -66,8 +67,9 @@ const SCALE_WORDS = ['', 'ಸಾವಿರ', 'ಲಕ್ಷ', 'ಕೋಟಿ', 'ಅ
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -165,7 +167,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // The fraction is spelled digit by digit, so only the integer part has a ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   let result = ''
 
@@ -218,7 +220,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -239,7 +241,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''

--- a/src/mr-IN.js
+++ b/src/mr-IN.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -66,8 +67,9 @@ const SCALE_WORDS = ['', 'हजार', 'लाख', 'कोटी', 'अब्
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -165,7 +167,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // The fraction is spelled digit by digit, so only the integer part has a ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   let result = ''
 
@@ -219,7 +221,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -240,7 +242,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''

--- a/src/pa-IN.js
+++ b/src/pa-IN.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -65,8 +66,9 @@ const SCALE_WORDS = ['', 'ਹਜ਼ਾਰ', 'ਲੱਖ', 'ਕਰੋੜ', 'ਅਰ
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -174,9 +176,7 @@ function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   let result = ''
 
@@ -230,7 +230,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -251,7 +251,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''

--- a/src/ta-IN.js
+++ b/src/ta-IN.js
@@ -16,7 +16,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -74,8 +75,9 @@ const SCALE_WORDS = ['', 'ஆயிரம்', 'லட்சம்', 'கோட�
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -177,7 +179,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // The fraction is spelled digit by digit, so only the integer part has a ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   let result = ''
 
@@ -230,7 +232,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -251,7 +253,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''

--- a/src/te-IN.js
+++ b/src/te-IN.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -70,8 +71,9 @@ const SCALE_WORDS = ['', 'వెయ్యి', 'లక్ష', 'కోటి', '
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -171,7 +173,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // The fraction is spelled digit by digit, so only the integer part has a ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   let result = ''
 
@@ -224,7 +226,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -245,7 +247,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''

--- a/src/ur-PK.js
+++ b/src/ur-PK.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { indian } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary
@@ -65,8 +66,9 @@ const SCALE_WORDS = ['', 'ہزار', 'لاکھ', 'کروڑ', 'ارب', 'کھرب
 // 3-2-2 Indian grouping: a 3-digit base segment, then 2 digits per scale word
 // (SCALE_WORDS[0] = '' is the units slot). Past the table the scale word is
 // dropped, which collapses the magnitude — so cap there.
-const MAX_CARDINAL_EXPONENT = 3 + 2 * (SCALE_WORDS.length - 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = indian(SCALE_WORDS.length)
+export const ordinalMax = indian(SCALE_WORDS.length)
+export const currencyMax = indian(SCALE_WORDS.length)
 
 // ============================================================================
 // Segment Building
@@ -174,9 +176,7 @@ function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   let result = ''
 
@@ -230,7 +230,7 @@ function integerToOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals build on the cardinal speller, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -251,7 +251,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
-  if (rupees >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rupees, currencyMax)
 
   // Build result
   let result = ''


### PR DESCRIPTION
Migrates the nine 3-2-2 Indian-grouping languages onto the range contract — bigint `*Max` exports + `checkMax` guards, replacing each `MAX_CARDINAL` block.

All nine use a units-slot scale table (`SCALE_WORDS[0] = ''`), so each declares `indian(SCALE_WORDS.length)` for all three forms. Ordinal and currency build on the cardinal speller, so they **share its ceiling** (= **10^19** for every one of them).

## The split — cardinal decimal handling

| Decimals | Languages | Cardinal guard |
|---|---|---|
| Integer-spelled (via scale builder) | `hi-IN`, `bn-BD`, `pa-IN`, `ur-PK` | `checkMax(integerPart, cardinalMax, decimalPart)` |
| Digit-by-digit | `gu-IN`, `kn-IN`, `mr-IN`, `ta-IN`, `te-IN` | `checkMax(integerPart, cardinalMax)` |

(The integer-spelled set passes `decimalPart` so an over-long fraction is still caught; the digit-wise set has no fractional ceiling.)

## Verification

- Ceilings **unchanged** from the prior `MAX_CARDINAL` (all `10^19`), now derived from the scale-table size via `indian(SCALE_WORDS.length)`.
- Two-sided boundary holds for all nine (`max` throws `RangeError`, `max - 1` well-formed); integer-spelled fraction overflow still guarded.
- Full suite green (390 tests); the range-contract gate auto-covers all nine.

Part of the family-by-family sweep. Next: long scale `longScale` (fr-BE, fr-FR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)