### PR TITLE
test(core): require the range declaration for every exported form

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Then: implement the form(s) you're adding (`toCardinal`, `toOrdinal`, and/or `to
 A new language must clear four enforced gates (in `test/`):
 
 - **Contract** (`contract.test.js`): every exported form returns a well-formed string or throws `RangeError` for any input.
-- **Range** (`range-contract.test.js`): each declared `*Max` is well-formed and injective across its range, and (if finite) throws exactly at the ceiling.
+- **Range** (`range-contract.test.js`): every exported form **must** declare its `*Max` (helper-derived or `UNBOUNDED`) — a form without one fails — and uphold it: well-formed and injective across the range, throwing exactly at a finite ceiling.
 - **Coverage** (`conversions.test.js`): ≥5 fixture cases per form.
 - **Canonical code** (`conversions.test.js`): the filename is canonical BCP 47 (`en-US`, not `en-us`).
 

--- a/docs/range-contract.md
+++ b/docs/range-contract.md
@@ -6,9 +6,9 @@ language's range, lets the gate pin the exact ceiling, and makes the
 silent-magnitude-collapse bug class structurally catchable — with no per-language
 test code.
 
-> Status: introduced as a proof on `en-US`, `it-IT`, `zh-Hans-CN`, `th-TH`
-> (one of each structural kind). The remaining languages are migrated to it
-> family by family, and the gate covers each one the moment it declares a `*Max`.
+> Status: adopted by every language, and **required** — the gate fails any
+> exported form that doesn't declare its `*Max`, so a new language can't skip
+> the contract and pass CI.
 
 ## The fact: a bigint `*Max` per form
 
@@ -79,12 +79,13 @@ scale table:
 Contiguity ("no missing in-between scale word") is therefore a *behavioural*
 property the injectivity sweep enforces, not a structural assertion.
 
-## Migrating a language
+## Declaring a language's range
 
-1. Export `cardinalMax` / `ordinalMax` / `currencyMax` — a helper, `bounded(e)`, or
-   `UNBOUNDED`.
+1. Export `cardinalMax` / `ordinalMax` / `currencyMax` for each form you export —
+   a helper, `bounded(e)`, or `UNBOUNDED`. This is required: the gate fails an
+   exported form with no declaration.
 2. Guard each form with `checkMax(value, max, fraction?)`.
-3. Run `npm test` — the gate picks the language up automatically.
+3. Run `npm test` — the gate verifies the declaration behaviourally.
 
 ## Why this shape
 

--- a/test/range-contract.test.js
+++ b/test/range-contract.test.js
@@ -2,21 +2,20 @@ import test from 'ava'
 import { readdirSync } from 'node:fs'
 
 /**
- * Range-contract gate (proof).
+ * Range-contract gate.
  *
- * Each form declares its maximum supported value as an exported bigint
- * (`cardinalMax` / `ordinalMax` / `currencyMax`), or `null` for no fixed limit.
- * This gate verifies that fact behaviourally — no per-language magic, no probing,
- * no knowledge of any scale table:
+ * Every exported form MUST declare its maximum supported value as an exported
+ * bigint (`cardinalMax` / `ordinalMax` / `currencyMax`), or `null` (UNBOUNDED)
+ * for no fixed limit — a form exported without its declaration fails here, so
+ * the contract is a requirement, not a convention. The declaration is then
+ * verified behaviourally — no per-language magic, no probing, no knowledge of
+ * any scale table:
  *
  * - **well-formed + injective** across the valid range — distinct magnitudes
  *   must spell differently, so a gap / drop / clamp (which collapses magnitude)
  *   is caught generically;
  * - **boundary** (finite max only) — `max` throws RangeError and `max - 1`
  *   is well-formed, pinning the exact ceiling.
- *
- * Auto-covers any language that exports `*Max` (currently the four proof
- * languages) and would eventually subsume the well-formedness gate.
  */
 
 const FORMS = [
@@ -74,19 +73,28 @@ function checkForm(fn, max) {
   if (!isWellFormed(below)) throw new Error(`malformed just below the ceiling: ${render(below)}`)
 }
 
-// Pre-load modules so we register a test only for languages that declare a range.
+// Every language registers — the declaration is required, not opt-in. A form
+// exported without its *Max (or a *Max without its form) fails below.
 const languages = []
 for (const file of readdirSync('./src').filter(f => f.endsWith('.js') && !f.startsWith('utils')).sort()) {
   const mod = await import('../src/' + file)
-  const declared = FORMS.filter(([form]) => mod[`${form}Max`] !== undefined)
-  if (declared.length > 0) languages.push({ code: file.replace('.js', ''), mod, declared })
+  languages.push({ code: file.replace('.js', ''), mod })
 }
 
-for (const { code, mod, declared } of languages) {
+for (const { code, mod } of languages) {
   test(`${code} upholds its declared range`, (t) => {
-    for (const [form, fnName] of declared) {
-      t.is(typeof mod[fnName], 'function', `${code} declares ${form}Max but doesn't export ${fnName}()`)
-      t.notThrows(() => checkForm(mod[fnName], mod[`${form}Max`]), `${code} ${form}`)
+    for (const [form, fnName] of FORMS) {
+      const fn = mod[fnName]
+      const max = mod[`${form}Max`]
+      const hasFn = typeof fn === 'function'
+      const hasMax = max !== undefined
+      if (!hasFn && !hasMax) continue // form not implemented
+
+      t.true(hasMax, `${code} exports ${fnName}() but doesn't declare ${form}Max — every exported form must declare its range (see docs/range-contract.md)`)
+      t.true(hasFn, `${code} declares ${form}Max but doesn't export ${fnName}()`)
+      if (!hasFn || !hasMax) continue // declaration mismatch already failed above
+
+      t.notThrows(() => checkForm(fn, max), `${code} ${form}`)
     }
   })
 }


### PR DESCRIPTION
Closes the enforcement hole found while reviewing #390: **both contract gates were opt-in.** The range gate registered tests only for languages that declare a `*Max` (`if (declared.length > 0)`), so a brand-new language exporting forms with **no declaration at all** got zero contract coverage and passed CI clean. The contract was a convention with great tooling — not a requirement.

## The flip

Every language now registers, and for each of the three forms, the function and its declaration must **both** exist:

- exports `toCardinal()` without `cardinalMax` → **fails**: `da-DK exports toCardinal() but doesn't declare cardinalMax — every exported form must declare its range (see docs/range-contract.md)`
- declares `cardinalMax` without `toCardinal()` → still fails (as before)
- both present → the behavioral verification runs unchanged (well-formed + injective + boundary)

## Verification

- **All 72 languages comply today**, so this lands green (72 gate tests, 409 total).
- **Teeth proven, not assumed**: temporarily stripped `da-DK`'s `cardinalMax` → the gate failed with exactly the teaching message above → restored → green. An enforcement change that never demonstrated a failure is the trap this whole effort exists to avoid.
- A fresh `lang:add` scaffold still passes the *declaration* check (it emits `*Max = UNBOUNDED` placeholders) and fails only on its unimplemented bodies/empty fixtures — incomplete work fails for the right reason.

## Docs

- `docs/range-contract.md` status: "adopted by every language, and **required** — a new language can't skip the contract and pass CI"; "Migrating a language" → "Declaring a language's range."
- `CLAUDE.md` gate list: the Range gate now says **must**.

The options gate (#390) gets the same flip at the end of its sweep — it can't require `<form>Defaults` while only en-US complies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)