### PR TITLE
refactor(fr): migrate the long-scale batch to the range contract

### DIFF
--- a/src/fr-BE.js
+++ b/src/fr-BE.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { longScale } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -33,8 +34,9 @@ const SCALES_ARD = ['milliard', 'billiard', 'trilliard', 'quadrilliard']
 // so with the units group that's 2 * SCALES.length + 2 groups of 3 digits.
 // Cardinals must stay below 10^30; ordinals and currency build on the cardinal,
 // so they share the same ceiling.
-const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = longScale(SCALES.length)
+export const ordinalMax = longScale(SCALES.length)
+export const currencyMax = longScale(SCALES.length)
 
 const THOUSAND = 'mille'
 const HUNDRED = 'cent'
@@ -347,9 +349,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { withHyphenSeparator = false } = options
@@ -453,7 +453,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -479,7 +479,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimes } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/fr-FR.js
+++ b/src/fr-FR.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { longScale } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -34,8 +35,9 @@ const SCALES_ARD = ['milliard', 'billiard', 'trilliard', 'quadrilliard']
 // so with the units group that's 2 * SCALES.length + 2 groups of 3 digits.
 // Cardinals must stay below 10^30; ordinals and currency build on the cardinal,
 // so they share the same ceiling.
-const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+export const cardinalMax = longScale(SCALES.length)
+export const ordinalMax = longScale(SCALES.length)
+export const currencyMax = longScale(SCALES.length)
 
 const THOUSAND = 'mille'
 const HUNDRED = 'cent'
@@ -378,9 +380,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { withHyphenSeparator = false } = options
@@ -488,7 +488,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -514,7 +514,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimes } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
   const { and: useAnd = true } = options
 
   // Build result


### PR DESCRIPTION
Migrates the two long-scale (–illion / –illiard) French variants onto the range contract — bigint `*Max` exports + `checkMax` guards, replacing each `MAX_CARDINAL` block. Same shape as the already-migrated `it-IT`.

## The derivation

Each `SCALES` entry (`million`, `billion`, …) carries a base and an `-ard` form, spanning two 3-digit groups. The prior ceiling was written `(2 * SCALES.length + 2) * 3`, which is **algebraically identical** to the `longScale` helper:

```
(2L + 2) * 3  =  6L + 6  =  6 * (L + 1)  =  longScale(L)
```

So both now declare `longScale(SCALES.length)` = **10^30** (`SCALES.length` = 4) for all three forms. Ordinal and currency build on the cardinal speller, so they share its ceiling.

Both spell the integer part **and** the decimal's significant digits via the scale builder, so the cardinal guard passes `decimalPart`: `checkMax(integerPart, cardinalMax, decimalPart)`.

## Verification

- Ceilings **unchanged** (10^30), now derived from the scale-table size.
- Two-sided boundary holds; integer-spelled fraction overflow still guarded (a 40-digit fraction throws).
- Full suite green (392 tests); the range-contract gate covers both.

Part of the family-by-family sweep. Next: the split-ceiling per-form group (es×3, ro, he/hbo, nl, pt×2, …).

🤖 Generated with [Claude Code](https://claude.com/claude-code)