### PR TITLE
refactor(core): migrate the remaining languages to the options contract

### DIFF
--- a/src/de-DE.js
+++ b/src/de-DE.js
@@ -17,7 +17,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -567,10 +567,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "und" between euros and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to German currency words (Euro).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "und" between euros and cents
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in German currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -582,10 +589,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false }) // 'zweiundvierzig Euro fünfzig Cent'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/fr-BE.js
+++ b/src/fr-BE.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { longScale } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -338,21 +338,27 @@ function decimalPartToWords(decimalPart, withHyphen) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [withHyphenSeparator] - Use hyphens between words
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { withHyphenSeparator: false }
+
+/**
  * Converts a numeric value to Belgian French words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.withHyphenSeparator] - Use hyphens between words
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Belgian French words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { withHyphenSeparator = false } = options
+  const { withHyphenSeparator } = resolveOptions(options, cardinalDefaults)
 
   let result = ''
   const sep = withHyphenSeparator ? '-' : ' '
@@ -462,10 +468,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "et" between euros and centimes
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Belgian French currency words (Euro).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "et" between euros and centimes
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Belgian French currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -477,10 +490,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false }) // 'quarante-deux euros cinquante centimes'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimes } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/fr-FR.js
+++ b/src/fr-FR.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { longScale } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -360,13 +360,20 @@ function decimalPartToWords(decimalPart, withHyphen) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [withHyphenSeparator] - Use hyphens between all words
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { withHyphenSeparator: false }
+
+/**
  * Converts a numeric value to French words.
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.withHyphenSeparator] - Use hyphens between all words
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in French words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -376,14 +383,13 @@ function decimalPartToWords(decimalPart, withHyphen) {
  * toCardinal(1000000)      // 'un million'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { withHyphenSeparator = false } = options
+  const { withHyphenSeparator } = resolveOptions(options, cardinalDefaults)
 
   let result = ''
   const sep = withHyphenSeparator ? '-' : ' '
@@ -497,10 +503,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "et" between euros and centimes
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to French currency words (Euro).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "et" between euros and centimes
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in French currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -512,10 +525,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false }) // 'quarante-deux euros cinquante centimes'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centimes } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/hbo-IL.js
+++ b/src/hbo-IL.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded, western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (arrays for indexed access - faster than object property lookup)
@@ -295,23 +295,27 @@ function decimalPartToWords(decimalPart, gender) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {('masculine'|'feminine')} [gender] - Grammatical gender
+ * @property {string} [andWord] - Custom conjunction word
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { gender: 'masculine', andWord: 'ו' }
+
+/** @type {{ gender: ReadonlyArray<Required<CardinalOptions>['gender']> }} */
+export const cardinalValues = { gender: ['masculine', 'feminine'] }
+
+/**
  * Converts a numeric value to Biblical Hebrew words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {('masculine'|'feminine')} [options.gender] - Grammatical gender
- * @param {string} [options.andWord] - Custom conjunction word
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Biblical Hebrew words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   checkMax(integerPart, cardinalMax)
-
-  // Apply option defaults
-  const {
-    gender = 'masculine',
-    andWord = 'ו',
-  } = options
+  const { gender, andWord } = resolveOptions(options, cardinalDefaults, cardinalValues)
 
   let result = ''
 

--- a/src/he-IL.js
+++ b/src/he-IL.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded, western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (arrays for indexed access - faster than object property lookup)
@@ -275,19 +275,25 @@ function decimalPartToWords(decimalPart) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {string} [andWord] - Custom conjunction word
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { andWord: 'ו' }
+
+/**
  * Converts a numeric value to Modern Hebrew words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {string} [options.andWord] - Custom conjunction word
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Modern Hebrew words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   checkMax(integerPart, cardinalMax)
 
   // Apply option defaults
-  const { andWord = 'ו' } = options
+  const { andWord } = resolveOptions(options, cardinalDefaults)
 
   let result = ''
 

--- a/src/it-IT.js
+++ b/src/it-IT.js
@@ -17,7 +17,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { longScale } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -469,10 +469,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Use "e" between euros and centesimi
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a numeric value to Italian currency words (Euro).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.and] - Use "e" between euros and centesimi
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Italian currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -484,10 +491,9 @@ function toOrdinal(value) {
  * toCurrency(42.50, { and: false }) // 'quarantadue euro cinquanta centesimi'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents: centesimi } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and: useAnd = true } = options
+  const { and: useAnd } = resolveOptions(options, currencyDefaults)
 
   // Build result
   let result = ''

--- a/src/nl-NL.js
+++ b/src/nl-NL.js
@@ -18,7 +18,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -309,15 +309,22 @@ function decimalPartToWords(decimalPart, options) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [accentOne] - Use "één" instead of "een"
+ * @property {boolean} [includeOptionalAnd] - Include "en" before small numbers
+ * @property {boolean} [noHundredPairing] - Disable hundred pairing (1104→duizend honderdvier)
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { accentOne: true, includeOptionalAnd: false, noHundredPairing: false }
+
+/**
  * Converts a numeric value to Dutch words.
  *
  * This is the main public API. It accepts any valid numeric input
  * (number, string, or bigint) and handles parsing internally.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.accentOne] - Use "één" instead of "een"
- * @param {boolean} [options.includeOptionalAnd] - Include "en" before small numbers
- * @param {boolean} [options.noHundredPairing] - Disable hundred pairing (1104→duizend honderdvier)
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Dutch words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -328,18 +335,13 @@ function decimalPartToWords(decimalPart, options) {
  * toCardinal(1104)                      // 'elfhonderd vier'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const {
-    accentOne = true,
-    includeOptionalAnd = false,
-    noHundredPairing = false,
-  } = options
+  const { accentOne, includeOptionalAnd, noHundredPairing } = resolveOptions(options, cardinalDefaults)
 
   const opts = { accentOne, includeOptionalAnd, noHundredPairing }
 
@@ -542,10 +544,17 @@ function buildLargeOrdinal(n) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Include "en" between euros and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a number to Dutch currency words (Euro).
  * @param {number | string | bigint} value - The amount to convert
- * @param {object} [options] Optional configuration
- * @param {boolean} [options.and] - Include "en" between euros and cents
+ * @param {CurrencyOptions} [options] Optional configuration
  * @returns {string} Dutch currency words
  * @example
  * toCurrency(42.50)  // 'tweeënveertig euro en vijftig cent'
@@ -553,10 +562,9 @@ function buildLargeOrdinal(n) {
  * toCurrency(0.01)   // 'één cent'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and = true } = options
+  const { and } = resolveOptions(options, currencyDefaults)
 
   let result = ''
 

--- a/src/pt-BR.js
+++ b/src/pt-BR.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -482,24 +482,30 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Include "e" between major and minor units
+ * @property {string} [currency] - Currency code (e.g., 'BRL', 'USD'); empty means auto-detect for pt-BR
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true, currency: '' }
+
+/**
  * Converts a number to Brazilian Portuguese currency words.
  * @param {number | string | bigint} value - The amount to convert
- * @param {object} [options] Currency formatting options
- * @param {boolean} [options.and] - Include "e" between major and minor units
- * @param {string} [options.currency] - Currency code (e.g., 'BRL', 'USD')
+ * @param {CurrencyOptions} [options] Currency formatting options
  * @returns {string} Brazilian Portuguese currency words
  * @example
  * toCurrency(42.50)                    // 'quarenta e dois reais e cinquenta centavos'
  * toCurrency(42.50, {currency: 'USD'}) // 'quarenta e dois dólares e cinquenta centavos'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: majorUnits, cents: minorUnits } = parseCurrencyValue(value)
   checkMax(majorUnits, currencyMax)
-  const { and = true } = options
+  const { and, currency } = resolveOptions(options, currencyDefaults)
 
   // 1. Descobre a moeda informada ou busca automaticamente a padrão do país (pt-BR = BRL)
-  let currencyCode = options.currency
+  let currencyCode = currency
   if (!currencyCode) {
     try {
       // Intl Locale Info (getCurrencies) is a newer TC39 API present at

--- a/src/pt-PT.js
+++ b/src/pt-PT.js
@@ -16,7 +16,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -486,10 +486,17 @@ function toOrdinal(value) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [and] - Include "e" between euros and cents
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { and: true }
+
+/**
  * Converts a number to Portuguese currency words (Euro).
  * @param {number | string | bigint} value - The amount to convert
- * @param {object} [options] Currency formatting options
- * @param {boolean} [options.and] - Include "e" between euros and cents
+ * @param {CurrencyOptions} [options] Currency formatting options
  * @returns {string} Portuguese currency words
  * @example
  * toCurrency(42.50)  // 'quarenta e dois euros e cinquenta cêntimos'
@@ -497,10 +504,9 @@ function toOrdinal(value) {
  * toCurrency(0.01)   // 'um cêntimo'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: euros, cents } = parseCurrencyValue(value)
   checkMax(euros, currencyMax)
-  const { and = true } = options
+  const { and } = resolveOptions(options, currencyDefaults)
 
   let result = ''
 

--- a/src/tr-TR.js
+++ b/src/tr-TR.js
@@ -14,7 +14,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { western } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary (module-level constants)
@@ -261,10 +261,17 @@ function decimalPartToWords(decimalPart, dropSpaces) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [dropSpaces] - Remove spaces for compound form
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { dropSpaces: false }
+
+/**
  * Converts a numeric value to Turkish words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Conversion options
- * @param {boolean} [options.dropSpaces] - Remove spaces for compound form
+ * @param {CardinalOptions} [options] - Conversion options
  * @returns {string} The number in Turkish words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -274,14 +281,13 @@ function decimalPartToWords(decimalPart, dropSpaces) {
  * toCardinal(1000)                      // 'bin'
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   // Both the integer part and the decimal's significant digits are spelled via
   // the scale builder, so both must clear the ceiling.
   checkMax(integerPart, cardinalMax, decimalPart)
 
   // Apply option defaults
-  const { dropSpaces = false } = options
+  const { dropSpaces } = resolveOptions(options, cardinalDefaults)
 
   const sep = dropSpaces ? '' : ' '
   let result = ''

--- a/src/zh-Hans-CN.js
+++ b/src/zh-Hans-CN.js
@@ -15,7 +15,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -213,19 +213,25 @@ function decimalDigitsToWords(decimalString, ones) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [formal] - Use formal/financial numerals
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { formal: true }
+
+/**
  * Converts a numeric value to Simplified Chinese words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.formal] - Use formal/financial numerals
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Simplified Chinese words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   checkMax(integerPart, cardinalMax)
 
   // Apply option defaults
-  const { formal = true } = options
+  const { formal } = resolveOptions(options, cardinalDefaults)
 
   let result = isNegative ? NEGATIVE : ''
 
@@ -256,10 +262,17 @@ function integerToOrdinal(n, formal) {
 }
 
 /**
+ * @typedef {object} OrdinalOptions
+ * @property {boolean} [formal] - Use formal/financial numerals
+ */
+
+/** @type {Required<OrdinalOptions>} */
+export const ordinalDefaults = { formal: true }
+
+/**
  * Converts a numeric value to Simplified Chinese ordinal words.
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.formal] - Use formal/financial numerals
+ * @param {OrdinalOptions} [options] - Optional configuration
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
@@ -269,10 +282,9 @@ function integerToOrdinal(n, formal) {
  * toOrdinal(10)                   // '第壹拾'
  */
 function toOrdinal(value, options) {
-  options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
   checkMax(integerPart, ordinalMax)
-  const { formal = true } = options
+  const { formal } = resolveOptions(options, ordinalDefaults)
   return integerToOrdinal(integerPart, formal)
 }
 
@@ -281,10 +293,17 @@ function toOrdinal(value, options) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [formal] - Use formal/financial numerals
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { formal: true }
+
+/**
  * Converts a numeric value to Simplified Chinese currency words (Yuan/Renminbi).
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.formal] - Use formal/financial numerals
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Simplified Chinese currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -295,10 +314,9 @@ function toOrdinal(value, options) {
  * toCurrency(42.50, { formal: false }) // '四十二元五角整'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: yuan, cents } = parseCurrencyValue(value)
   checkMax(yuan, currencyMax)
-  const { formal = true } = options
+  const { formal } = resolveOptions(options, currencyDefaults)
 
   const ones = formal ? ONES_FORMAL : ONES_COMMON
   const yuanWord = formal ? YUAN_FORMAL : YUAN_COMMON

--- a/src/zh-Hant-TW.js
+++ b/src/zh-Hant-TW.js
@@ -19,7 +19,7 @@ import { parseCurrencyValue } from './utils/parse-currency.js'
 import { parseOrdinalValue } from './utils/parse-ordinal.js'
 import { checkMax } from './utils/check-max.js'
 import { bounded } from './utils/scale.js'
-import { validateOptions } from './utils/validate-options.js'
+import { resolveOptions } from './utils/resolve-options.js'
 
 // ============================================================================
 // Vocabulary
@@ -223,19 +223,25 @@ function decimalDigitsToWords(decimalString, formal = true) {
 }
 
 /**
+ * @typedef {object} CardinalOptions
+ * @property {boolean} [formal] - Use formal/financial numerals
+ */
+
+/** @type {Required<CardinalOptions>} */
+export const cardinalDefaults = { formal: true }
+
+/**
  * Converts a numeric value to Traditional Chinese words.
  * @param {number | string | bigint} value - The numeric value to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.formal] - Use formal/financial numerals
+ * @param {CardinalOptions} [options] - Optional configuration
  * @returns {string} The number in Traditional Chinese words
  */
 function toCardinal(value, options) {
-  options = validateOptions(options)
   const { isNegative, integerPart, decimalPart } = parseCardinalValue(value)
   checkMax(integerPart, cardinalMax)
 
   // Apply option defaults
-  const { formal = true } = options
+  const { formal } = resolveOptions(options, cardinalDefaults)
 
   let result = ''
 
@@ -269,10 +275,17 @@ function integerToOrdinal(n, formal = true) {
 }
 
 /**
+ * @typedef {object} OrdinalOptions
+ * @property {boolean} [formal] - Use formal/financial numerals
+ */
+
+/** @type {Required<OrdinalOptions>} */
+export const ordinalDefaults = { formal: true }
+
+/**
  * Converts a numeric value to Traditional Chinese ordinal words.
  * @param {number | string | bigint} value - The numeric value to convert (positive integer)
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.formal] - Use formal/financial numerals
+ * @param {OrdinalOptions} [options] - Optional configuration
  * @returns {string} The number as ordinal words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {RangeError} If value is negative, zero, or has a decimal part
@@ -282,10 +295,9 @@ function integerToOrdinal(n, formal = true) {
  * toOrdinal(1, { formal: false }) // '第一'
  */
 function toOrdinal(value, options) {
-  options = validateOptions(options)
   const integerPart = parseOrdinalValue(value)
   checkMax(integerPart, ordinalMax)
-  const { formal = true } = options
+  const { formal } = resolveOptions(options, ordinalDefaults)
   return integerToOrdinal(integerPart, formal)
 }
 
@@ -294,13 +306,20 @@ function toOrdinal(value, options) {
 // ============================================================================
 
 /**
+ * @typedef {object} CurrencyOptions
+ * @property {boolean} [formal] - Use formal/financial numerals
+ */
+
+/** @type {Required<CurrencyOptions>} */
+export const currencyDefaults = { formal: true }
+
+/**
  * Converts a numeric value to Traditional Chinese currency words (New Taiwan Dollar).
  *
  * Uses 圓 (yuan), 角 (jiao, 1/10), 分 (fen, 1/100).
  * Formal writing adds 整 (zheng) for whole amounts.
  * @param {number | string | bigint} value - The currency amount to convert
- * @param {object} [options] - Optional configuration
- * @param {boolean} [options.formal] - Use formal/financial numerals
+ * @param {CurrencyOptions} [options] - Optional configuration
  * @returns {string} The amount in Traditional Chinese currency words
  * @throws {TypeError} If value is not a valid numeric type
  * @throws {Error} If value is not a valid number format
@@ -310,10 +329,9 @@ function toOrdinal(value, options) {
  * toCurrency(42, { formal: false }) // '四十二元整'
  */
 function toCurrency(value, options) {
-  options = validateOptions(options)
   const { isNegative, dollars: yuan, cents } = parseCurrencyValue(value)
   checkMax(yuan, currencyMax)
-  const { formal = true } = options
+  const { formal } = resolveOptions(options, currencyDefaults)
 
   const yuanWord = formal ? YUAN_FORMAL : YUAN_COMMON
 


### PR DESCRIPTION
The final language batch of the options sweep — **all 41 option-taking languages are now on the contract.**

## The twelve

| | forms | options |
|---|---|---|
| `de-DE` `it-IT` `pt-PT` | currency | `and: true` |
| `fr-BE` `fr-FR` | cardinal + currency | `withHyphenSeparator: false` · `and: true` |
| `he-IL` | cardinal | `andWord: 'ו'` (free string) |
| `nl-NL` | cardinal + currency | `accentOne: true`, `includeOptionalAnd: false`, `noHundredPairing: false` · `and: true` |
| `tr-TR` | cardinal | `dropSpaces: false` |
| `zh-Hans-CN` `zh-Hant-TW` | cardinal + ordinal + currency | `formal: true` ×3 |
| `pt-BR` | currency | `and: true`, `currency: ''` (see below) |
| `hbo-IL` | cardinal | `gender` (enum, + `cardinalValues`) + `andWord: 'ו'` |

## Two catches the earlier scans missed

- **nl-NL's cardinal takes three options**, not just currency's `and` — the script's `@params`↔destructure cross-check validated all three (this is why the script refuses to guess).
- **hbo-IL was invisible to the original scan entirely** (multi-line destructure blinded the regex; found by this batch's residual `validateOptions` grep — the authoritative check, since every options-taking language used it). Its `gender` joins the enum contract with a `cardinalValues` export: invalid gender now throws `RangeError` like the rest of the gender family.

## pt-BR's auto-detected currency

Its `currency` option is read off `options.currency` and Intl-auto-detected when absent — there is no static default. The contract declares `currency: ''`, and the body already treated falsy as auto-detect, so **behaviour is unchanged**: `''` flows into the same `if (!currencyCode)` → Intl → `'BRL'` chain. LANGUAGES.md keeps rendering `—` (empty string is falsy in the renderer). Bonus: `{ currency: 123 }` now throws a clean `TypeError` instead of crashing on `.toUpperCase()`.

## Verification

- 450 tests green · typecheck clean · options gate covers **41 languages**.
- `validateOptions` has **zero language callers** — its deletion ships with the finale.

Next (last) PR: flip the options gate to **required** (any form taking options must export `<form>Defaults`), delete `validateOptions`, and point `lang:add`'s currency stub + CLAUDE.md's Options Pattern at the contract shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)