### PR TITLE
docs(core): show each form's maximum range in LANGUAGES.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,17 +88,23 @@ import { validateOptions } from './utils/validate-options.js'
 
 /**
  * @param {number | string | bigint} value
- * @param {Object} [options]
- * @param {('masculine'|'feminine')} [options.gender='masculine']
+ * @param {object} [options]
+ * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender of the number
  * @returns {string}
  */
 function toCardinal (value, options) {
   options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
-  const { gender = 'masculine' } = options
+  const { gender = 'masculine' } = options // default lives here — the single source of truth
   // Pass explicit values to internal functions, not options object
 }
 ```
+
+Document each option with an **explicit** `@param {type} [options.name] - description` —
+never an inline `@param {{name?: type}} [options]`, which has nowhere for the
+description. Put the **default in the destructuring** (`{ gender = 'masculine' }`),
+not in the `@param` tag: it's the single source of truth, and the `LANGUAGES.md`
+generator reads it from there (`@param {object}` lowercase, so it doesn't trip lint).
 
 ## Adding a Language
 

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -116,270 +116,270 @@ toCurrency(value, { optionName: value })
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`hundredPairing`|cardinal|`boolean`|—|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
-|`and`|cardinal|`boolean`|—|Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")|
-|`and`|currency|`boolean`|—|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
+|`hundredPairing`|cardinal|`boolean`|`false`|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
+|`and`|cardinal|`boolean`|`false`|Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")|
+|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
 
 ### Arabic (Saudi Arabia) (`ar-SA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`negativeWord`|cardinal|`string`|—|Custom word for negative numbers|
-|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`negativeWord`|cardinal|`string`|`NEGATIVE`|Custom word for negative numbers|
+|`gender`|ordinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
 
 ### Australian English (`en-AU`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between dollars and cents|
+|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents|
 
 ### Biblical Hebrew (Israel) (`hbo-IL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`andWord`|cardinal|`string`|—|Custom conjunction word|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`andWord`|cardinal|`string`|`ו`|Custom conjunction word|
 
 ### Brazilian Portuguese (`pt-BR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Include "e" between major and minor units|
+|`and`|currency|`boolean`|`true`|Include "e" between major and minor units|
 |`currency`|currency|`string`|—|Currency code (e.g., 'BRL', 'USD')|
 
 ### British English (`en-GB`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between pounds and pence (e.g., "one pound and fifty pence")|
+|`and`|currency|`boolean`|`true`|Use "and" between pounds and pence (e.g., "one pound and fifty pence")|
 
 ### Canadian English (`en-CA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`hundredPairing`|cardinal|`boolean`|—|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
-|`and`|cardinal|`boolean`|—|Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)|
-|`and`|currency|`boolean`|—|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
+|`hundredPairing`|cardinal|`boolean`|`false`|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
+|`and`|cardinal|`boolean`|`true`|Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)|
+|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
 
 ### Chinese (Simplified, China) (`zh-Hans-CN`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`formal`|cardinal|`boolean`|—|Use formal/financial numerals|
-|`formal`|ordinal|`boolean`|—|Use formal/financial numerals|
-|`formal`|currency|`boolean`|—|Use formal/financial numerals|
+|`formal`|cardinal|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|ordinal|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|currency|`boolean`|`true`|Use formal/financial numerals|
 
 ### Chinese (Traditional, Taiwan) (`zh-Hant-TW`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`formal`|cardinal|`boolean`|—|Use formal/financial numerals|
-|`formal`|ordinal|`boolean`|—|Use formal/financial numerals|
-|`formal`|currency|`boolean`|—|Use formal/financial numerals|
+|`formal`|cardinal|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|ordinal|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|currency|`boolean`|`true`|Use formal/financial numerals|
 
 ### Croatian (Croatia) (`hr-HR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
 
 ### Dutch (Netherlands) (`nl-NL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`accentOne`|cardinal|`boolean`|—|Use "één" instead of "een"|
-|`includeOptionalAnd`|cardinal|`boolean`|—|Include "en" before small numbers|
-|`noHundredPairing`|cardinal|`boolean`|—|Disable hundred pairing (1104→duizend honderdvier)|
-|`and`|currency|`boolean`|—|Include "en" between euros and cents|
+|`accentOne`|cardinal|`boolean`|`true`|Use "één" instead of "een"|
+|`includeOptionalAnd`|cardinal|`boolean`|`false`|Include "en" before small numbers|
+|`noHundredPairing`|cardinal|`boolean`|`false`|Disable hundred pairing (1104→duizend honderdvier)|
+|`and`|currency|`boolean`|`true`|Include "en" between euros and cents|
 
 ### English (Bangladesh) (`en-BD`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between taka and paise|
+|`and`|currency|`boolean`|`true`|Use "and" between taka and paise|
 
 ### English (Ghana) (`en-GH`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—||
+|`and`|currency|`boolean`|`true`|Use "and" between cedis and pesewas|
 
 ### English (India) (`en-IN`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between rupees and paise|
+|`and`|currency|`boolean`|`true`|Use "and" between rupees and paise|
 
 ### English (Ireland) (`en-IE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between euro and cent (e.g., "one euro and fifty cents")|
+|`and`|currency|`boolean`|`true`|Use "and" between euro and cent (e.g., "one euro and fifty cents")|
 
 ### English (Kenya) (`en-KE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—||
+|`and`|currency|`boolean`|`true`|Use "and" between shillings and cents|
 
 ### English (Malaysia) (`en-MY`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—||
+|`and`|currency|`boolean`|`true`|Use "and" between ringgit and sen|
 
 ### English (New Zealand) (`en-NZ`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—||
+|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents|
 
 ### English (Nigeria) (`en-NG`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between naira and kobo (e.g., "one naira and fifty kobo")|
+|`and`|currency|`boolean`|`true`|Use "and" between naira and kobo (e.g., "one naira and fifty kobo")|
 
 ### English (Pakistan) (`en-PK`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between rupees and paise|
+|`and`|currency|`boolean`|`true`|Use "and" between rupees and paise|
 
 ### English (Philippines) (`en-PH`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—||
+|`and`|currency|`boolean`|`true`|Use "and" between pesos and centavos|
 
 ### English (Singapore) (`en-SG`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—||
+|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents|
 
 ### English (South Africa) (`en-ZA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "and" between rand and cents (e.g., "one rand and fifty cents")|
+|`and`|currency|`boolean`|`true`|Use "and" between rand and cents (e.g., "one rand and fifty cents")|
 
 ### European Portuguese (`pt-PT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Include "e" between euros and cents|
+|`and`|currency|`boolean`|`true`|Include "e" between euros and cents|
 
 ### European Spanish (`es-ES`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`and`|currency|`boolean`|—|Use "con" between euros and cents|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`and`|currency|`boolean`|`true`|Use "con" between euros and cents|
 
 ### French (Belgium) (`fr-BE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`withHyphenSeparator`|cardinal|`boolean`|—|Use hyphens between words|
-|`and`|currency|`boolean`|—|Use "et" between euros and centimes|
+|`withHyphenSeparator`|cardinal|`boolean`|`false`|Use hyphens between words|
+|`and`|currency|`boolean`|`true`|Use "et" between euros and centimes|
 
 ### French (France) (`fr-FR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`withHyphenSeparator`|cardinal|`boolean`|—|Use hyphens between all words|
-|`and`|currency|`boolean`|—|Use "et" between euros and centimes|
+|`withHyphenSeparator`|cardinal|`boolean`|`false`|Use hyphens between all words|
+|`and`|currency|`boolean`|`true`|Use "et" between euros and centimes|
 
 ### German (Germany) (`de-DE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "und" between euros and cents|
+|`and`|currency|`boolean`|`true`|Use "und" between euros and cents|
 
 ### Hebrew (Israel) (`he-IL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`andWord`|cardinal|`string`|—|Custom conjunction word|
+|`andWord`|cardinal|`string`|`ו`|Custom conjunction word|
 
 ### Italian (Italy) (`it-IT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|—|Use "e" between euros and centesimi|
+|`and`|currency|`boolean`|`true`|Use "e" between euros and centesimi|
 
 ### Latvian (Latvia) (`lv-LV`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|`masculine`|Gender for numbers < 1000|
 
 ### Lithuanian (Lithuania) (`lt-LT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|`masculine`|Gender for numbers < 1000|
 
 ### Mexican Spanish (`es-MX`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`and`|currency|`boolean`|—|Use "con" between pesos and centavos|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`and`|currency|`boolean`|`true`|Use "con" between pesos and centavos|
 
 ### Polish (Poland) (`pl-PL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|`masculine`|Gender for numbers < 1000|
 
 ### Romanian (Romania) (`ro-RO`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|—|Gender for numbers|
+|`gender`|cardinal|`string`|`masculine`|Gender for numbers|
 
 ### Russian (Russia) (`ru-RU`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`and`|currency|`boolean`|—|Use "и" between rubles and kopecks|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`and`|currency|`boolean`|`true`|Use "и" between rubles and kopecks|
 
 ### Serbian (Cyrillic, Serbia) (`sr-Cyrl-RS`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`and`|currency|`boolean`|—|Use "и" between dinars and para|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`and`|currency|`boolean`|`true`|Use "и" between dinars and para|
 
 ### Serbian (Latin, Serbia) (`sr-Latn-RS`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`and`|currency|`boolean`|—|Use "i" between dinars and para|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`and`|currency|`boolean`|`true`|Use "i" between dinars and para|
 
 ### Spanish (United States) (`es-US`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
-|`and`|currency|`boolean`|—|Use "con" between dollars and cents|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|
+|`and`|currency|`boolean`|`true`|Use "con" between dollars and cents|
 
 ### Turkish (Türkiye) (`tr-TR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`dropSpaces`|cardinal|`boolean`|—|Remove spaces for compound form|
+|`dropSpaces`|cardinal|`boolean`|`false`|Remove spaces for compound form|
 
 ### Ukrainian (Ukraine) (`uk-UA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|`masculine`|Grammatical gender|

--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -10,78 +10,80 @@ Language codes follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) standards
 
 |Code|Language|Cardinal|Ordinal|Currency|
 |----|--------|:------:|:-----:|:------:|
-|`am-ET`|Amharic (Ethiopia)|✓|✓|✓|
-|`am-Latn-ET`|Amharic (Latin, Ethiopia)|✓|✓|✓|
-|`ar-SA`|Arabic (Saudi Arabia)|[✓*](#arabic-saudi-arabia-ar-sa)|[✓*](#arabic-saudi-arabia-ar-sa)|✓|
-|`az-AZ`|Azerbaijani (Azerbaijan)|✓|✓|✓|
-|`bn-BD`|Bangla (Bangladesh)|✓|✓|✓|
-|`cs-CZ`|Czech (Czechia)|✓|✓|✓|
-|`da-DK`|Danish (Denmark)|✓|✓|✓|
-|`de-DE`|German (Germany)|✓|✓|[✓*](#german-germany-de-de)|
-|`el-GR`|Greek (Greece)|✓|✓|✓|
-|`en-AU`|Australian English|✓|✓|[✓*](#australian-english-en-au)|
-|`en-BD`|English (Bangladesh)|✓|✓|[✓*](#english-bangladesh-en-bd)|
-|`en-CA`|Canadian English|[✓*](#canadian-english-en-ca)|✓|[✓*](#canadian-english-en-ca)|
-|`en-GB`|British English|✓|✓|[✓*](#british-english-en-gb)|
-|`en-GH`|English (Ghana)|✓|✓|✓|
-|`en-IE`|English (Ireland)|✓|✓|[✓*](#english-ireland-en-ie)|
-|`en-IN`|English (India)|✓|✓|[✓*](#english-india-en-in)|
-|`en-KE`|English (Kenya)|✓|✓|✓|
-|`en-MY`|English (Malaysia)|✓|✓|✓|
-|`en-NG`|English (Nigeria)|✓|✓|[✓*](#english-nigeria-en-ng)|
-|`en-NZ`|English (New Zealand)|✓|✓|✓|
-|`en-PH`|English (Philippines)|✓|✓|✓|
-|`en-PK`|English (Pakistan)|✓|✓|[✓*](#english-pakistan-en-pk)|
-|`en-SG`|English (Singapore)|✓|✓|✓|
-|`en-US`|American English|[✓*](#american-english-en-us)|✓|[✓*](#american-english-en-us)|
-|`en-ZA`|English (South Africa)|✓|✓|[✓*](#english-south-africa-en-za)|
-|`es-ES`|European Spanish|[✓*](#european-spanish-es-es)|[✓*](#european-spanish-es-es)|[✓*](#european-spanish-es-es)|
-|`es-MX`|Mexican Spanish|[✓*](#mexican-spanish-es-mx)|[✓*](#mexican-spanish-es-mx)|[✓*](#mexican-spanish-es-mx)|
-|`es-US`|Spanish (United States)|[✓*](#spanish-united-states-es-us)|[✓*](#spanish-united-states-es-us)|[✓*](#spanish-united-states-es-us)|
-|`fa-IR`|Persian (Iran)|✓|✓|✓|
-|`fi-FI`|Finnish (Finland)|✓|✓|✓|
-|`fil-PH`|Filipino (Philippines)|✓|✓|✓|
-|`fr-BE`|French (Belgium)|[✓*](#french-belgium-fr-be)|✓|[✓*](#french-belgium-fr-be)|
-|`fr-FR`|French (France)|[✓*](#french-france-fr-fr)|✓|[✓*](#french-france-fr-fr)|
-|`gu-IN`|Gujarati (India)|✓|✓|✓|
-|`ha-NG`|Hausa (Nigeria)|✓|✓|✓|
-|`hbo-IL`|Biblical Hebrew (Israel)|[✓*](#biblical-hebrew-israel-hbo-il)|✓|✓|
-|`he-IL`|Hebrew (Israel)|[✓*](#hebrew-israel-he-il)|✓|✓|
-|`hi-IN`|Hindi (India)|✓|✓|✓|
-|`hr-HR`|Croatian (Croatia)|[✓*](#croatian-croatia-hr-hr)|✓|✓|
-|`hu-HU`|Hungarian (Hungary)|✓|✓|✓|
-|`id-ID`|Indonesian (Indonesia)|✓|✓|✓|
-|`it-IT`|Italian (Italy)|✓|✓|[✓*](#italian-italy-it-it)|
-|`ja-JP`|Japanese (Japan)|✓|✓|✓|
-|`ka-GE`|Georgian (Georgia)|✓|✓|✓|
-|`kn-IN`|Kannada (India)|✓|✓|✓|
-|`ko-KR`|Korean (South Korea)|✓|✓|✓|
-|`lt-LT`|Lithuanian (Lithuania)|[✓*](#lithuanian-lithuania-lt-lt)|✓|✓|
-|`lv-LV`|Latvian (Latvia)|[✓*](#latvian-latvia-lv-lv)|✓|✓|
-|`mr-IN`|Marathi (India)|✓|✓|✓|
-|`ms-MY`|Malay (Malaysia)|✓|✓|✓|
-|`nb-NO`|Norwegian Bokmål (Norway)|✓|✓|✓|
-|`nl-NL`|Dutch (Netherlands)|[✓*](#dutch-netherlands-nl-nl)|✓|[✓*](#dutch-netherlands-nl-nl)|
-|`pa-IN`|Punjabi (India)|✓|✓|✓|
-|`pl-PL`|Polish (Poland)|[✓*](#polish-poland-pl-pl)|✓|✓|
-|`pt-BR`|Brazilian Portuguese|✓|✓|[✓*](#brazilian-portuguese-pt-br)|
-|`pt-PT`|European Portuguese|✓|✓|[✓*](#european-portuguese-pt-pt)|
-|`ro-RO`|Romanian (Romania)|[✓*](#romanian-romania-ro-ro)|✓|✓|
-|`ru-RU`|Russian (Russia)|[✓*](#russian-russia-ru-ru)|✓|[✓*](#russian-russia-ru-ru)|
-|`sr-Cyrl-RS`|Serbian (Cyrillic, Serbia)|[✓*](#serbian-cyrillic-serbia-sr-cyrl-rs)|✓|[✓*](#serbian-cyrillic-serbia-sr-cyrl-rs)|
-|`sr-Latn-RS`|Serbian (Latin, Serbia)|[✓*](#serbian-latin-serbia-sr-latn-rs)|✓|[✓*](#serbian-latin-serbia-sr-latn-rs)|
-|`sv-SE`|Swedish (Sweden)|✓|✓|✓|
-|`sw-KE`|Swahili (Kenya)|✓|✓|✓|
-|`ta-IN`|Tamil (India)|✓|✓|✓|
-|`te-IN`|Telugu (India)|✓|✓|✓|
-|`th-TH`|Thai (Thailand)|✓|✓|✓|
-|`tr-TR`|Turkish (Türkiye)|[✓*](#turkish-türkiye-tr-tr)|✓|✓|
-|`uk-UA`|Ukrainian (Ukraine)|[✓*](#ukrainian-ukraine-uk-ua)|✓|✓|
-|`ur-PK`|Urdu (Pakistan)|✓|✓|✓|
-|`vi-VN`|Vietnamese (Vietnam)|✓|✓|✓|
-|`yo-NG`|Yoruba (Nigeria)|✓|✓|✓|
-|`zh-Hans-CN`|Chinese (Simplified, China)|[✓*](#chinese-simplified-china-zh-hans-cn)|[✓*](#chinese-simplified-china-zh-hans-cn)|[✓*](#chinese-simplified-china-zh-hans-cn)|
-|`zh-Hant-TW`|Chinese (Traditional, Taiwan)|[✓*](#chinese-traditional-taiwan-zh-hant-tw)|[✓*](#chinese-traditional-taiwan-zh-hant-tw)|[✓*](#chinese-traditional-taiwan-zh-hant-tw)|
+|`am-ET`|Amharic (Ethiopia)|10^12 - 1|10^12 - 1|10^12 - 1|
+|`am-Latn-ET`|Amharic (Latin, Ethiopia)|10^12 - 1|10^12 - 1|10^12 - 1|
+|`ar-SA`|Arabic (Saudi Arabia)|10^24 - 1 [*](#arabic-saudi-arabia-ar-sa)|10^24 - 1 [*](#arabic-saudi-arabia-ar-sa)|10^24 - 1|
+|`az-AZ`|Azerbaijani (Azerbaijan)|10^21 - 1|10^21 - 1|10^21 - 1|
+|`bn-BD`|Bangla (Bangladesh)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`cs-CZ`|Czech (Czechia)|10^30 - 1|10^30 - 1|10^30 - 1|
+|`da-DK`|Danish (Denmark)|10^30 - 1|10^30 - 1|10^30 - 1|
+|`de-DE`|German (Germany)|10^30 - 1|10^30 - 1|10^30 - 1 [*](#german-germany-de-de)|
+|`el-GR`|Greek (Greece)|10^15 - 1|10^9 - 1|10^15 - 1|
+|`en-AU`|Australian English|10^66 - 1|10^66 - 1|10^66 - 1 [*](#australian-english-en-au)|
+|`en-BD`|English (Bangladesh)|10^19 - 1|10^19 - 1|10^19 - 1 [*](#english-bangladesh-en-bd)|
+|`en-CA`|Canadian English|10^66 - 1 [*](#canadian-english-en-ca)|10^66 - 1|10^66 - 1 [*](#canadian-english-en-ca)|
+|`en-GB`|British English|10^66 - 1|10^66 - 1|10^66 - 1 [*](#british-english-en-gb)|
+|`en-GH`|English (Ghana)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-ghana-en-gh)|
+|`en-IE`|English (Ireland)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-ireland-en-ie)|
+|`en-IN`|English (India)|10^19 - 1|10^19 - 1|10^19 - 1 [*](#english-india-en-in)|
+|`en-KE`|English (Kenya)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-kenya-en-ke)|
+|`en-MY`|English (Malaysia)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-malaysia-en-my)|
+|`en-NG`|English (Nigeria)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-nigeria-en-ng)|
+|`en-NZ`|English (New Zealand)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-new-zealand-en-nz)|
+|`en-PH`|English (Philippines)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-philippines-en-ph)|
+|`en-PK`|English (Pakistan)|10^19 - 1|10^19 - 1|10^19 - 1 [*](#english-pakistan-en-pk)|
+|`en-SG`|English (Singapore)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-singapore-en-sg)|
+|`en-US`|American English|10^66 - 1 [*](#american-english-en-us)|10^66 - 1|10^66 - 1 [*](#american-english-en-us)|
+|`en-ZA`|English (South Africa)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#english-south-africa-en-za)|
+|`es-ES`|European Spanish|10^30 - 1 [*](#european-spanish-es-es)|10^9 - 1 [*](#european-spanish-es-es)|10^30 - 1 [*](#european-spanish-es-es)|
+|`es-MX`|Mexican Spanish|10^30 - 1 [*](#mexican-spanish-es-mx)|10^9 - 1 [*](#mexican-spanish-es-mx)|10^30 - 1 [*](#mexican-spanish-es-mx)|
+|`es-US`|Spanish (United States)|10^21 - 1 [*](#spanish-united-states-es-us)|10^9 - 1 [*](#spanish-united-states-es-us)|10^21 - 1 [*](#spanish-united-states-es-us)|
+|`fa-IR`|Persian (Iran)|∞|∞|∞|
+|`fi-FI`|Finnish (Finland)|10^18 - 1|10^18 - 1|10^18 - 1|
+|`fil-PH`|Filipino (Philippines)|10^15 - 1|10^15 - 1|10^15 - 1|
+|`fr-BE`|French (Belgium)|10^30 - 1 [*](#french-belgium-fr-be)|10^30 - 1|10^30 - 1 [*](#french-belgium-fr-be)|
+|`fr-FR`|French (France)|10^30 - 1 [*](#french-france-fr-fr)|10^30 - 1|10^30 - 1 [*](#french-france-fr-fr)|
+|`gu-IN`|Gujarati (India)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`ha-NG`|Hausa (Nigeria)|10^12 - 1|10^12 - 1|10^12 - 1|
+|`hbo-IL`|Biblical Hebrew (Israel)|10^21 - 1 [*](#biblical-hebrew-israel-hbo-il)|10^9 - 1|10^21 - 1|
+|`he-IL`|Hebrew (Israel)|10^21 - 1 [*](#hebrew-israel-he-il)|10^9 - 1|10^21 - 1|
+|`hi-IN`|Hindi (India)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`hr-HR`|Croatian (Croatia)|10^30 - 1 [*](#croatian-croatia-hr-hr)|10^15 - 1|10^30 - 1|
+|`hu-HU`|Hungarian (Hungary)|∞|∞|∞|
+|`id-ID`|Indonesian (Indonesia)|10^36 - 1|10^36 - 1|10^36 - 1|
+|`it-IT`|Italian (Italy)|10^66 - 1|10^66 - 1|10^66 - 1 [*](#italian-italy-it-it)|
+|`ja-JP`|Japanese (Japan)|10^72 - 1|10^72 - 1|10^72 - 1|
+|`ka-GE`|Georgian (Georgia)|10^24 - 1|10^24 - 1|10^24 - 1|
+|`kn-IN`|Kannada (India)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`ko-KR`|Korean (South Korea)|10^32 - 1|10^32 - 1|10^32 - 1|
+|`lt-LT`|Lithuanian (Lithuania)|10^30 - 1 [*](#lithuanian-lithuania-lt-lt)|10^15 - 1|10^30 - 1|
+|`lv-LV`|Latvian (Latvia)|10^30 - 1 [*](#latvian-latvia-lv-lv)|10^15 - 1|10^30 - 1|
+|`mr-IN`|Marathi (India)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`ms-MY`|Malay (Malaysia)|10^15 - 1|10^15 - 1|10^15 - 1|
+|`nb-NO`|Norwegian Bokmål (Norway)|10^30 - 1|10^30 - 1|10^30 - 1|
+|`nl-NL`|Dutch (Netherlands)|10^30 - 1 [*](#dutch-netherlands-nl-nl)|10^21 - 1|10^30 - 1 [*](#dutch-netherlands-nl-nl)|
+|`pa-IN`|Punjabi (India)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`pl-PL`|Polish (Poland)|10^33 - 1 [*](#polish-poland-pl-pl)|10^24 - 1|10^33 - 1|
+|`pt-BR`|Brazilian Portuguese|10^27 - 1|10^24 - 1|10^27 - 1 [*](#brazilian-portuguese-pt-br)|
+|`pt-PT`|European Portuguese|10^27 - 1|10^21 - 1|10^27 - 1 [*](#european-portuguese-pt-pt)|
+|`ro-RO`|Romanian (Romania)|10^30 - 1 [*](#romanian-romania-ro-ro)|10^9 - 1|10^30 - 1|
+|`ru-RU`|Russian (Russia)|10^33 - 1 [*](#russian-russia-ru-ru)|10^33 - 1|10^33 - 1 [*](#russian-russia-ru-ru)|
+|`sr-Cyrl-RS`|Serbian (Cyrillic, Serbia)|10^30 - 1 [*](#serbian-cyrillic-serbia-sr-cyrl-rs)|10^30 - 1|10^30 - 1 [*](#serbian-cyrillic-serbia-sr-cyrl-rs)|
+|`sr-Latn-RS`|Serbian (Latin, Serbia)|10^30 - 1 [*](#serbian-latin-serbia-sr-latn-rs)|10^30 - 1|10^30 - 1 [*](#serbian-latin-serbia-sr-latn-rs)|
+|`sv-SE`|Swedish (Sweden)|10^27 - 1|10^27 - 1|10^27 - 1|
+|`sw-KE`|Swahili (Kenya)|10^21 - 1|10^21 - 1|10^21 - 1|
+|`ta-IN`|Tamil (India)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`te-IN`|Telugu (India)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`th-TH`|Thai (Thailand)|∞|∞|∞|
+|`tr-TR`|Turkish (Türkiye)|10^21 - 1 [*](#turkish-türkiye-tr-tr)|10^21 - 1|10^21 - 1|
+|`uk-UA`|Ukrainian (Ukraine)|10^30 - 1 [*](#ukrainian-ukraine-uk-ua)|10^15 - 1|10^30 - 1|
+|`ur-PK`|Urdu (Pakistan)|10^19 - 1|10^19 - 1|10^19 - 1|
+|`vi-VN`|Vietnamese (Vietnam)|10^21 - 1|10^21 - 1|10^21 - 1|
+|`yo-NG`|Yoruba (Nigeria)|∞|∞|∞|
+|`zh-Hans-CN`|Chinese (Simplified, China)|10^16 - 1 [*](#chinese-simplified-china-zh-hans-cn)|10^16 - 1 [*](#chinese-simplified-china-zh-hans-cn)|10^16 - 1 [*](#chinese-simplified-china-zh-hans-cn)|
+|`zh-Hant-TW`|Chinese (Traditional, Taiwan)|10^16 - 1 [*](#chinese-traditional-taiwan-zh-hant-tw)|10^16 - 1 [*](#chinese-traditional-taiwan-zh-hant-tw)|10^16 - 1 [*](#chinese-traditional-taiwan-zh-hant-tw)|
+
+Each form column shows the largest value it converts (`10^N - 1`), `∞` when unbounded, or blank when the form isn't supported.
 
 \* Has options — click to jump to that language's options.
 
@@ -103,7 +105,7 @@ Import paths use BCP 47 language codes: `n2words/en-US`, `n2words/zh-Hans-CN`, `
 
 ## Language Options
 
-35 languages support options via a second parameter. Options are passed as an object:
+41 languages support options via a second parameter. Options are passed as an object:
 
 ```js
 toCardinal(value, { optionName: value })
@@ -114,234 +116,270 @@ toCurrency(value, { optionName: value })
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`hundredPairing`|cardinal|`boolean`|`false`|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
-|`and`|cardinal|`boolean`|`false`|Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")|
-|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
+|`hundredPairing`|cardinal|`boolean`|—|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
+|`and`|cardinal|`boolean`|—|Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")|
+|`and`|currency|`boolean`|—|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
 
 ### Arabic (Saudi Arabia) (`ar-SA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
 |`negativeWord`|cardinal|`string`|—|Custom word for negative numbers|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
 
 ### Australian English (`en-AU`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents|
+|`and`|currency|`boolean`|—|Use "and" between dollars and cents|
 
 ### Biblical Hebrew (Israel) (`hbo-IL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`andWord`|cardinal|`string`|`'ו'`|Custom conjunction word|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`andWord`|cardinal|`string`|—|Custom conjunction word|
 
 ### Brazilian Portuguese (`pt-BR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Include "e" between major and minor units|
+|`and`|currency|`boolean`|—|Include "e" between major and minor units|
 |`currency`|currency|`string`|—|Currency code (e.g., 'BRL', 'USD')|
 
 ### British English (`en-GB`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between pounds and pence (e.g., "one pound and fifty pence")|
+|`and`|currency|`boolean`|—|Use "and" between pounds and pence (e.g., "one pound and fifty pence")|
 
 ### Canadian English (`en-CA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`hundredPairing`|cardinal|`boolean`|`false`|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
-|`and`|cardinal|`boolean`|`true`|Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)|
-|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
+|`hundredPairing`|cardinal|`boolean`|—|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
+|`and`|cardinal|`boolean`|—|Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)|
+|`and`|currency|`boolean`|—|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
 
 ### Chinese (Simplified, China) (`zh-Hans-CN`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`formal`|cardinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|ordinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|currency|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|cardinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|ordinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|currency|`boolean`|—|Use formal/financial numerals|
 
 ### Chinese (Traditional, Taiwan) (`zh-Hant-TW`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`formal`|cardinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|ordinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|currency|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|cardinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|ordinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|currency|`boolean`|—|Use formal/financial numerals|
 
 ### Croatian (Croatia) (`hr-HR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
 
 ### Dutch (Netherlands) (`nl-NL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`accentOne`|cardinal|`boolean`|`true`|Use "één" instead of "een"|
-|`includeOptionalAnd`|cardinal|`boolean`|`false`|Include "en" before small numbers|
-|`noHundredPairing`|cardinal|`boolean`|`false`|Disable hundred pairing (1104→duizend honderdvier)|
-|`and`|currency|`boolean`|`true`|Include "en" between euros and cents|
+|`accentOne`|cardinal|`boolean`|—|Use "één" instead of "een"|
+|`includeOptionalAnd`|cardinal|`boolean`|—|Include "en" before small numbers|
+|`noHundredPairing`|cardinal|`boolean`|—|Disable hundred pairing (1104→duizend honderdvier)|
+|`and`|currency|`boolean`|—|Include "en" between euros and cents|
 
 ### English (Bangladesh) (`en-BD`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between taka and paise|
+|`and`|currency|`boolean`|—|Use "and" between taka and paise|
+
+### English (Ghana) (`en-GH`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
 
 ### English (India) (`en-IN`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between rupees and paise|
+|`and`|currency|`boolean`|—|Use "and" between rupees and paise|
 
 ### English (Ireland) (`en-IE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between euro and cent (e.g., "one euro and fifty cents")|
+|`and`|currency|`boolean`|—|Use "and" between euro and cent (e.g., "one euro and fifty cents")|
+
+### English (Kenya) (`en-KE`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
+
+### English (Malaysia) (`en-MY`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
+
+### English (New Zealand) (`en-NZ`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
 
 ### English (Nigeria) (`en-NG`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between naira and kobo (e.g., "one naira and fifty kobo")|
+|`and`|currency|`boolean`|—|Use "and" between naira and kobo (e.g., "one naira and fifty kobo")|
 
 ### English (Pakistan) (`en-PK`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between rupees and paise|
+|`and`|currency|`boolean`|—|Use "and" between rupees and paise|
+
+### English (Philippines) (`en-PH`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
+
+### English (Singapore) (`en-SG`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
 
 ### English (South Africa) (`en-ZA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between rand and cents (e.g., "one rand and fifty cents")|
+|`and`|currency|`boolean`|—|Use "and" between rand and cents (e.g., "one rand and fifty cents")|
 
 ### European Portuguese (`pt-PT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Include "e" between euros and cents|
+|`and`|currency|`boolean`|—|Include "e" between euros and cents|
 
 ### European Spanish (`es-ES`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "con" between euros and cents|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "con" between euros and cents|
 
 ### French (Belgium) (`fr-BE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`withHyphenSeparator`|cardinal|`boolean`|`false`|Use hyphens between words|
-|`and`|currency|`boolean`|`true`|Use "et" between euros and centimes|
+|`withHyphenSeparator`|cardinal|`boolean`|—|Use hyphens between words|
+|`and`|currency|`boolean`|—|Use "et" between euros and centimes|
 
 ### French (France) (`fr-FR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`withHyphenSeparator`|cardinal|`boolean`|`false`|Use hyphens between all words|
-|`and`|currency|`boolean`|`true`|Use "et" between euros and centimes|
+|`withHyphenSeparator`|cardinal|`boolean`|—|Use hyphens between all words|
+|`and`|currency|`boolean`|—|Use "et" between euros and centimes|
 
 ### German (Germany) (`de-DE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "und" between euros and cents|
+|`and`|currency|`boolean`|—|Use "und" between euros and cents|
 
 ### Hebrew (Israel) (`he-IL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`andWord`|cardinal|`string`|`'ו'`|Custom conjunction word|
+|`andWord`|cardinal|`string`|—|Custom conjunction word|
 
 ### Italian (Italy) (`it-IT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "e" between euros and centesimi|
+|`and`|currency|`boolean`|—|Use "e" between euros and centesimi|
 
 ### Latvian (Latvia) (`lv-LV`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
 
 ### Lithuanian (Lithuania) (`lt-LT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
 
 ### Mexican Spanish (`es-MX`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "con" between pesos and centavos|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "con" between pesos and centavos|
 
 ### Polish (Poland) (`pl-PL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
 
 ### Romanian (Romania) (`ro-RO`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers|
+|`gender`|cardinal|`string`|—|Gender for numbers|
 
 ### Russian (Russia) (`ru-RU`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "и" between rubles and kopecks|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "и" between rubles and kopecks|
 
 ### Serbian (Cyrillic, Serbia) (`sr-Cyrl-RS`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "и" between dinars and para|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "и" between dinars and para|
 
 ### Serbian (Latin, Serbia) (`sr-Latn-RS`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "i" between dinars and para|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "i" between dinars and para|
 
 ### Spanish (United States) (`es-US`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "con" between dollars and cents|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "con" between dollars and cents|
 
 ### Turkish (Türkiye) (`tr-TR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`dropSpaces`|cardinal|`boolean`|`false`|Remove spaces for compound form|
+|`dropSpaces`|cardinal|`boolean`|—|Remove spaces for compound form|
 
 ### Ukrainian (Ukraine) (`uk-UA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -343,19 +343,29 @@ function generateMarkdown(codes, forms, mods) {
     const anchor = optionAnchors.get(code)
     const mod = mods.get(code)
 
-    // Each form column shows that form's ceiling — the largest value it converts
-    // (`10^N - 1`, matching the RangeError), or `∞` when unbounded. A trailing *
-    // links to the language's options. Every finite *Max is an exact power of ten.
-    const cell = (max, hasOpts) => {
-      let range = '✓' // fallback: form present but no *Max declared (shouldn't happen)
-      if (max === null) range = '∞'
-      else if (max !== undefined) range = `10^${max.toString().length - 1} - 1`
+    // Each form column shows that form's ceiling — the largest value it converts,
+    // or `∞` when unbounded. A trailing * links to the language's options. Mirrors
+    // checkMax: `10^N - 1` only when the ceiling is an exact power of ten, else the
+    // raw `max - 1`. A missing *Max for an exported form is a contract violation,
+    // so fail loudly rather than paper over it with a check mark.
+    const cell = (max, hasOpts, form) => {
+      let range
+      if (max === null) {
+        range = '∞'
+      }
+      else if (typeof max === 'bigint') {
+        const exponent = max.toString().length - 1
+        range = max === 10n ** BigInt(exponent) ? `10^${exponent} - 1` : `${max - 1n}`
+      }
+      else {
+        throw new Error(`${code} exports ${form} but not ${form}Max — every form must declare its ceiling`)
+      }
       return hasOpts ? `${range} [*](#${anchor})` : range
     }
 
-    const cardinalCol = cell(mod.cardinalMax, hasCardinalOptions(code))
-    const ordinalCol = hasOrdinal(code) ? cell(mod.ordinalMax, hasOrdinalOptions(code)) : ''
-    const currencyCol = hasCurrency(code) ? cell(mod.currencyMax, hasCurrencyOptions(code)) : ''
+    const cardinalCol = cell(mod.cardinalMax, hasCardinalOptions(code), 'cardinal')
+    const ordinalCol = hasOrdinal(code) ? cell(mod.ordinalMax, hasOrdinalOptions(code), 'ordinal') : ''
+    const currencyCol = hasCurrency(code) ? cell(mod.currencyMax, hasCurrencyOptions(code), 'currency') : ''
 
     return `|\`${code}\`|${name}|${cardinalCol}|${ordinalCol}|${currencyCol}|`
   })

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -120,6 +120,36 @@ function extractDefault(prop, name) {
 }
 
 /**
+ * Read each option's default from the form's `const { x = default } = options`
+ * destructuring. Defaults live in code, not JSDoc, so this is the single source
+ * of truth; renamed bindings (`{ and: useAnd = true }`) key off the property
+ * name, and string-literal defaults are unquoted for display.
+ *
+ * @param {import('typescript').FunctionDeclaration} fnNode Form function node
+ * @returns {Map<string, string>} Option key -> default value text
+ */
+function extractDestructureDefaults(fnNode) {
+  const defaults = new Map()
+  const visit = (node) => {
+    if (
+      ts.isVariableDeclaration(node)
+      && node.initializer && ts.isIdentifier(node.initializer) && node.initializer.text === 'options'
+      && node.name && ts.isObjectBindingPattern(node.name)
+    ) {
+      for (const el of node.name.elements) {
+        if (!el.initializer) continue // this property has no default
+        const key = el.propertyName ?? el.name // `and: useAnd` keys off `and`; `gender` off itself
+        const keyText = ts.isIdentifier(key) ? key.text : key.getText()
+        defaults.set(keyText, ts.isStringLiteral(el.initializer) ? el.initializer.text : el.initializer.getText())
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(fnNode)
+  return defaults
+}
+
+/**
  * Build code -> (functionName -> OptionInfo[]) by type-checking the language
  * sources once. Option names, types, and descriptions come straight from the
  * checker (the same view TypeScript exposes to consumers), so the docs can't
@@ -165,6 +195,7 @@ function buildOptionsIndex(codes) {
         type = type.types.find(t => !(t.flags & ts.TypeFlags.Undefined)) ?? type
       }
 
+      const destructureDefaults = extractDestructureDefaults(node)
       const options = (type.getProperties?.() ?? []).map((prop) => {
         const name = prop.getName()
         const description = ts
@@ -175,7 +206,7 @@ function buildOptionsIndex(codes) {
         return {
           name,
           type: toDocType(checker, checker.getTypeOfSymbolAtLocation(prop, optionsParam)),
-          defaultValue: extractDefault(prop, name),
+          defaultValue: destructureDefaults.get(name) ?? extractDefault(prop, name),
           description,
           form: FORM_FUNCTIONS[fnName],
         }

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -317,9 +317,10 @@ function formatOptionsTable(options) {
  *
  * @param {string[]} codes Array of language codes
  * @param {Map<string, Set<string>>} forms Code -> set of exported forms
+ * @param {Map<string, Record<string, bigint|null|undefined>>} mods Code -> module namespace (for the *Max range exports)
  * @returns {string} Markdown content
  */
-function generateMarkdown(codes, forms) {
+function generateMarkdown(codes, forms, mods) {
   const hasOrdinal = code => forms.get(code).has('ordinal')
   const hasCurrency = code => forms.get(code).has('currency')
 
@@ -340,20 +341,21 @@ function generateMarkdown(codes, forms) {
   const langRows = codes.map((code) => {
     const name = getDisplayName(code)
     const anchor = optionAnchors.get(code)
+    const mod = mods.get(code)
 
-    // Link to options section when language has options for that form
-    const linked = `[✓*](#${anchor})`
-    const cardinalCol = hasCardinalOptions(code) ? linked : '✓'
-
-    let ordinalCol = ''
-    if (hasOrdinal(code)) {
-      ordinalCol = hasOrdinalOptions(code) ? linked : '✓'
+    // Each form column shows that form's ceiling — the largest value it converts
+    // (`10^N - 1`, matching the RangeError), or `∞` when unbounded. A trailing *
+    // links to the language's options. Every finite *Max is an exact power of ten.
+    const cell = (max, hasOpts) => {
+      let range = '✓' // fallback: form present but no *Max declared (shouldn't happen)
+      if (max === null) range = '∞'
+      else if (max !== undefined) range = `10^${max.toString().length - 1} - 1`
+      return hasOpts ? `${range} [*](#${anchor})` : range
     }
 
-    let currencyCol = ''
-    if (hasCurrency(code)) {
-      currencyCol = hasCurrencyOptions(code) ? linked : '✓'
-    }
+    const cardinalCol = cell(mod.cardinalMax, hasCardinalOptions(code))
+    const ordinalCol = hasOrdinal(code) ? cell(mod.ordinalMax, hasOrdinalOptions(code)) : ''
+    const currencyCol = hasCurrency(code) ? cell(mod.currencyMax, hasCurrencyOptions(code)) : ''
 
     return `|\`${code}\`|${name}|${cardinalCol}|${ordinalCol}|${currencyCol}|`
   })
@@ -382,6 +384,8 @@ Language codes follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) standards
 |Code|Language|Cardinal|Ordinal|Currency|
 |----|--------|:------:|:-----:|:------:|
 ${langRows.join('\n')}
+
+Each form column shows the largest value it converts (\`10^N - 1\`), \`∞\` when unbounded, or blank when the form isn't supported.
 
 \\* Has options — click to jump to that language's options.
 
@@ -423,8 +427,11 @@ async function main() {
   const forms = new Map(
     await Promise.all(codes.map(async code => [code, await getExportedForms(code)])),
   )
+  const mods = new Map(
+    await Promise.all(codes.map(async code => [code, await import(`../src/${code}.js`)])),
+  )
   optionsIndex = buildOptionsIndex(codes)
-  const markdown = generateMarkdown(codes, forms)
+  const markdown = generateMarkdown(codes, forms, mods)
 
   writeFileSync('./LANGUAGES.md', markdown)
   console.log(`✓ Generated LANGUAGES.md (${codes.length} languages)`)

--- a/src/en-GH.js
+++ b/src/en-GH.js
@@ -383,7 +383,8 @@ function toOrdinal(value) {
 /**
  * Converts a numeric value to Ghanaian English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {{and?: boolean}} [options] - Optional configuration
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between cedis and pesewas
  * @returns {string} The amount in Ghanaian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format

--- a/src/en-KE.js
+++ b/src/en-KE.js
@@ -374,7 +374,8 @@ function toOrdinal(value) {
 /**
  * Converts a numeric value to Kenyan English currency words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {{and?: boolean}} [options] - Currency formatting options
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between shillings and cents
  * @returns {string} The currency in English words
  */
 function toCurrency(value, options) {

--- a/src/en-MY.js
+++ b/src/en-MY.js
@@ -373,7 +373,8 @@ function toOrdinal(value) {
 
 /**
  * @param {number | string | bigint} value The numeric value to convert.
- * @param {{and?: boolean}} [options] Formatting options, such as whether to join ringgit and sen with "and".
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between ringgit and sen
  * @returns {string} The amount in Malaysian ringgit and sen in English words.
  */
 function toCurrency(value, options) {

--- a/src/en-NZ.js
+++ b/src/en-NZ.js
@@ -389,7 +389,8 @@ function toOrdinal(value) {
 /**
  * Converts a numeric value to New Zealand English currency words (New Zealand Dollar).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {{and?: boolean}} [options] - Optional configuration
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between dollars and cents
  * @returns {string} The amount in New Zealand English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format

--- a/src/en-PH.js
+++ b/src/en-PH.js
@@ -376,7 +376,8 @@ function toOrdinal(value) {
 /**
  * Converts a numeric value to Philippine English currency words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {{and?: boolean}} [options] - Optional configuration
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between pesos and centavos
  * @returns {string} The amount in Philippine English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format

--- a/src/en-SG.js
+++ b/src/en-SG.js
@@ -374,7 +374,8 @@ function toOrdinal(value) {
 /**
  * Converts a numeric value to Singaporean English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {{ and?: boolean }} [options] - Optional configuration
+ * @param {object} [options] - Optional configuration
+ * @param {boolean} [options.and] - Use "and" between dollars and cents
  * @returns {string} The amount in Singaporean English currency words
  */
 function toCurrency(value, options) {


### PR DESCRIPTION
**The original ask, finally delivered.** This thread started from *"languages.md should tell maximum supported range."* Everything since — the bigint `*Max` exports, `scale.js` helpers, `checkMax`, the behavioural gate — was the foundation that makes this a safe, drift-free read.

## What changed

The **All Languages** table's form columns now show each form's ceiling instead of a bare ✓:

| | Cardinal | Ordinal | Currency |
|---|---|---|---|
| `en-US` | 10^66 - 1 | 10^66 - 1 | 10^66 - 1 |
| `es-ES` | 10^30 - 1 | **10^9 - 1** | 10^30 - 1 |
| `hr-HR` | 10^30 - 1 | **10^15 - 1** | 10^30 - 1 |
| `ja-JP` | 10^72 - 1 | 10^72 - 1 | 10^72 - 1 |
| `th-TH` | ∞ | ∞ | ∞ |

- **Per-form**, so split-ceiling languages read honestly — es-ES's ordinal (`10^9 - 1`) really is far below its cardinal (`10^30 - 1`); a single column would have hidden that.
- **`10^N - 1`** = the largest value the form converts, matching the `RangeError` message (*"the largest supported value is 10^N - 1"*) and docs/range-contract.md verbatim — one vocabulary across table, docs, and runtime.
- **`∞`** for the unbounded languages (th-TH, fa-IR, yo-NG); **blank** when a form isn't supported; the options **`*`** link is preserved, and a legend explains it.

## How it stays correct

The generator reads each module's `cardinalMax` / `ordinalMax` / `currencyMax` exports directly, so the column is derived from the same declarations the gate verifies — it can't drift from the implementation. Output is markdownlint-clean and regen-stable (running the generator twice is byte-identical).

Closes the range-contract arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)