### PR TITLE
refactor(core): migrate the Romance split-ceiling batch to the range contract

### DIFF
--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded, longScale } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -51,10 +52,9 @@ const SCALES_PLURAL = ['millones', 'billones', 'trillones', 'cuatrillones']
 // that's 2 * SCALES.length + 2 groups of 3 digits, so cardinals must stay below
 // 10^30. Ordinals are bounded lower: the millions multiplier uses
 // buildOrdinalSegment (0-999), so n must stay below 10^9.
-const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = 9
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = longScale(SCALES.length)
+export const ordinalMax = bounded(9)
+export const currencyMax = longScale(SCALES.length)
 
 const THOUSAND = 'mil'
 const ZERO = 'cero'
@@ -233,7 +233,7 @@ function integerToWords(n, feminine) {
 function buildLargeNumberWords(n, feminine) {
   // Extract segments using BigInt division (faster than string slicing)
   // Segments stored least-significant first (index 0 = ones, 1 = thousands, etc.)
-  // Callers guard the magnitude (MAX_CARDINAL) before reaching here.
+  // Callers guard the magnitude (cardinalMax) before reaching here.
   const segmentValues = []
   let temp = n
   while (temp > 0n) {
@@ -339,9 +339,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -494,7 +492,7 @@ function integerToOrdinal(n, feminine) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
 
   const { gender = 'masculine' } = options
   const feminine = gender === 'feminine'
@@ -526,7 +524,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimos } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
   const { and: useAnd = true } = options
 
   let result = ''

--- a/src/es-MX.js
+++ b/src/es-MX.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded, longScale } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -51,10 +52,9 @@ const SCALES_PLURAL = ['millones', 'billones', 'trillones', 'cuatrillones']
 // that's 2 * SCALES.length + 2 groups of 3 digits, so cardinals must stay below
 // 10^30. Ordinals are bounded lower: the millions multiplier uses
 // buildOrdinalSegment (0-999), so n must stay below 10^9.
-const MAX_CARDINAL_EXPONENT = (2 * SCALES.length + 2) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = 9
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = longScale(SCALES.length)
+export const ordinalMax = bounded(9)
+export const currencyMax = longScale(SCALES.length)
 
 const THOUSAND = 'mil'
 
@@ -233,7 +233,7 @@ function integerToWords(n, feminine) {
 function buildLargeNumberWords(n, feminine) {
   // Extract segments using BigInt division (faster than string slicing)
   // Segments stored least-significant first (index 0 = ones, 1 = thousands, etc.)
-  // Callers guard the magnitude (MAX_CARDINAL) before reaching here.
+  // Callers guard the magnitude (cardinalMax) before reaching here.
   const segmentValues = []
   let temp = n
   while (temp > 0n) {
@@ -336,9 +336,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -478,7 +476,7 @@ function integerToOrdinal(n, feminine) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
 
   const { gender = 'masculine' } = options
   const feminine = gender === 'feminine'
@@ -510,7 +508,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: pesos, cents: centavos } = parseCurrencyValue(value)
-  if (pesos >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(pesos, currencyMax)
   const { and: useAnd = true } = options
 
   let result = ''

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -20,7 +20,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded, western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -50,10 +51,9 @@ const SCALES_PLURAL = ['mil', 'millones', 'billones', 'trillones', 'cuatrillones
 // scale: SCALES covers 10^3..10^18, plus the units group, so cardinals span at
 // most SCALES.length + 1 groups of 3 digits (below 10^21). Ordinals are bounded
 // lower: the millions multiplier uses buildOrdinalSegment (0-999), so n < 10^9.
-const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = 9
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALES.length)
+export const ordinalMax = bounded(9)
+export const currencyMax = western(SCALES.length)
 
 const ZERO = 'cero'
 const NEGATIVE = 'menos'
@@ -190,7 +190,7 @@ function integerToWords(n, feminine) {
     }
     else {
       // Millions and above: "un millón", "dos millones", etc.
-      // Callers guard the magnitude (MAX_CARDINAL) so scaleIndex stays in range.
+      // Callers guard the magnitude (cardinalMax) so scaleIndex stays in range.
       const scaleIndex = i - 1 // SCALES[1] = millón, SCALES[2] = billón, etc.
       if (segment === 1n) {
         // "un millón" not "uno millón"
@@ -250,9 +250,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -392,7 +390,7 @@ function integerToOrdinal(n, feminine) {
 function toOrdinal(value, options) {
   options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
 
   const { gender = 'masculine' } = options
   const feminine = gender === 'feminine'
@@ -424,7 +422,7 @@ function toOrdinal(value, options) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars, cents: centavos } = parseCurrencyValue(value)
-  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(dollars, currencyMax)
   const { and: useAnd = true } = options
 
   let result = ''

--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -146,10 +147,9 @@ const SCALE_ORDINAL = ['', 'milésimo', 'milionésimo', 'bilionésimo', 'trilion
 // cardinals/currency must stay below 10^27. The ordinal of a number whose
 // lowest non-zero group is a scale group uses SCALE_ORDINAL, which is shorter,
 // so ordinals must stay below 10^(SCALE_ORDINAL.length * 3).
-const MAX_CARDINAL_EXPONENT = SCALE_WORDS_SINGULAR.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = SCALE_ORDINAL.length * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_WORDS_SINGULAR.length - 1)
+export const ordinalMax = western(SCALE_ORDINAL.length - 1)
+export const currencyMax = western(SCALE_WORDS_SINGULAR.length - 1)
 
 // ============================================================================
 // Conversion Functions
@@ -307,9 +307,7 @@ function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   let result = ''
 
@@ -448,7 +446,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
-  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(n, ordinalMax)
 
   // Fast path: 1-9
   if (n < 10n) {
@@ -497,7 +495,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: majorUnits, cents: minorUnits } = parseCurrencyValue(value)
-  if (majorUnits >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(majorUnits, currencyMax)
   const { and = true } = options
 
   // 1. Descobre a moeda informada ou busca automaticamente a padrão do país (pt-BR = BRL)

--- a/src/pt-PT.js
+++ b/src/pt-PT.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -135,10 +136,9 @@ const SCALE_ORDINAL = ['', 'milésimo', 'milionésimo', 'mil milionésimo', 'bil
 // cardinals/currency must stay below 10^27. The ordinal of a number whose
 // lowest non-zero group is a scale group uses SCALE_ORDINAL, which is shorter,
 // so ordinals must stay below 10^(SCALE_ORDINAL.length * 3).
-const MAX_CARDINAL_EXPONENT = SCALE_WORDS_SINGULAR.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = SCALE_ORDINAL.length * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_WORDS_SINGULAR.length - 1)
+export const ordinalMax = western(SCALE_ORDINAL.length - 1)
+export const currencyMax = western(SCALE_WORDS_SINGULAR.length - 1)
 
 // ============================================================================
 // Conversion Functions
@@ -307,9 +307,7 @@ function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   let result = ''
 
@@ -452,7 +450,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
-  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(n, ordinalMax)
 
   // Fast path: 1-9
   if (n < 10n) {
@@ -501,7 +499,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
   const { and = true } = options
 
   let result = ''

--- a/src/ro-RO.js
+++ b/src/ro-RO.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded, western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -69,10 +70,9 @@ const SCALE_META = [
 // Cardinal scale words run thousand..octilion; past SCALE_META the builder drops
 // the scale word. The ordinal spells its millions multiplier via spellUnder1000
 // (0-999), so it overflows once that multiplier reaches 1000 — n must stay below 10^9.
-const MAX_CARDINAL_EXPONENT = 3 * (SCALE_META.length + 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = 9
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_META.length)
+export const ordinalMax = bounded(9)
+export const currencyMax = western(SCALE_META.length)
 
 // ============================================================================
 // Helper Functions
@@ -270,9 +270,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -410,7 +408,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
-  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(n, ordinalMax)
   return integerToOrdinal(n)
 }
 
@@ -430,7 +428,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
-  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(dollars, currencyMax)
 
   const parts = []
 


### PR DESCRIPTION
First of the **split-ceiling** languages — where ordinals stop spelling well below cardinals, so a single shared ceiling no longer works and each form declares its own `*Max`.

## Per-form ceilings

| Lang | cardinal | ordinal | currency |
|---|---|---|---|
| `es-ES`, `es-MX` | `longScale(SCALES.length)` — 10^30 | `bounded(9)` — 10^9 | = cardinal |
| `es-US` | `western(SCALES.length)` — 10^21 | `bounded(9)` — 10^9 | = cardinal |
| `pt-PT`, `pt-BR` | `western(SCALE_WORDS_SINGULAR.length - 1)` — 10^27 | `western(SCALE_ORDINAL.length - 1)` | = cardinal |
| `ro-RO` | `western(SCALE_META.length)` — 10^30 | `bounded(9)` — 10^9 | = cardinal |

The Spanish/Romanian ordinals cap at 10^9 because the millions multiplier is spelled via a 0–999 segment builder; Portuguese ordinals use a shorter `SCALE_ORDINAL` table than the cardinal scale.

## No drift

Every helper expression is **algebraically identical** to the prior `MAX_*_EXPONENT` it replaces (e.g. `western(SCALE_META.length)` exponent = `3*(SCALE_META.length+1)`; `western(SCALE_ORDINAL.length-1)` = `SCALE_ORDINAL.length*3`), so no ceiling moves. Stale `// ... (MAX_CARDINAL) ...` comments refreshed to `cardinalMax`.

## Verification

- The gate's two-sided boundary check now pins **both** the cardinal and ordinal ceiling for all six (at-max throws `RangeError`, max-1 well-formed).
- Full suite green (398 tests).

Cardinal guards are integer-spelled (pass `decimalPart`). Part of the sweep; next: the Semitic/Hellenic/Germanic split-ceiling set (he/hbo, el-GR, nl-NL), then Slavic/Baltic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)