### PR TITLE
refactor(en): migrate the en-* family to the options contract

### DIFF
--- a/src/en-AU.js
+++ b/src/en-AU.js
@@ -14,7 +14,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -387,10 +387,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between dollars and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Australian English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between dollars and cents
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Australian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -401,10 +408,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two dollars fifty cents'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
   checkMax(dollars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/en-BD.js
+++ b/src/en-BD.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { indian } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -378,10 +378,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between taka and paise
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Bangladeshi English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between taka and paise
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Bangladeshi English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -393,10 +400,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two taka fifty paise'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: taka, cents: paise } = parseCurrencyValue(value)
   checkMax(taka, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/en-CA.js
+++ b/src/en-CA.js
@@ -24,7 +24,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // VOCABULARY
@@ -269,14 +269,21 @@ function decimalPartToWords(decimalPart, useAnd) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [hundredPairing] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
+ * @property {boolean} [and] - Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { hundredPairing: false, and: true }
+
+/**
  * Converts a numeric value to Canadian English words.
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.hundredPairing] - Use hundred-pairing for 1100-9999 (e.g., "fifteen hundred" instead of "one thousand five hundred")
- * @param {boolean} [options.and] - Use "and" after hundreds and before final small numbers (default: true, Canadian/British style)
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Canadian English words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -288,14 +295,13 @@ function decimalPartToWords(decimalPart, useAnd) {
  * toCardinal(1500, { hundredPairing: true }) // 'fifteen hundred'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Extract options with defaults (Canadian English uses "and" like British English)
-  const { hundredPairing = false, and: useAnd = true } = options
+  const { hundredPairing, and: useAnd } = resolveOptions(options, cardinalDefaults)
 
   let result = ''
 
@@ -479,10 +485,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Canadian English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between dollars and cents (e.g., "one dollar and fifty cents")
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Canadian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -493,10 +506,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two dollars fifty cents'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
   checkMax(dollars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/en-GB.js
+++ b/src/en-GB.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -429,10 +429,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between pounds and pence (e.g., "one pound and fifty pence")
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to British English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between pounds and pence (e.g., "one pound and fifty pence")
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in British English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -444,10 +451,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two pounds fifty pence'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: pounds, cents: pence } = parseCurrencyValue(value)
   checkMax(pounds, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/en-GH.js
+++ b/src/en-GH.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -381,19 +381,25 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between cedis and pesewas
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Ghanaian English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between cedis and pesewas
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Ghanaian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: cedis, cents: pesewas } = parseCurrencyValue(value)
   checkMax(cedis, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/en-IE.js
+++ b/src/en-IE.js
@@ -25,7 +25,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -438,10 +438,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between euro and cent (e.g., "one euro and fifty cents")
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Irish English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between euro and cent (e.g., "one euro and fifty cents")
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Irish English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -453,10 +460,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two euro fifty cents'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/en-IN.js
+++ b/src/en-IN.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { indian } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -379,10 +379,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between rupees and paise
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Indian English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between rupees and paise
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Indian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -394,10 +401,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two rupees fifty paise'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
   checkMax(rupees, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/en-KE.js
+++ b/src/en-KE.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -372,17 +372,23 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between shillings and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Kenyan English currency words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between shillings and cents
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The currency in English words
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: shillings, cents } = parseCurrencyValue(value)
   checkMax(shillings, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/en-MY.js
+++ b/src/en-MY.js
@@ -25,7 +25,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -372,16 +372,22 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between ringgit and sen
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * @param {number | string | bigint} value The numeric value to convert.
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between ringgit and sen
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Malaysian ringgit and sen in English words.
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: ringgit, cents: sen } = parseCurrencyValue(value)
   checkMax(ringgit, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/en-NG.js
+++ b/src/en-NG.js
@@ -25,7 +25,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -437,10 +437,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between naira and kobo (e.g., "one naira and fifty kobo")
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Nigerian English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between naira and kobo (e.g., "one naira and fifty kobo")
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Nigerian English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -452,10 +459,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two naira fifty kobo'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: naira, cents: kobo } = parseCurrencyValue(value)
   checkMax(naira, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/en-NZ.js
+++ b/src/en-NZ.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -387,19 +387,25 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between dollars and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to New Zealand English currency words (New Zealand Dollar).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between dollars and cents
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in New Zealand English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
   checkMax(dollars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/en-PH.js
+++ b/src/en-PH.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -374,19 +374,25 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between pesos and centavos
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Philippine English currency words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between pesos and centavos
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Philippine English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: pesos, cents: centavos } = parseCurrencyValue(value)
   checkMax(pesos, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/en-PK.js
+++ b/src/en-PK.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { indian } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -379,10 +379,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between rupees and paise
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Pakistani English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between rupees and paise
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Pakistani English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -394,10 +401,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two rupees fifty paise'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: rupees, cents: paise } = parseCurrencyValue(value)
   checkMax(rupees, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/en-SG.js
+++ b/src/en-SG.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -372,17 +372,23 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between dollars and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Singaporean English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between dollars and cents
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Singaporean English currency words
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars, cents } = parseCurrencyValue(value)
   checkMax(dollars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/en-ZA.js
+++ b/src/en-ZA.js
@@ -24,7 +24,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -437,10 +437,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "and" between rand and cents (e.g., "one rand and fifty cents")
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to South African English currency words.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "and" between rand and cents (e.g., "one rand and fifty cents")
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in South African English currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -452,10 +459,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'forty-two rand fifty cents'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: rand, cents } = parseCurrencyValue(value)
   checkMax(rand, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''


### PR DESCRIPTION
First batch of the options sweep — the fifteen options-taking `en-*` variants (en-US migrated in the #390 proof), all boolean options, mirroring the range sweep's en-* batch (#373).

## Per form

| | forms | options |
|---|---|---|
| `en-CA` | cardinal + currency | `hundredPairing: false`, `and: true` (cardinal — note the **Canadian-style `true`**, unlike en-US's `false`) · `and: true` (currency) |
| the other 14 | currency | `and: true` |

Each migrates to the contract shape proven in #390:

```js
/**
 * @typedef {object} CurrencyOptions
 * @property {boolean} [and] - Use "and" between cedis and pesewas
 */

/** @type {Required<CurrencyOptions>} */
export const currencyDefaults = { and: true }

function toCurrency(value, options) {
  ...
  const { and: useAnd } = resolveOptions(options, currencyDefaults)
```

- **Descriptions carried verbatim** from each file's `@param` lines (locale units preserved: taka/paise, cedis/pesewas, rand/cents, …).
- **Defaults read from each file's own destructure, never assumed** — which is how en-CA's divergent cardinal default survived.
- `validateOptions` import → `resolveOptions`; zero `validateOptions` references remain in these files.

## Verification

- Options gate now covers **16 languages**; all assertions green (round-trip defaults, undefined-means-default, unknown-key/wrong-type/`__proto__` → `TypeError`).
- **Typecheck teeth proven empirically** (the open item from the #390 review): with `Required<CurrencyOptions>` on the defaults export, strict checkJs fails a *missing* key (Required demands it) **and** an *extra* key (excess-property check) — verified by breaking en-AU both ways and watching typecheck fail, then restore clean. The typedef↔defaults tie is machine-enforced, not convention.
- Full suite green (425 tests).

Next batches: the `values` mechanism + the 13 `gender` languages (the enum case — out-of-set values will throw `RangeError` per the agreed taxonomy), then the remaining 11 (de, fr-×2, he, it, nl, pt-×2, tr, zh-×2), then the gate flip to required + `validateOptions` retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)