### PR TITLE
refactor(core): migrate the Slavic/Baltic split-ceiling batch

### DIFF
--- a/src/cs-CZ.js
+++ b/src/cs-CZ.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -48,8 +49,10 @@ const PLURAL_FORMS = {
 
 // PLURAL_FORMS is keyed by 1000-power; past its largest key the builder drops the
 // scale word (cardinal) or dereferences undefined (ordinal), so cap there.
-const MAX_CARDINAL_EXPONENT = 3 * (Math.max(...Object.keys(PLURAL_FORMS).map(Number)) + 1)
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
+const MAX_SCALE_KEY = Math.max(...Object.keys(PLURAL_FORMS).map(Number))
+export const cardinalMax = western(MAX_SCALE_KEY)
+export const ordinalMax = western(MAX_SCALE_KEY)
+export const currencyMax = western(MAX_SCALE_KEY)
 
 const ZERO = 'nula'
 const NEGATIVE = 'mínus'
@@ -347,9 +350,7 @@ function toCardinal(value) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   let result = ''
 
@@ -517,7 +518,7 @@ function buildLargeOrdinal(n) {
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
   // Ordinals reuse the cardinal scale table, so they share its ceiling.
-  if (integerPart >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -539,7 +540,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: koruny, cents: halere } = parseCurrencyValue(value)
-  if (koruny >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(koruny, currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/hr-HR.js
+++ b/src/hr-HR.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -261,10 +262,9 @@ function decimalPartToWords(decimalPart, gender) {
 // Supported magnitude ceilings (checked at the public entry points). Both
 // tables are indexed [scaleIndex - 1] (units separate), so the ceiling is
 // 10^((length + 1) * 3): cardinal/currency 10^30, ordinal 10^15.
-const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_FORMS.length)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(SCALE_FORMS.length)
 
 /**
  * Converts a numeric value to Croatian words.
@@ -278,9 +278,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -458,7 +456,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -480,7 +478,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/lt-LT.js
+++ b/src/lt-LT.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -80,10 +81,9 @@ const SCALE_FORMS = [
 // currency ceiling is 10^((SCALE_FORMS.length + 1) * 3) = 10^30, and the
 // shorter ORDINAL_SCALES bounds ordinals at 10^((ORDINAL_SCALES.length + 1) *
 // 3) = 10^15.
-const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_FORMS.length)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(SCALE_FORMS.length)
 
 // ============================================================================
 // Segment Building
@@ -321,9 +321,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -504,7 +502,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -526,7 +524,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/lv-LV.js
+++ b/src/lv-LV.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -81,10 +82,9 @@ const SCALE_FORMS = [
 // currency ceiling is 10^((SCALE_FORMS.length + 1) * 3) = 10^30, and the
 // shorter ORDINAL_SCALES bounds ordinals at 10^((ORDINAL_SCALES.length + 1) *
 // 3) = 10^15.
-const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_FORMS.length)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(SCALE_FORMS.length)
 
 // ============================================================================
 // Segment Building
@@ -368,9 +368,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -562,7 +560,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -584,7 +582,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
-  if (euros >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(euros, currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/pl-PL.js
+++ b/src/pl-PL.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -312,10 +313,9 @@ function decimalPartToWords(decimalPart, gender) {
 // the fraction would spell silently-wrong, so the decimal is guarded too.)
 // Derive from the max numeric key (robust to gaps / non-scale keys).
 const MAX_SCALE_KEY = Math.max(...Object.keys(PLURAL_FORMS).map(Number))
-const MAX_CARDINAL_EXPONENT = (MAX_SCALE_KEY + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(MAX_SCALE_KEY)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(MAX_SCALE_KEY)
 
 /**
  * Converts a numeric value to Polish words.
@@ -339,9 +339,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -548,7 +546,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -570,7 +568,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: zloty, cents: grosze } = parseCurrencyValue(value)
-  if (zloty >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(zloty, currencyMax)
 
   let result = ''
   if (isNegative) {

--- a/src/ru-RU.js
+++ b/src/ru-RU.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -297,10 +298,9 @@ function decimalPartToWords(decimalPart, gender) {
 // Supported magnitude ceilings (checked at the public entry points). Both
 // tables are indexed [scaleIndex - 1] (units separate), so the ceiling is
 // 10^((length + 1) * 3): cardinal/currency 10^33, ordinal 10^33.
-const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_FORMS.length)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(SCALE_FORMS.length)
 
 /**
  * Converts a numeric value to Russian words.
@@ -314,9 +314,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -526,7 +524,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -552,7 +550,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: rubles, cents: kopecks } = parseCurrencyValue(value)
-  if (rubles >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(rubles, currencyMax)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/sr-Cyrl-RS.js
+++ b/src/sr-Cyrl-RS.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -86,10 +87,9 @@ const SCALE_FORMS = [
 // Supported magnitude ceilings (checked at the public entry points). Both the
 // cardinal SCALE_FORMS and the ORDINAL_SCALES tables cover units + N scale
 // groups, so values must stay below 10^((length + 1) * 3) = 10^30.
-const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_FORMS.length)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(SCALE_FORMS.length)
 
 // ============================================================================
 // Segment Building
@@ -286,9 +286,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -494,7 +492,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -520,7 +518,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: dinars, cents: para } = parseCurrencyValue(value)
-  if (dinars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(dinars, currencyMax)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/sr-Latn-RS.js
+++ b/src/sr-Latn-RS.js
@@ -14,7 +14,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -86,10 +87,9 @@ const SCALE_FORMS = [
 // Supported magnitude ceilings (checked at the public entry points). Both the
 // cardinal SCALE_FORMS and the ORDINAL_SCALES tables cover units + N scale
 // groups, so values must stay below 10^((length + 1) * 3) = 10^30.
-const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_FORMS.length)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(SCALE_FORMS.length)
 
 // ============================================================================
 // Segment Building
@@ -286,9 +286,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -494,7 +492,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -520,7 +518,7 @@ function toOrdinal(value) {
 function toCurrency(value, options) {
   options = validateOptions(options)
   const { isNegative, dollars: dinars, cents: para } = parseCurrencyValue(value)
-  if (dinars >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(dinars, currencyMax)
   const { and: useAnd = true } = options
 
   // Build result

--- a/src/uk-UA.js
+++ b/src/uk-UA.js
@@ -13,7 +13,8 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
-import { tooLargeError } from './utils/too-large-error.js'
+import { checkMax } from './utils/check-max.js'
+import { western } from './utils/scale.js'
 import { validateOptions } from './utils/validate-options.js'
 
 // ============================================================================
@@ -261,10 +262,9 @@ function decimalPartToWords(decimalPart, gender) {
 // Supported magnitude ceilings (checked at the public entry points). Both
 // tables are indexed [scaleIndex - 1] (units separate), so the ceiling is
 // 10^((length + 1) * 3): cardinal/currency 10^30, ordinal 10^15.
-const MAX_CARDINAL_EXPONENT = (SCALE_FORMS.length + 1) * 3
-const MAX_CARDINAL = 10n ** BigInt(MAX_CARDINAL_EXPONENT)
-const MAX_ORDINAL_EXPONENT = (ORDINAL_SCALES.length + 1) * 3
-const MAX_ORDINAL = 10n ** BigInt(MAX_ORDINAL_EXPONENT)
+export const cardinalMax = western(SCALE_FORMS.length)
+export const ordinalMax = western(ORDINAL_SCALES.length)
+export const currencyMax = western(SCALE_FORMS.length)
 
 /**
  * Converts a numeric value to Ukrainian words.
@@ -278,9 +278,7 @@ function toCardinal(value, options) {
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
-  if (integerPart >= MAX_CARDINAL || (decimalPart && BigInt(decimalPart) >= MAX_CARDINAL)) {
-    throw tooLargeError(MAX_CARDINAL_EXPONENT)
-  }
+  checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
   const { gender = 'masculine' } = options
@@ -458,7 +456,7 @@ function buildLargeOrdinal(n) {
  */
 function toOrdinal(value) {
   const integerPart = parseOrdinalValue(value)
-  if (integerPart >= MAX_ORDINAL) throw tooLargeError(MAX_ORDINAL_EXPONENT)
+  checkMax(integerPart, ordinalMax)
   return integerToOrdinal(integerPart)
 }
 
@@ -480,7 +478,7 @@ function toOrdinal(value) {
  */
 function toCurrency(value) {
   const { isNegative, dollars: hryvnia, cents: kopiyky } = parseCurrencyValue(value)
-  if (hryvnia >= MAX_CARDINAL) throw tooLargeError(MAX_CARDINAL_EXPONENT)
+  checkMax(hryvnia, currencyMax)
 
   let result = ''
   if (isNegative) {


### PR DESCRIPTION
The last big split-ceiling batch — nine Slavic/Baltic languages. Per-form `*Max`, currency sharing the cardinal ceiling.

## Per-form ceilings

| Lang | cardinal | ordinal |
|---|---|---|
| `hr-HR`, `lt-LT`, `lv-LV`, `uk-UA` | `western(SCALE_FORMS.length)` 10^30 | `western(ORDINAL_SCALES.length)` 10^15 |
| `ru-RU` | `western(SCALE_FORMS.length)` 10^33 | `western(ORDINAL_SCALES.length)` 10^33 |
| `sr-Latn-RS`, `sr-Cyrl-RS` | `western(SCALE_FORMS.length)` 10^30 | `western(ORDINAL_SCALES.length)` 10^30 |
| `pl-PL` | `western(MAX_SCALE_KEY)` 10^33 | `western(ORDINAL_SCALES.length)` 10^24 |
| `cs-CZ` | `western(MAX_SCALE_KEY)` 10^30 | *shares cardinal* 10^30 |

`cs-CZ` is the odd one: its ordinals reuse the cardinal scale table, so there's no separate ordinal ceiling — all three forms share `western(MAX_SCALE_KEY)` (the largest `PLURAL_FORMS` key, which I extracted to a `MAX_SCALE_KEY` const to match `pl-PL`'s existing pattern).

## Verification

- All cardinal guards integer-spelled (pass `decimalPart`).
- Every helper expression is **algebraically identical** to the prior `MAX_*_EXPONENT` (no drift).
- The gate's two-sided boundary check pins **both** forms for all nine.
- Full suite green (411 tests).

With this, the split-ceiling group is done. Remaining in the sweep: the three unbounded stragglers (fa-IR, hu-HU, yo-NG), then `vi-VN`'s vocab fix and the LANGUAGES.md range column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)