### PR TITLE
refactor(core): migrate the gender family to the options contract with values

### DIFF
--- a/src/ar-SA.js
+++ b/src/ar-SA.js
@@ -17,7 +17,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -226,26 +226,32 @@ function decimalPartToWords(decimalPart, gender) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ * @property {string} [negativeWord] - Custom word for negative numbers
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine', negativeWord: NEGATIVE }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Arabic words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
- * @param {string} [options.negativeWord] - Custom word for negative numbers
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Arabic words
  * @example
  * toCardinal(1)                        // 'واحد'
  * toCardinal(1, {gender: 'feminine'})  // 'واحدة'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const {
-    gender = 'masculine',
-    negativeWord = NEGATIVE,
-  } = options
+  const { gender, negativeWord } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   const parts = []
 
@@ -289,10 +295,20 @@ function integerToOrdinal(n, gender) {
 }
 
 /**
+ * @typedef {object} OrdinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<OrdinalOptions>} */
+export const ordinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<OrdinalOptions>['gender']> }} */
+export const ordinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Arabic ordinal words.
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {OrdinalOptions} [options] - Optional configuration
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
@@ -302,10 +318,9 @@ function integerToOrdinal(n, gender) {
  * toOrdinal(3)                        // 'الثالث'
  */
 function toOrdinal(value, options) {
-  options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
   checkMax(integerPart, ordinalMax)
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, ordinalDefaults, ordinalValues)
   return integerToOrdinal(integerPart, gender)
 }
 

--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded, longScale } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -319,13 +319,23 @@ function decimalPartToWords(decimalPart, feminine) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Spanish words.
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Spanish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -335,14 +345,13 @@ function decimalPartToWords(decimalPart, feminine) {
  * toCardinal(1000000)                   // 'un millón'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
   const feminine = gender === 'feminine'
 
   let result = ''
@@ -473,13 +482,23 @@ function integerToOrdinal(n, feminine) {
 }
 
 /**
+ * @typedef {object} OrdinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<OrdinalOptions>} */
+export const ordinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<OrdinalOptions>['gender']> }} */
+export const ordinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Spanish ordinal words.
  *
  * Spanish ordinals agree in gender with the noun they modify.
  * Only positive integers are valid for ordinals.
  * @param {number | string | bigint} value - The positive integer to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {OrdinalOptions} [options] - Optional configuration
  * @returns {string} The number in Spanish ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
@@ -490,11 +509,10 @@ function integerToOrdinal(n, feminine) {
  * toOrdinal(100)                        // 'centésimo'
  */
 function toOrdinal(value, options) {
-  options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
   checkMax(integerPart, ordinalMax)
 
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, ordinalDefaults, ordinalValues)
   const feminine = gender === 'feminine'
 
   return integerToOrdinal(integerPart, feminine)
@@ -505,13 +523,20 @@ function toOrdinal(value, options) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "con" between euros and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Spanish Euro currency words.
  *
  * Spanish currency uses masculine gender for euros (el euro)
  * and masculine for céntimos (el céntimo).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "con" between euros and cents
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Spanish currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -522,10 +547,9 @@ function toOrdinal(value, options) {
  * toCurrency(42.50, { and: false })  // 'cuarenta y dos euros cincuenta céntimos'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimos } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/es-MX.js
+++ b/src/es-MX.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded, longScale } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -319,10 +319,20 @@ function decimalPartToWords(decimalPart, feminine) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Spanish words (long scale).
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Spanish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -332,14 +342,13 @@ function decimalPartToWords(decimalPart, feminine) {
  * toCardinal(1000000000)                // 'mil millones'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
   const feminine = gender === 'feminine'
 
   let result = ''
@@ -461,10 +470,20 @@ function integerToOrdinal(n, feminine) {
 }
 
 /**
+ * @typedef {object} OrdinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<OrdinalOptions>} */
+export const ordinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<OrdinalOptions>['gender']> }} */
+export const ordinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Spanish ordinal words.
  * @param {number | string | bigint} value - The positive integer to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {OrdinalOptions} [options] - Optional configuration
  * @returns {string} The number in Spanish ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
@@ -474,11 +493,10 @@ function integerToOrdinal(n, feminine) {
  * toOrdinal(21)                         // 'vigésimo primero'
  */
 function toOrdinal(value, options) {
-  options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
   checkMax(integerPart, ordinalMax)
 
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, ordinalDefaults, ordinalValues)
   const feminine = gender === 'feminine'
 
   return integerToOrdinal(integerPart, feminine)
@@ -489,13 +507,20 @@ function toOrdinal(value, options) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "con" between pesos and centavos
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Mexican Peso currency words.
  *
  * Mexican currency uses masculine gender for pesos (el peso)
  * and masculine for centavos (el centavo).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "con" between pesos and centavos
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Mexican currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -506,10 +531,9 @@ function toOrdinal(value, options) {
  * toCurrency(42.50, { and: false })  // 'cuarenta y dos pesos cincuenta centavos'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: pesos, cents: centavos } = parseCurrencyValue(value)
   checkMax(pesos, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -22,7 +22,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded, western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -233,10 +233,20 @@ function decimalPartToWords(decimalPart, feminine) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Spanish words (US short scale).
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Spanish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -246,14 +256,13 @@ function decimalPartToWords(decimalPart, feminine) {
  * toCardinal(1000000000)                // 'un billón'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
   const feminine = gender === 'feminine'
 
   let result = ''
@@ -375,10 +384,20 @@ function integerToOrdinal(n, feminine) {
 }
 
 /**
+ * @typedef {object} OrdinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<OrdinalOptions>} */
+export const ordinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<OrdinalOptions>['gender']> }} */
+export const ordinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Spanish ordinal words.
  * @param {number | string | bigint} value - The positive integer to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {OrdinalOptions} [options] - Optional configuration
  * @returns {string} The number in Spanish ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a positive integer
@@ -388,11 +407,10 @@ function integerToOrdinal(n, feminine) {
  * toOrdinal(21)                         // 'vigésimo primero'
  */
 function toOrdinal(value, options) {
-  options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
   checkMax(integerPart, ordinalMax)
 
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, ordinalDefaults, ordinalValues)
   const feminine = gender === 'feminine'
 
   return integerToOrdinal(integerPart, feminine)
@@ -403,13 +421,20 @@ function toOrdinal(value, options) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "con" between dollars and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to US Dollar currency words in Spanish.
  *
  * US Dollar uses masculine gender for dólares (el dólar)
  * and masculine for centavos (el centavo).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "con" between dollars and cents
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Spanish US Dollar currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -420,10 +445,9 @@ function toOrdinal(value, options) {
  * toCurrency(42.50, { and: false })  // 'cuarenta y dos dólares cincuenta centavos'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars, cents: centavos } = parseCurrencyValue(value)
   checkMax(dollars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   let result = ''
   if (isNegative) result = NEGATIVE + ' '

--- a/src/hr-HR.js
+++ b/src/hr-HR.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -267,21 +267,30 @@ export const ordinalMax = western(ORDINAL_SCALES.length)
 export const currencyMax = western(SCALE_FORMS.length)
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Croatian words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Croatian words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 

--- a/src/lt-LT.js
+++ b/src/lt-LT.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -304,10 +304,20 @@ function decimalPartToWords(decimalPart, gender) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Gender for numbers < 1000
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Lithuanian words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Conversion options
- * @param {string} [options.gender] - Gender for numbers < 1000
+ * @param {CardinalOptions} [options] - Conversion options
  * @returns {string} The number in Lithuanian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -317,14 +327,13 @@ function decimalPartToWords(decimalPart, gender) {
  * toCardinal(1000000)                     // 'vienas milijonas'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 

--- a/src/lv-LV.js
+++ b/src/lv-LV.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -351,10 +351,20 @@ function decimalPartToWords(decimalPart, gender) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Gender for numbers < 1000
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Latvian words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Conversion options
- * @param {string} [options.gender] - Gender for numbers < 1000
+ * @param {CardinalOptions} [options] - Conversion options
  * @returns {string} The number in Latvian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -364,14 +374,13 @@ function decimalPartToWords(decimalPart, gender) {
  * toCardinal(1000)                        // 'tūkstotis'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 

--- a/src/pl-PL.js
+++ b/src/pl-PL.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -318,13 +318,23 @@ export const ordinalMax = western(ORDINAL_SCALES.length)
 export const currencyMax = western(MAX_SCALE_KEY)
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Gender for numbers < 1000
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Polish words.
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Conversion options
- * @param {string} [options.gender] - Gender for numbers < 1000
+ * @param {CardinalOptions} [options] - Conversion options
  * @returns {string} The number in Polish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -335,14 +345,13 @@ export const currencyMax = western(MAX_SCALE_KEY)
  * toCardinal(2000)                       // 'dwa tysiące'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 

--- a/src/ro-RO.js
+++ b/src/ro-RO.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded, western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -253,10 +253,20 @@ function decimalPartToWords(decimalPart) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Gender for numbers
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Romanian words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Conversion options
- * @param {string} [options.gender] - Gender for numbers
+ * @param {CardinalOptions} [options] - Conversion options
  * @returns {string} The number in Romanian words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -266,14 +276,13 @@ function decimalPartToWords(decimalPart) {
  * toCardinal(1000)                      // 'o mie'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 

--- a/src/ru-RU.js
+++ b/src/ru-RU.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -303,21 +303,30 @@ export const ordinalMax = western(ORDINAL_SCALES.length)
 export const currencyMax = western(SCALE_FORMS.length)
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Russian words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Russian words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 
@@ -533,10 +542,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "и" between rubles and kopecks
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Russian currency words (Russian Ruble).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "и" between rubles and kopecks
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Russian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -548,10 +564,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'сорок два рубля пятьдесят копеек'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: rubles, cents: kopecks } = parseCurrencyValue(value)
   checkMax(rubles, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/sr-Cyrl-RS.js
+++ b/src/sr-Cyrl-RS.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -275,21 +275,30 @@ function decimalPartToWords(decimalPart, gender) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Serbian (Cyrillic) words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Serbian Cyrillic words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 
@@ -501,10 +510,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "и" between dinars and para
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Serbian currency words (Serbian Dinar).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "и" between dinars and para
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Serbian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -516,10 +532,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'четрдесет два динара педесет пара'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: dinars, cents: para } = parseCurrencyValue(value)
   checkMax(dinars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/sr-Latn-RS.js
+++ b/src/sr-Latn-RS.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -275,21 +275,30 @@ function decimalPartToWords(decimalPart, gender) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Serbian (Latin) words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Serbian Latin words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 
@@ -501,10 +510,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "i" between dinars and para
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Serbian currency words (Serbian Dinar).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "i" between dinars and para
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Serbian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -516,10 +532,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false })    // 'četrdeset dva dinara pedeset para'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: dinars, cents: para } = parseCurrencyValue(value)
   checkMax(dinars, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/uk-UA.js
+++ b/src/uk-UA.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -267,21 +267,30 @@ export const ordinalMax = western(ORDINAL_SCALES.length)
 export const currencyMax = western(SCALE_FORMS.length)
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Ukrainian words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Ukrainian words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { gender = 'masculine' } = options
+  const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 

--- a/src/utils/resolve-options.js
+++ b/src/utils/resolve-options.js
@@ -5,14 +5,18 @@ import { isPlainObject } from './is-plain-object.js'
  *
  * The exported defaults map (e.g. `cardinalDefaults`) is the single source of
  * truth for each option's default value — the form never restates it, and the
- * docs generator imports it rather than scraping the body. An unknown key or a
- * wrong-typed value throws loudly instead of being silently dropped.
+ * docs generator imports it rather than scraping the body. A malformed options
+ * argument (unknown key, wrong-typed value, inherited key) throws `TypeError`;
+ * a known option with a value outside its declared allowed set (an exported
+ * `<form>Values` map, e.g. gender) throws `RangeError` — right kind of value,
+ * out of range — instead of silently falling back to the default.
  * @template {object} T
  * @param {T | undefined} options - Caller-provided options, or undefined
  * @param {Required<T>} defaults - The form's default for every option
+ * @param {Partial<Record<keyof T & string, readonly unknown[]>>} [values] - Allowed set per enum-valued option
  * @returns {Required<T>} The options with every default applied
  */
-export function resolveOptions(options, defaults) {
+export function resolveOptions(options, defaults, values) {
   /** @type {Record<string, unknown>} */
   const resolved = { ...defaults }
   if (options === undefined) return /** @type {Required<T>} */ (resolved)
@@ -36,6 +40,12 @@ export function resolveOptions(options, defaults) {
     if (value === undefined) continue
     if (typeof value !== typeof resolved[key]) {
       throw new TypeError(`Option "${key}" must be a ${typeof resolved[key]}, got ${typeof value}`)
+    }
+    if (values !== undefined && Object.hasOwn(values, key)) {
+      const set = /** @type {Record<string, readonly unknown[]>} */ (values)[key]
+      if (!set.includes(value)) {
+        throw new RangeError(`Option "${key}" must be one of: ${set.join(', ')} — got "${value}"`)
+      }
     }
     resolved[key] = value
   }

--- a/src/utils/resolve-options.js
+++ b/src/utils/resolve-options.js
@@ -44,7 +44,10 @@ export function resolveOptions(options, defaults, values) {
     if (values !== undefined && Object.hasOwn(values, key)) {
       const set = /** @type {Record<string, readonly unknown[]>} */ (values)[key]
       if (!set.includes(value)) {
-        throw new RangeError(`Option "${key}" must be one of: ${set.join(', ')} — got "${value}"`)
+        // The received value is caller-supplied and arbitrary — stringify it so
+        // quotes/newlines can't garble the message. The allowed set is our own
+        // gate-verified declaration and reads cleaner unquoted.
+        throw new RangeError(`Option "${key}" must be one of: ${set.join(', ')} — got ${JSON.stringify(value)}`)
       }
     }
     resolved[key] = value

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -34,6 +34,25 @@ const FORMS = [
   ['currency', 'toCurrency', 42.5],
 ]
 
+/**
+ * A value of the given typeof that is guaranteed outside the allowed set, or
+ * null when none is constructible (e.g. a boolean set declaring both values).
+ * @param {readonly unknown[]} set Allowed values
+ * @param {string} type `typeof` the option's default
+ * @returns {unknown} The probe value, or null
+ */
+function outOfSetProbe(set, type) {
+  if (type === 'string') {
+    let probe = '__not_in_set__'
+    while (set.includes(probe)) probe += '_'
+    return probe
+  }
+  if (type === 'number') return Math.max(0, ...set.filter(v => typeof v === 'number')) + 1
+  if (type === 'bigint') return set.filter(v => typeof v === 'bigint').reduce((max, v) => v > max ? v : max, 0n) + 1n
+  if (type === 'boolean') return set.includes(true) ? (set.includes(false) ? null : false) : true
+  return null
+}
+
 // Pre-load so a test is registered only for forms that declare the contract.
 const languages = []
 for (const file of readdirSync('./src').filter(f => f.endsWith('.js') && !f.startsWith('utils')).sort()) {
@@ -85,21 +104,27 @@ for (const { code, mod, declared } of languages) {
       t.falsy(/** @type {Record<string, unknown>} */ ({}).polluted, 'prototype must not be polluted')
 
       // Enum options: every declared value works, the default is in the set,
-      // and an out-of-set value throws RangeError (not a silent fallback).
-      for (const [key, set] of Object.entries(mod[`${form}Values`] ?? {})) {
+      // and an out-of-set value throws RangeError (not a silent fallback). The
+      // export must be a plain object when present — a falsy non-object would
+      // otherwise skip this block silently via empty Object.entries.
+      const formValues = mod[`${form}Values`]
+      t.true(formValues === undefined || isPlainObject(formValues), `${code} ${form}Values must be a plain object when exported`)
+      for (const [key, set] of Object.entries(isPlainObject(formValues) ? formValues : {})) {
         t.true(Object.hasOwn(defaults, key), `${code} ${form}Values.${key} must be a declared option`)
         t.true(Array.isArray(set) && set.length > 0, `${code} ${form}Values.${key} must be a non-empty array`)
         t.true(set.includes(defaults[key]), `${code} ${form}: the default for "${key}" must be in its allowed set`)
         for (const allowedValue of set) {
           t.notThrows(() => fn(sample, { [key]: allowedValue }), `${code} ${form}: declared value "${allowedValue}" must be accepted`)
         }
-        // The probe shares the option's typeof so it reaches the set check
-        // (a different typeof would TypeError first). All current enums are strings.
-        t.throws(
-          () => fn(sample, { [key]: '__not_in_set__' }),
-          { instanceOf: RangeError },
-          `${code} ${form}: out-of-set "${key}" must throw RangeError`,
-        )
+        // The probe must share the option's typeof to reach the set check (a
+        // different typeof would TypeError first), so derive it from the default.
+        for (const probe of [outOfSetProbe(set, typeof defaults[key])].filter(p => p !== null)) {
+          t.throws(
+            () => fn(sample, { [key]: probe }),
+            { instanceOf: RangeError },
+            `${code} ${form}: out-of-set "${key}" must throw RangeError`,
+          )
+        }
       }
     }
   })

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -18,6 +18,9 @@ import { isPlainObject } from '../src/utils/is-plain-object.js'
  * - a malformed options argument throws `TypeError` — an unknown key, a
  *   wrong-typed value, or an inherited key all fail loudly, not silently.
  *   (`RangeError` is reserved for a value out of range, e.g. checkMax.)
+ * - an enum-valued option declares its allowed set as `<form>Values`: every
+ *   declared value is accepted, the default is in the set, and an out-of-set
+ *   value throws `RangeError` instead of silently falling back to the default.
  *
  * Auto-covers any form that exports `<form>Defaults` while the sweep is in
  * progress. Once every options-taking language is migrated, this flips to
@@ -80,6 +83,24 @@ for (const { code, mod, declared } of languages) {
         `${code} ${form}: must reject inherited keys like __proto__`,
       )
       t.falsy(/** @type {Record<string, unknown>} */ ({}).polluted, 'prototype must not be polluted')
+
+      // Enum options: every declared value works, the default is in the set,
+      // and an out-of-set value throws RangeError (not a silent fallback).
+      for (const [key, set] of Object.entries(mod[`${form}Values`] ?? {})) {
+        t.true(Object.hasOwn(defaults, key), `${code} ${form}Values.${key} must be a declared option`)
+        t.true(Array.isArray(set) && set.length > 0, `${code} ${form}Values.${key} must be a non-empty array`)
+        t.true(set.includes(defaults[key]), `${code} ${form}: the default for "${key}" must be in its allowed set`)
+        for (const allowedValue of set) {
+          t.notThrows(() => fn(sample, { [key]: allowedValue }), `${code} ${form}: declared value "${allowedValue}" must be accepted`)
+        }
+        // The probe shares the option's typeof so it reaches the set check
+        // (a different typeof would TypeError first). All current enums are strings.
+        t.throws(
+          () => fn(sample, { [key]: '__not_in_set__' }),
+          { instanceOf: RangeError },
+          `${code} ${form}: out-of-set "${key}" must throw RangeError`,
+        )
+      }
     }
   })
 }


### PR DESCRIPTION
The **enum batch** — and the one that kills a real bug class. Thirteen languages take a `gender` option, every implementation is binary (`gender === 'feminine' ? F : M`), so any other value — `'neuter'`, a typo, garbage — **silently converted as masculine** with well-formed output. The exact silently-wrong class this whole campaign exists to kill, surfaced while reviewing #390.

## The `values` mechanism

`resolveOptions` gains an optional third argument — the form's exported allowed-set map:

```js
/**
 * @typedef {object} CardinalOptions
 * @property {('masculine'|'feminine')} [gender] - Grammatical gender
 */

/** @type {Required<CardinalOptions>} */
export const cardinalDefaults = { gender: 'masculine' }

/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
export const cardinalValues = { gender: ['masculine', 'feminine'] }

const { gender } = resolveOptions(options, cardinalDefaults, cardinalValues)
```

Error taxonomy holds exactly as settled: malformed options (unknown key / wrong type / inherited key) → `TypeError`; a **known key with an out-of-set value** → `RangeError` (*"Option "gender" must be one of: masculine, feminine — got "neuter""*) — right kind of value, out of range, same family as `checkMax`.

## Enforcement at every layer

- **Typecheck**: the values export is typed `ReadonlyArray<Required<…Options>['gender']>` — a typo in the set fails strict checkJs.
- **Gate** (new assertions, auto-cover any `<form>Values` export): every key is a declared option; every declared value is accepted; **the default is in the set**; an out-of-set value throws `RangeError`. Teeth verified by breaking lv-LV's set and watching its test fail.
- **Runtime**: prototype-pollution-safe lookup (`Object.hasOwn`), set check after the typeof check.

## The thirteen

| | forms migrated |
|---|---|
| `ar-SA` | cardinal (gender + free-string `negativeWord`, default carried as the `NEGATIVE` vocabulary const) + ordinal |
| `es-ES` `es-MX` `es-US` | cardinal + ordinal (gender), currency (`and`) |
| `ru-RU` `sr-Cyrl-RS` `sr-Latn-RS` | cardinal (gender), currency (`and`) |
| `hr-HR` `lt-LT` `lv-LV` `pl-PL` `ro-RO` `uk-UA` | cardinal (gender) |

`lt-LT` / `lv-LV` / `pl-PL` / `ro-RO` had under-typed gender as bare `{string}` — upgraded to the union their implementations actually enforce.

## ⚠️ Deliberate behaviour change

An invalid gender value now **throws `RangeError`** instead of silently converting as masculine. That's the point of the batch — fail loud per the contract, matching the published union type.

438 tests green · typecheck clean · **29 languages on the options contract.** Remaining: batch 3 (de, fr-×2, he-IL, it, nl, pt-×2, tr, zh-×2), then the gate flip to required + `validateOptions` retirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)