### PR TITLE
refactor(core): migrate the Semitic/Hellenic/Germanic split-ceiling batch

### DIFF
--- a/src/el-GR.js
+++ b/src/el-GR.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded, western } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -38,10 +39,9 @@ const DECIMAL_SEP = 'κόμμα'
 const SCALES = ['εκατομμύριο', 'δισεκατομμύριο', 'τρισεκατομμύριο']
 
 // Supported magnitude ceiling (checked at the public entry points), derived from the scale table.
-const MAX_CARDINAL_EXPONENT = (SCALES.length + 2) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = 9
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALES.length + 1)
+export const ordinalMax = bounded(9)
+export const currencyMax = western(SCALES.length + 1)
 
 // Ordinal vocabulary
 const ORDINAL_ONES = ['', 'πρώτος', 'δεύτερος', 'τρίτος', 'τέταρτος', 'πέμπτος', 'έκτος', 'έβδομος', 'όγδοος', 'ένατος']
@@ -245,7 +245,7 @@ function decimalPartToWords(decimalPart) {
  */
 function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   let result = ''
 
@@ -379,7 +379,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
-  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(n, ordinalMax)
   return integerToOrdinal(n)
 }
 
@@ -399,7 +399,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
-  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(dollars, currencyMax)
 
   const parts = []
 

--- a/src/hbo-IL.js
+++ b/src/hbo-IL.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded, western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -45,10 +46,9 @@ const SCALE_PLURAL = ['', 'אלפים', 'מיליונים', 'מיליארדים'
 // below 10^(SCALE.length * 3) = 10^21. Ordinals are bounded lower: past 10^6
 // the millions multiplier is built with buildScaleSegment (0-999), so n must
 // stay below 10^9. Decimals are read digit-by-digit (no ceiling).
-const MAX_CARDINAL_EXPONENT = SCALE.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = 9
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE.length - 1)
+export const ordinalMax = bounded(9)
+export const currencyMax = western(SCALE.length - 1)
 
 const ZERO = 'אפס'
 const NEGATIVE = 'מינוס'
@@ -305,7 +305,7 @@ function decimalPartToWords(decimalPart, gender) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   // Apply option defaults
   const {
@@ -447,7 +447,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
-  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(n, ordinalMax)
   return integerToOrdinal(n)
 }
 
@@ -467,7 +467,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
-  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(dollars, currencyMax)
 
   const parts = []
 

--- a/src/he-IL.js
+++ b/src/he-IL.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { bounded, western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -39,10 +40,9 @@ const SCALE_PLURAL = ['', 'אלפים', 'מיליונים', 'מיליארדים'
 // below 10^(SCALE.length * 3) = 10^21. Ordinals are bounded lower: past 10^6
 // the millions multiplier is built with buildScaleSegment (0-999), so n must
 // stay below 10^9. Decimals are read digit-by-digit (no ceiling).
-const MAX_CARDINAL_EXPONENT = SCALE.length * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = 9
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE.length - 1)
+export const ordinalMax = bounded(9)
+export const currencyMax = western(SCALE.length - 1)
 
 const ZERO = 'אפס'
 const NEGATIVE = 'מינוס'
@@ -284,7 +284,7 @@ function decimalPartToWords(decimalPart) {
 function toCardinal(value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, cardinalMax)
 
   // Apply option defaults
   const { andWord = 'ו' } = options
@@ -434,7 +434,7 @@ function integerToOrdinal(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
-  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(n, ordinalMax)
   return integerToOrdinal(n)
 }
 
@@ -528,7 +528,7 @@ function integerToCurrencyWords(n) {
  */
 function toCurrency(value) {
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
-  if (dollars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(dollars, currencyMax)
 
   const parts = []
 

--- a/src/nl-NL.js
+++ b/src/nl-NL.js
@@ -16,7 +16,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -41,10 +42,9 @@ const SCALE_ORDINAL = ['', 'duizendste', 'miljoenste', 'miljardste', 'biljoenste
 // 10^((SCALES.length + 1) * 3) = 10^30. The ordinal of a number whose lowest
 // non-zero group is a scale group uses the shorter SCALE_ORDINAL, so ordinals
 // are bounded at 10^(SCALE_ORDINAL.length * 3) = 10^21.
-const MAX_CARDINAL_EXPONENT = (SCALES.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = SCALE_ORDINAL.length * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALES.length)
+export const ordinalMax = western(SCALE_ORDINAL.length - 1)
+export const currencyMax = western(SCALES.length)
 
 const ZERO = 'nul'
 const NEGATIVE = 'min'
@@ -332,9 +332,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const {
@@ -438,7 +436,7 @@ function buildOrdinalSegment(n) {
  */
 function toOrdinal(value) {
   const n = parseOrdinalValue(value)
-  if (n >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(n, ordinalMax)
 
   // Fast path: 1-9
   if (n < 10n) return ORDINAL_ONES[Number(n)]
@@ -557,7 +555,7 @@ function buildLargeOrdinal(n) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
   const { and = true } = options
 
   let result = ''


### PR DESCRIPTION
Second split-ceiling batch — Hebrew, Biblical Hebrew, Greek, Dutch. Per-form `*Max`, currency sharing the cardinal ceiling.

## Per-form ceilings

| Lang | cardinal | ordinal | decimals |
|---|---|---|---|
| `he-IL`, `hbo-IL` | `western(SCALE.length - 1)` — 10^21 | `bounded(9)` — 10^9 | digit-by-digit |
| `el-GR` | `western(SCALES.length + 1)` — 10^15 | `bounded(9)` — 10^9 | digit-by-digit |
| `nl-NL` | `western(SCALES.length)` — 10^30 | `western(SCALE_ORDINAL.length - 1)` — 10^21 | integer-spelled |

he/hbo/el read decimals digit-by-digit, so the cardinal guard omits `decimalPart`; nl-NL spells them via the scale builder, so it passes `decimalPart`. The Hebrew/Greek ordinals cap at 10^9 (a 0–999 segment multiplier); the Dutch ordinal uses a shorter `SCALE_ORDINAL` table.

## Verification

- Every helper expression is **algebraically identical** to the prior `MAX_*_EXPONENT` (no drift).
- The gate's two-sided boundary check now pins **both** the cardinal and ordinal ceiling for all four.
- Full suite green (402 tests).

Part of the sweep; next: the Slavic/Baltic split-ceiling set (hr, lt, lv, uk, pl, cs, ru, sr×2) — the last big group before the unbounded stragglers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)