### PR TITLE
feat(core): prove the options contract on en-US

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -23,16 +23,16 @@ Language codes follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) standards
 |`en-BD`|English (Bangladesh)|✓|✓|[✓*](#english-bangladesh-en-bd)|
 |`en-CA`|Canadian English|[✓*](#canadian-english-en-ca)|✓|[✓*](#canadian-english-en-ca)|
 |`en-GB`|British English|✓|✓|[✓*](#british-english-en-gb)|
-|`en-GH`|English (Ghana)|✓|✓|✓|
+|`en-GH`|English (Ghana)|✓|✓|[✓*](#english-ghana-en-gh)|
 |`en-IE`|English (Ireland)|✓|✓|[✓*](#english-ireland-en-ie)|
 |`en-IN`|English (India)|✓|✓|[✓*](#english-india-en-in)|
-|`en-KE`|English (Kenya)|✓|✓|✓|
-|`en-MY`|English (Malaysia)|✓|✓|✓|
+|`en-KE`|English (Kenya)|✓|✓|[✓*](#english-kenya-en-ke)|
+|`en-MY`|English (Malaysia)|✓|✓|[✓*](#english-malaysia-en-my)|
 |`en-NG`|English (Nigeria)|✓|✓|[✓*](#english-nigeria-en-ng)|
-|`en-NZ`|English (New Zealand)|✓|✓|✓|
-|`en-PH`|English (Philippines)|✓|✓|✓|
+|`en-NZ`|English (New Zealand)|✓|✓|[✓*](#english-new-zealand-en-nz)|
+|`en-PH`|English (Philippines)|✓|✓|[✓*](#english-philippines-en-ph)|
 |`en-PK`|English (Pakistan)|✓|✓|[✓*](#english-pakistan-en-pk)|
-|`en-SG`|English (Singapore)|✓|✓|✓|
+|`en-SG`|English (Singapore)|✓|✓|[✓*](#english-singapore-en-sg)|
 |`en-US`|American English|[✓*](#american-english-en-us)|✓|[✓*](#american-english-en-us)|
 |`en-ZA`|English (South Africa)|✓|✓|[✓*](#english-south-africa-en-za)|
 |`es-ES`|European Spanish|[✓*](#european-spanish-es-es)|[✓*](#european-spanish-es-es)|[✓*](#european-spanish-es-es)|
@@ -103,7 +103,7 @@ Import paths use BCP 47 language codes: `n2words/en-US`, `n2words/zh-Hans-CN`, `
 
 ## Language Options
 
-35 languages support options via a second parameter. Options are passed as an object:
+41 languages support options via a second parameter. Options are passed as an object:
 
 ```js
 toCardinal(value, { optionName: value })
@@ -122,226 +122,262 @@ toCurrency(value, { optionName: value })
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
 |`negativeWord`|cardinal|`string`|—|Custom word for negative numbers|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
 
 ### Australian English (`en-AU`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents|
+|`and`|currency|`boolean`|—|Use "and" between dollars and cents|
 
 ### Biblical Hebrew (Israel) (`hbo-IL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`andWord`|cardinal|`string`|`'ו'`|Custom conjunction word|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`andWord`|cardinal|`string`|—|Custom conjunction word|
 
 ### Brazilian Portuguese (`pt-BR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Include "e" between major and minor units|
+|`and`|currency|`boolean`|—|Include "e" between major and minor units|
 |`currency`|currency|`string`|—|Currency code (e.g., 'BRL', 'USD')|
 
 ### British English (`en-GB`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between pounds and pence (e.g., "one pound and fifty pence")|
+|`and`|currency|`boolean`|—|Use "and" between pounds and pence (e.g., "one pound and fifty pence")|
 
 ### Canadian English (`en-CA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`hundredPairing`|cardinal|`boolean`|`false`|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
-|`and`|cardinal|`boolean`|`true`|Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)|
-|`and`|currency|`boolean`|`true`|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
+|`hundredPairing`|cardinal|`boolean`|—|Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")|
+|`and`|cardinal|`boolean`|—|Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)|
+|`and`|currency|`boolean`|—|Use "and" between dollars and cents (e.g., "one dollar and fifty cents")|
 
 ### Chinese (Simplified, China) (`zh-Hans-CN`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`formal`|cardinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|ordinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|currency|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|cardinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|ordinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|currency|`boolean`|—|Use formal/financial numerals|
 
 ### Chinese (Traditional, Taiwan) (`zh-Hant-TW`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`formal`|cardinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|ordinal|`boolean`|`true`|Use formal/financial numerals|
-|`formal`|currency|`boolean`|`true`|Use formal/financial numerals|
+|`formal`|cardinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|ordinal|`boolean`|—|Use formal/financial numerals|
+|`formal`|currency|`boolean`|—|Use formal/financial numerals|
 
 ### Croatian (Croatia) (`hr-HR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
 
 ### Dutch (Netherlands) (`nl-NL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`accentOne`|cardinal|`boolean`|`true`|Use "één" instead of "een"|
-|`includeOptionalAnd`|cardinal|`boolean`|`false`|Include "en" before small numbers|
-|`noHundredPairing`|cardinal|`boolean`|`false`|Disable hundred pairing (1104→duizend honderdvier)|
-|`and`|currency|`boolean`|`true`|Include "en" between euros and cents|
+|`accentOne`|cardinal|`boolean`|—|Use "één" instead of "een"|
+|`includeOptionalAnd`|cardinal|`boolean`|—|Include "en" before small numbers|
+|`noHundredPairing`|cardinal|`boolean`|—|Disable hundred pairing (1104→duizend honderdvier)|
+|`and`|currency|`boolean`|—|Include "en" between euros and cents|
 
 ### English (Bangladesh) (`en-BD`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between taka and paise|
+|`and`|currency|`boolean`|—|Use "and" between taka and paise|
+
+### English (Ghana) (`en-GH`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
 
 ### English (India) (`en-IN`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between rupees and paise|
+|`and`|currency|`boolean`|—|Use "and" between rupees and paise|
 
 ### English (Ireland) (`en-IE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between euro and cent (e.g., "one euro and fifty cents")|
+|`and`|currency|`boolean`|—|Use "and" between euro and cent (e.g., "one euro and fifty cents")|
+
+### English (Kenya) (`en-KE`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
+
+### English (Malaysia) (`en-MY`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
+
+### English (New Zealand) (`en-NZ`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
 
 ### English (Nigeria) (`en-NG`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between naira and kobo (e.g., "one naira and fifty kobo")|
+|`and`|currency|`boolean`|—|Use "and" between naira and kobo (e.g., "one naira and fifty kobo")|
 
 ### English (Pakistan) (`en-PK`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between rupees and paise|
+|`and`|currency|`boolean`|—|Use "and" between rupees and paise|
+
+### English (Philippines) (`en-PH`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
+
+### English (Singapore) (`en-SG`)
+
+|Option|Form|Type|Default|Description|
+|------|----|----|-------|-----------|
+|`and`|currency|`boolean`|—||
 
 ### English (South Africa) (`en-ZA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "and" between rand and cents (e.g., "one rand and fifty cents")|
+|`and`|currency|`boolean`|—|Use "and" between rand and cents (e.g., "one rand and fifty cents")|
 
 ### European Portuguese (`pt-PT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Include "e" between euros and cents|
+|`and`|currency|`boolean`|—|Include "e" between euros and cents|
 
 ### European Spanish (`es-ES`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "con" between euros and cents|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "con" between euros and cents|
 
 ### French (Belgium) (`fr-BE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`withHyphenSeparator`|cardinal|`boolean`|`false`|Use hyphens between words|
-|`and`|currency|`boolean`|`true`|Use "et" between euros and centimes|
+|`withHyphenSeparator`|cardinal|`boolean`|—|Use hyphens between words|
+|`and`|currency|`boolean`|—|Use "et" between euros and centimes|
 
 ### French (France) (`fr-FR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`withHyphenSeparator`|cardinal|`boolean`|`false`|Use hyphens between all words|
-|`and`|currency|`boolean`|`true`|Use "et" between euros and centimes|
+|`withHyphenSeparator`|cardinal|`boolean`|—|Use hyphens between all words|
+|`and`|currency|`boolean`|—|Use "et" between euros and centimes|
 
 ### German (Germany) (`de-DE`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "und" between euros and cents|
+|`and`|currency|`boolean`|—|Use "und" between euros and cents|
 
 ### Hebrew (Israel) (`he-IL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`andWord`|cardinal|`string`|`'ו'`|Custom conjunction word|
+|`andWord`|cardinal|`string`|—|Custom conjunction word|
 
 ### Italian (Italy) (`it-IT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`and`|currency|`boolean`|`true`|Use "e" between euros and centesimi|
+|`and`|currency|`boolean`|—|Use "e" between euros and centesimi|
 
 ### Latvian (Latvia) (`lv-LV`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
 
 ### Lithuanian (Lithuania) (`lt-LT`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
 
 ### Mexican Spanish (`es-MX`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "con" between pesos and centavos|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "con" between pesos and centavos|
 
 ### Polish (Poland) (`pl-PL`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers < 1000|
+|`gender`|cardinal|`string`|—|Gender for numbers < 1000|
 
 ### Romanian (Romania) (`ro-RO`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|`string`|`'masculine'`|Gender for numbers|
+|`gender`|cardinal|`string`|—|Gender for numbers|
 
 ### Russian (Russia) (`ru-RU`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "и" between rubles and kopecks|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "и" between rubles and kopecks|
 
 ### Serbian (Cyrillic, Serbia) (`sr-Cyrl-RS`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "и" between dinars and para|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "и" between dinars and para|
 
 ### Serbian (Latin, Serbia) (`sr-Latn-RS`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "i" between dinars and para|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "i" between dinars and para|
 
 ### Spanish (United States) (`es-US`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`gender`|ordinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
-|`and`|currency|`boolean`|`true`|Use "con" between dollars and cents|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`gender`|ordinal|'masculine' \| 'feminine'|—|Grammatical gender|
+|`and`|currency|`boolean`|—|Use "con" between dollars and cents|
 
 ### Turkish (Türkiye) (`tr-TR`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`dropSpaces`|cardinal|`boolean`|`false`|Remove spaces for compound form|
+|`dropSpaces`|cardinal|`boolean`|—|Remove spaces for compound form|
 
 ### Ukrainian (Ukraine) (`uk-UA`)
 
 |Option|Form|Type|Default|Description|
 |------|----|----|-------|-----------|
-|`gender`|cardinal|'masculine' \| 'feminine'|`'masculine'`|Grammatical gender|
+|`gender`|cardinal|'masculine' \| 'feminine'|—|Grammatical gender|

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -183,7 +183,7 @@ function buildOptionsIndex(codes, mods) {
         return {
           name,
           type: toDocType(checker, checker.getTypeOfSymbolAtLocation(prop, optionsParam)),
-          defaultValue: formDefaults && name in formDefaults ? String(formDefaults[name]) : extractDefault(prop, name),
+          defaultValue: formDefaults && Object.hasOwn(formDefaults, name) ? String(formDefaults[name]) : extractDefault(prop, name),
           description,
           form: FORM_FUNCTIONS[fnName],
         }

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -126,9 +126,10 @@ function extractDefault(prop, name) {
  * drift from comment formatting the way the old regex scrape could.
  *
  * @param {string[]} codes Language codes
+ * @param {Map<string, object>} mods Code -> module namespace (for `<form>Defaults` exports)
  * @returns {Map<string, Map<string, OptionInfo[]>>}
  */
-function buildOptionsIndex(codes) {
+function buildOptionsIndex(codes, mods) {
   const program = ts.createProgram(
     codes.map(code => `./src/${code}.js`),
     {
@@ -165,6 +166,13 @@ function buildOptionsIndex(codes) {
         type = type.types.find(t => !(t.flags & ts.TypeFlags.Undefined)) ?? type
       }
 
+      // Defaults come from the form's exported `<form>Defaults` map (the single
+      // source of truth) — imported, not scraped. Falls back to the legacy JSDoc
+      // `[name=default]` tag for languages not yet on the options contract.
+      const formDefaults = /** @type {Record<string, unknown> | undefined} */ (
+        mods.get(code)?.[`${FORM_FUNCTIONS[fnName]}Defaults`]
+      )
+
       const options = (type.getProperties?.() ?? []).map((prop) => {
         const name = prop.getName()
         const description = ts
@@ -175,7 +183,7 @@ function buildOptionsIndex(codes) {
         return {
           name,
           type: toDocType(checker, checker.getTypeOfSymbolAtLocation(prop, optionsParam)),
-          defaultValue: extractDefault(prop, name),
+          defaultValue: formDefaults && name in formDefaults ? String(formDefaults[name]) : extractDefault(prop, name),
           description,
           form: FORM_FUNCTIONS[fnName],
         }
@@ -423,7 +431,10 @@ async function main() {
   const forms = new Map(
     await Promise.all(codes.map(async code => [code, await getExportedForms(code)])),
   )
-  optionsIndex = buildOptionsIndex(codes)
+  const mods = new Map(
+    await Promise.all(codes.map(async code => [code, await import(`../src/${code}.js`)])),
+  )
+  optionsIndex = buildOptionsIndex(codes, mods)
   const markdown = generateMarkdown(codes, forms)
 
   writeFileSync('./LANGUAGES.md', markdown)

--- a/src/en-US.js
+++ b/src/en-US.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // VOCABULARY
@@ -270,14 +270,21 @@ function decimalPartToWords(decimalPart, useAnd) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [hundredPairing] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
+ * @property {boolean} [and] - Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { hundredPairing: false, and: false }
+
+/**
  * Converts a numeric value to American English words.
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.hundredPairing] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
- * @param {boolean} [options.and] - Use "and" after hundreds and before final small numbers (e.g., "one hundred and one" instead of "one hundred one")
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in American English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -289,14 +296,12 @@ function decimalPartToWords(decimalPart, useAnd) {
  * toCardinal(1500, { hundredPairing: true }) // 'fifteen hundred'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
-  // Extract options with defaults
-  const { hundredPairing = false, and: useAnd = false } = options
+  const { hundredPairing, and: useAnd } = resolveOptions(options, cardinalDefaults)
 
   let result = ''
 
@@ -480,10 +485,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to American English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in American English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -494,10 +506,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two dollars fifty cents'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
   checkMax(dollars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/utils/resolve-options.js
+++ b/src/utils/resolve-options.js
@@ -20,9 +20,13 @@ export function resolveOptions(options, defaults) {
   if (!isPlainObject(options)) {
     throw new TypeError(`Invalid options: expected plain object or undefined, got ${typeof options}`)
   }
+  const allowed = Object.keys(defaults)
   for (const [key, value] of Object.entries(options)) {
-    if (!(key in resolved)) {
-      throw new RangeError(`Unknown option "${key}" — expected one of: ${Object.keys(resolved).join(', ')}`)
+    // Own-property check: inherited keys (__proto__, constructor, …) are not
+    // options. Using `key in defaults` here would let them past the guard and
+    // into `resolved[key] = value` — a prototype-pollution vector.
+    if (!Object.hasOwn(defaults, key)) {
+      throw new RangeError(`Unknown option "${key}" — expected one of: ${allowed.join(', ')}`)
     }
     if (typeof value !== typeof resolved[key]) {
       throw new TypeError(`Option "${key}" must be a ${typeof resolved[key]}, got ${typeof value}`)

--- a/src/utils/resolve-options.js
+++ b/src/utils/resolve-options.js
@@ -24,9 +24,11 @@ export function resolveOptions(options, defaults) {
   for (const [key, value] of Object.entries(options)) {
     // Own-property check: inherited keys (__proto__, constructor, …) are not
     // options. Using `key in defaults` here would let them past the guard and
-    // into `resolved[key] = value` — a prototype-pollution vector.
+    // into `resolved[key] = value` — a prototype-pollution vector. An unknown
+    // key is a malformed-argument (shape) error, hence TypeError — RangeError is
+    // reserved for a value outside an allowed range/set (see checkMax).
     if (!Object.hasOwn(defaults, key)) {
-      throw new RangeError(`Unknown option "${key}" — expected one of: ${allowed.join(', ')}`)
+      throw new TypeError(`Unknown option "${key}" — expected one of: ${allowed.join(', ')}`)
     }
     if (typeof value !== typeof resolved[key]) {
       throw new TypeError(`Option "${key}" must be a ${typeof resolved[key]}, got ${typeof value}`)

--- a/src/utils/resolve-options.js
+++ b/src/utils/resolve-options.js
@@ -30,6 +30,10 @@ export function resolveOptions(options, defaults) {
     if (!Object.hasOwn(defaults, key)) {
       throw new TypeError(`Unknown option "${key}" — expected one of: ${allowed.join(', ')}`)
     }
+    // `{ key: undefined }` means "use the default": `key?: T` is `T | undefined`
+    // without exactOptionalPropertyTypes, and the old destructuring defaults
+    // treated undefined the same way. Omit it rather than reject it as a type.
+    if (value === undefined) continue
     if (typeof value !== typeof resolved[key]) {
       throw new TypeError(`Option "${key}" must be a ${typeof resolved[key]}, got ${typeof value}`)
     }

--- a/src/utils/resolve-options.js
+++ b/src/utils/resolve-options.js
@@ -1,0 +1,33 @@
+import { isPlainObject } from './is-plain-object.js'
+
+/**
+ * Apply a form's option defaults and reject anything it doesn't declare.
+ *
+ * The exported defaults map (e.g. `cardinalDefaults`) is the single source of
+ * truth for each option's default value — the form never restates it, and the
+ * docs generator imports it rather than scraping the body. An unknown key or a
+ * wrong-typed value throws loudly instead of being silently dropped.
+ * @template {object} T
+ * @param {T | undefined} options - Caller-provided options, or undefined
+ * @param {Required<T>} defaults - The form's default for every option
+ * @returns {Required<T>} The options with every default applied
+ */
+export function resolveOptions(options, defaults) {
+  /** @type {Record<string, unknown>} */
+  const resolved = { ...defaults }
+  if (options === undefined) return /** @type {Required<T>} */ (resolved)
+
+  if (!isPlainObject(options)) {
+    throw new TypeError(`Invalid options: expected plain object or undefined, got ${typeof options}`)
+  }
+  for (const [key, value] of Object.entries(options)) {
+    if (!(key in resolved)) {
+      throw new RangeError(`Unknown option "${key}" — expected one of: ${Object.keys(resolved).join(', ')}`)
+    }
+    if (typeof value !== typeof resolved[key]) {
+      throw new TypeError(`Option "${key}" must be a ${typeof resolved[key]}, got ${typeof value}`)
+    }
+    resolved[key] = value
+  }
+  return /** @type {Required<T>} */ (resolved)
+}

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -50,6 +50,10 @@ for (const { code, mod, declared } of languages) {
       // The declared defaults are the real defaults: explicit must equal omitted.
       t.is(fn(sample, { ...defaults }), fn(sample), `${code} ${form}: explicit defaults must match the no-options output`)
 
+      // `{ key: undefined }` means "use the default" (matches `key?: T`), not a throw.
+      const firstName = Object.keys(defaults)[0]
+      t.is(fn(sample, { [firstName]: undefined }), fn(sample), `${code} ${form}: an undefined "${firstName}" falls back to its default`)
+
       // An undeclared option fails loudly rather than being silently ignored.
       t.throws(
         () => fn(sample, { __unknown_option__: true }),

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -54,6 +54,23 @@ for (const { code, mod, declared } of languages) {
         { instanceOf: RangeError },
         `${code} ${form}: must reject unknown options`,
       )
+
+      // A wrong-typed value is rejected too (not coerced or silently kept).
+      const [firstKey, firstDefault] = Object.entries(defaults)[0]
+      const wrongTyped = typeof firstDefault === 'string' ? 0 : 'wrong-type'
+      t.throws(
+        () => fn(sample, { [firstKey]: wrongTyped }),
+        { instanceOf: TypeError },
+        `${code} ${form}: must reject a wrong-typed "${firstKey}"`,
+      )
+
+      // Inherited keys must not bypass the guard (prototype-pollution defence).
+      t.throws(
+        () => fn(sample, JSON.parse('{ "__proto__": { "polluted": true } }')),
+        { instanceOf: RangeError },
+        `${code} ${form}: must reject inherited keys like __proto__`,
+      )
+      t.falsy(/** @type {Record<string, unknown>} */ ({}).polluted, 'prototype must not be polluted')
     }
   })
 }

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -15,7 +15,9 @@ import { isPlainObject } from '../src/utils/is-plain-object.js'
  * - the form accepts `(value, options)`;
  * - calling with the explicit defaults reproduces the no-options output, so the
  *   declared defaults really are the defaults;
- * - an undeclared option throws `RangeError` — a typo fails loudly, not silently.
+ * - a malformed options argument throws `TypeError` — an unknown key, a
+ *   wrong-typed value, or an inherited key all fail loudly, not silently.
+ *   (`RangeError` is reserved for a value out of range, e.g. checkMax.)
  *
  * Auto-covers any form that exports `<form>Defaults`.
  */
@@ -51,7 +53,7 @@ for (const { code, mod, declared } of languages) {
       // An undeclared option fails loudly rather than being silently ignored.
       t.throws(
         () => fn(sample, { __unknown_option__: true }),
-        { instanceOf: RangeError },
+        { instanceOf: TypeError },
         `${code} ${form}: must reject unknown options`,
       )
 
@@ -67,7 +69,7 @@ for (const { code, mod, declared } of languages) {
       // Inherited keys must not bypass the guard (prototype-pollution defence).
       t.throws(
         () => fn(sample, JSON.parse('{ "__proto__": { "polluted": true } }')),
-        { instanceOf: RangeError },
+        { instanceOf: TypeError },
         `${code} ${form}: must reject inherited keys like __proto__`,
       )
       t.falsy(/** @type {Record<string, unknown>} */ ({}).polluted, 'prototype must not be polluted')

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -19,7 +19,10 @@ import { isPlainObject } from '../src/utils/is-plain-object.js'
  *   wrong-typed value, or an inherited key all fail loudly, not silently.
  *   (`RangeError` is reserved for a value out of range, e.g. checkMax.)
  *
- * Auto-covers any form that exports `<form>Defaults`.
+ * Auto-covers any form that exports `<form>Defaults` while the sweep is in
+ * progress. Once every options-taking language is migrated, this flips to
+ * required — any form accepting an options parameter without a `<form>Defaults`
+ * export fails, exactly as the range gate requires `*Max`.
  */
 
 const FORMS = [

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -1,0 +1,59 @@
+import test from 'ava'
+import { readdirSync } from 'node:fs'
+import { isPlainObject } from '../src/utils/is-plain-object.js'
+
+/**
+ * Options-contract gate (proof).
+ *
+ * A form that accepts options declares its defaults as an exported map
+ * (`cardinalDefaults` / `ordinalDefaults` / `currencyDefaults`) — the single
+ * source of truth that the runtime applies (via `resolveOptions`) and the docs
+ * generator imports rather than scraping. This gate verifies the contract
+ * behaviourally, with no per-language knowledge:
+ *
+ * - the defaults export is a non-empty plain object;
+ * - the form accepts `(value, options)`;
+ * - calling with the explicit defaults reproduces the no-options output, so the
+ *   declared defaults really are the defaults;
+ * - an undeclared option throws `RangeError` — a typo fails loudly, not silently.
+ *
+ * Auto-covers any form that exports `<form>Defaults`.
+ */
+
+const FORMS = [
+  ['cardinal', 'toCardinal', 101],
+  ['ordinal', 'toOrdinal', 101],
+  ['currency', 'toCurrency', 42.5],
+]
+
+// Pre-load so a test is registered only for forms that declare the contract.
+const languages = []
+for (const file of readdirSync('./src').filter(f => f.endsWith('.js') && !f.startsWith('utils')).sort()) {
+  const mod = await import('../src/' + file)
+  const declared = FORMS.filter(([form]) => mod[`${form}Defaults`] !== undefined)
+  if (declared.length > 0) languages.push({ code: file.replace('.js', ''), mod, declared })
+}
+
+for (const { code, mod, declared } of languages) {
+  test(`${code} upholds its options contract`, (t) => {
+    for (const [form, fnName, sample] of declared) {
+      const defaults = mod[`${form}Defaults`]
+      const fn = mod[fnName]
+
+      t.true(isPlainObject(defaults), `${code} ${form}Defaults must be a plain object`)
+      t.true(Object.keys(defaults).length > 0, `${code} ${form}Defaults must declare at least one option`)
+      t.is(typeof fn, 'function', `${code} declares ${form}Defaults but doesn't export ${fnName}()`)
+      t.true(fn.length >= 2, `${code} ${fnName} must accept (value, options)`)
+
+      // The declared defaults are the real defaults: explicit must equal omitted.
+      t.is(fn(sample, { ...defaults }), fn(sample), `${code} ${form}: explicit defaults must match the no-options output`)
+
+      // An undeclared option fails loudly rather than being silently ignored.
+      t.throws(
+        () => fn(sample, { __unknown_option__: true }),
+        { instanceOf: RangeError },
+        `${code} ${form}: must reject unknown options`,
+      )
+    }
+  })
+}


### PR DESCRIPTION
The options analog of the range contract — a proof on **en-US** (cardinal + currency), the way #372 proved the range contract on four languages. The goal you set: options info comes from **exports the generator imports** and **a gate that fails non-compliance**, not from scraping JSDoc or reading destructure defaults out of the AST.

## The shape

```js
/**
 * @typedef {object} CardinalOptions
 * @property {boolean} [hundredPairing] - Use hundred-pairing for 1100–9999 …
 * @property {boolean} [and] - Use "and" after hundreds …
 */

/** @type {Required<CardinalOptions>} */
export const cardinalDefaults = { hundredPairing: false, and: false }

/** @param {CardinalOptions} [options] */
function toCardinal (value, options) {
  const { hundredPairing, and } = resolveOptions(options, cardinalDefaults) // fills defaults + validates
}
```

**Each fact has exactly one home:**
- **default** → the exported `cardinalDefaults` map. The runtime applies it (`resolveOptions`) and the generator *imports* it. Gone from the destructure.
- **type + description** → the `@typedef`. `jsdoc/require-property-description` *forces* every option to carry a description, so a non-compliant typedef fails lint.

## How it hits the goals

- **Reliable, no hacks** — the generator does `import` and reads `cardinalDefaults` for the Default column; type + description come from the typedef via the TS checker. No regex, no AST destructure-reading.
- **Fails if not followed** — `test/options-contract.test.js`: for any form exporting `<form>Defaults`, the export must be a non-empty plain object, the declared defaults must **round-trip** (`fn(x, {...defaults}) === fn(x)`), and an unknown option must throw `TypeError`. Plus lint forces the `@property` descriptions.
- **Stronger validation** — `resolveOptions` rejects unknown keys, wrong-typed values, and inherited keys — all `TypeError` (malformed-argument defects) — where the old generic `validateOptions` silently passed them through. `RangeError` stays reserved for one thing across the package: an oversized number (`checkMax`).

## What consumers get (the `.d.ts`)

```ts
export type CardinalOptions = {
    hundredPairing?: boolean | undefined;   // + the description, on hover
    and?: boolean | undefined;
};
export const cardinalDefaults: Required<CardinalOptions>;
```

A real named type with descriptions in IntelliSense, and the defaults as a typed export.

## Verification

- Runtime: defaults applied, unknown keys + wrong types rejected; en-US fixtures unchanged.
- `.d.ts`: named type + descriptions + `cardinalDefaults` export.
- Gate green; LANGUAGES.md shows en-US's defaults (from the export) + descriptions (from the typedef).
- Full suite green (410).

## The one honest wart

The type can't be *derived* from the export (JSDoc has no mapped types), so the typedef is written by hand alongside the defaults. It's not duplicated info — the typedef holds type+description, the export holds defaults — but it does mean two declarations per form, tied together by the gate (and lint). If that ever feels heavy, the typedef could be code-generated from the export; I'd leave that until the full sweep proves it's worth it.

This is a **proof on one language**, not the sweep. If the shape's right, the rollout mirrors the range sweep: family by family, the gate covering each as it converts, `validateOptions` retired once the last form is migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
