### PR TITLE
docs(core): refresh CONTRIBUTING and a stale guard comment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,7 @@ default". Boolean/free-string forms omit the `<form>Values` argument.
 ## Adding a Language
 
 ```bash
-npm run lang:add -- <code>  # Creates stub + fixture + type tests
+npm run lang:add -- <code>  # Creates stub + fixture, regenerates LANGUAGES.md
 ```
 
 Then: implement the form(s) you're adding (`toCardinal`, `toOrdinal`, and/or `toCurrency` — at least one) in `src/{code}.js` — **including the `*Max` declarations and `checkMax` guards** (see Language File Pattern) — add cases to `test/fixtures/{code}.js`, run `npm test`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Scopes use BCP 47 language codes — one (`en-US`), comma-separated (`az-AZ,tr-T
 npm run lang:add -- <code>   # e.g., ko-KR, sr-Cyrl-RS, fr-BE
 ```
 
-This scaffolds the language file, test fixture, and type tests. A language can
+This scaffolds the language file and test fixture, and regenerates LANGUAGES.md. A language can
 implement one, two, or all three **forms** — start with whichever you can do
 well and others can be added later:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ npm test
 - `refactor(core): simplify exports` — code refactoring
 - `docs: update README` — documentation
 
-Scopes use BCP 47 language codes (`en-US`, `fr-BE`, `zh-Hans-CN`) or project areas (`core`, `types`, `umd`). See [.commitlintrc.mjs](.commitlintrc.mjs) for details.
+Scopes use BCP 47 language codes — one (`en-US`), comma-separated (`az-AZ,tr-TR`), or a bare primary subtag for a variant family (`en`, `es`) — or project areas (`core`, `types`, `umd`). See [.commitlintrc.mjs](.commitlintrc.mjs) for details.
 
 ## Adding a New Language
 
@@ -36,7 +36,9 @@ Scopes use BCP 47 language codes (`en-US`, `fr-BE`, `zh-Hans-CN`) or project are
 npm run lang:add -- <code>   # e.g., ko-KR, sr-Cyrl-RS, fr-BE
 ```
 
-This scaffolds all required files. Every language implements three **forms**:
+This scaffolds the language file, test fixture, and type tests. A language can
+implement one, two, or all three **forms** — start with whichever you can do
+well and others can be added later:
 
 | Form     | Function       | Example              |
 | -------- | -------------- | -------------------- |
@@ -46,13 +48,18 @@ This scaffolds all required files. Every language implements three **forms**:
 
 Then:
 
-1. Implement all three forms in `src/<code>.js`
+1. Implement your form(s) in `src/<code>.js` — including each form's range
+   declaration (`cardinalMax` etc., scaffolded as `UNBOUNDED` placeholders; see
+   [docs/range-contract.md](docs/range-contract.md)) and, if a form takes
+   options, its options contract (see
+   [docs/options-contract.md](docs/options-contract.md))
 2. Add test cases to `test/fixtures/<code>.js`
-3. Run `npm test`
+3. Run `npm test` — the suite's gates verify everything automatically and tell
+   you exactly what's missing; green means done
 
 ## Code Style
 
-- **JavaScript:** ESLint with [neostandard](https://github.com/neostandard/neostandard) (standard style) — `npm run lint:fix`
+- **JavaScript:** [ESLint](https://eslint.org/) — `npm run lint:fix`
 - **Markdown:** [markdownlint](https://github.com/DavidAnson/markdownlint) — `npm run lint:md -- --fix`
 
 ## Testing

--- a/src/da-DK.js
+++ b/src/da-DK.js
@@ -193,7 +193,7 @@ function buildLargeNumberWords(n) {
   }
 
   // Convert segments to words with scale tracking
-  // Callers guard the magnitude (MAX_CARDINAL) before reaching here.
+  // Callers guard the magnitude (cardinalMax) before reaching here.
   // scaleIndex: 0 = units, 1 = thousands, 2 = millions, etc.
   const parts = []
   let scaleIndex = segments.length - 1


### PR DESCRIPTION
Cleanup audit follow-through after the contracts arc (#397 merged).

## CONTRIBUTING.md — the human front door was teaching wrong things

| was | now |
|---|---|
| "Every language implements three forms" / "Implement all three forms" | One, two, or all three — start with what you can do well (the incremental-forms policy the gates actually enforce) |
| Recipe: implement → fixtures → test, no contracts | Recipe includes the range declaration + options contract, with links to `docs/range-contract.md` / `docs/options-contract.md`, and frames the gates as the feedback loop: *"the gates verify everything automatically and tell you exactly what's missing; green means done"* |
| "ESLint with neostandard" | ESLint (neostandard was dropped for ESLint 10 in #335) |
| Scopes: codes or areas | + comma-separated lists and bare-subtag family scopes (`en`, `es`) that commitlint actually accepts |

## Also

- `da-DK`'s last stale guard comment (`MAX_CARDINAL` → `cardinalMax`) — same class swept in es-* during the range migration; this was the only one left repo-wide (audited by grep).

## Audit all-clears (no action needed, for the record)

- UMD build uses `exports: 'named'` — the contract exports (`*Max`, `<form>Defaults`, `<form>Values`) flow through.
- `contract.test.js` is **not** subsumed by the range gate — fast-check fuzzes arbitrary inputs (negatives, decimals, strings) while the gate sweeps magnitudes; both earn their keep.
- No other stale references to `tooLargeError` / `exceedsMax` / `validateOptions` / `MAX_*` anywhere in src/test/scripts/docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)