### PR TITLE
refactor(core): declare the unbounded languages' range (fa-IR, hu-HU, yo-NG)

### DIFF
--- a/src/fa-IR.js
+++ b/src/fa-IR.js
@@ -12,6 +12,12 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { UNBOUNDED } from './utils/scale.js'
+
+// No fixed scale ceiling — the speller composes every magnitude.
+export const cardinalMax = UNBOUNDED
+export const ordinalMax = UNBOUNDED
+export const currencyMax = UNBOUNDED
 
 // ============================================================================
 // Vocabulary

--- a/src/hu-HU.js
+++ b/src/hu-HU.js
@@ -13,6 +13,12 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { UNBOUNDED } from './utils/scale.js'
+
+// No fixed scale ceiling — the speller composes every magnitude.
+export const cardinalMax = UNBOUNDED
+export const ordinalMax = UNBOUNDED
+export const currencyMax = UNBOUNDED
 
 // ============================================================================
 // Vocabulary

--- a/src/yo-NG.js
+++ b/src/yo-NG.js
@@ -19,6 +19,12 @@
 import { parseCardinalValue } from './utils/parse-cardinal.js'
 import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
+import { UNBOUNDED } from './utils/scale.js'
+
+// No fixed scale ceiling — the vigesimal speller composes every magnitude.
+export const cardinalMax = UNBOUNDED
+export const ordinalMax = UNBOUNDED
+export const currencyMax = UNBOUNDED
 
 // ============================================================================
 // Vocabulary (module-level constants)


### PR DESCRIPTION
The unbounded stragglers — the languages that compose every magnitude without ever running out of scale words, so they have no ceiling to enforce.

| Lang | why unbounded |
|---|---|
| `fa-IR` (Persian) | recursive/compounding speller |
| `hu-HU` (Hungarian) | recursive/compounding speller |
| `yo-NG` (Yoruba) | vigesimal compounding speller |

Each now exports `cardinalMax = ordinalMax = currencyMax = UNBOUNDED` (= `null`) — the explicit "no fixed limit" declaration. No guard is added (there's nothing to refuse).

## Why this is safe

Before declaring it, I verified empirically that all three forms of all three languages stay **well-formed and injective from 10^1 to 10^329** — the same sweep the gate runs (this is exactly the check that caught vi-VN's collapse, so it's not taken on faith). The gate now registers and passes all three (no boundary check, since the max is `null`).

Full suite green (414 tests).

With this, **every language except `vi-VN` is on the range contract**. Remaining: vi-VN's vocabulary fix (its `10^14 ≡ 10^15` collapse), then the LANGUAGES.md range column built off the `*Max` exports, then deleting the now-unused `tooLargeError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)