### PR TITLE
chore: let commit bodies cite issue references

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -188,7 +188,13 @@ export default {
     // -------------------------------------------------------------------------
     'body-leading-blank': [2, 'always'],
     'body-max-line-length': [0], // Disabled - URLs can be long
-    'footer-leading-blank': [2, 'always'],
+    // Disabled: the conventional parser treats any body line containing a
+    // "#123" reference as the START of the footer, so this rule fails valid
+    // messages position-dependently (it bit three commits running). Its
+    // protection here is ~nil — git trailers (Co-Authored-By) are never parser
+    // footer-starts, and a glued BREAKING CHANGE still parses as a note, so the
+    // blank line it wants is purely stylistic. Off lets commit bodies cite #123.
+    'footer-leading-blank': [0],
     'footer-max-line-length': [0], // Disabled - URLs can be long
   },
 }


### PR DESCRIPTION
Commit bodies couldn't cite `#123` naturally: the conventional parser treats any body line containing a reference as the start of the footer, so `footer-leading-blank` failed valid messages position-dependently. It bit the commit messages of #365, #370, and #397, each worked around by writing "PR 365" — a rule carried in a head instead of the machine.

## The change

One line: `footer-leading-blank: [0]`, documented inline — the same `[0]` pattern this config already uses for `body-max-line-length` and `footer-max-line-length`. The rule's protection here is ~nil: git trailers (`Co-Authored-By`) are never parser footer-starts, and a glued `BREAKING CHANGE` still parses as a note, so the blank line it wants is purely stylistic.

## No config test (changed from the first draft)

An earlier version of this branch patched the *parser* and added a test gating the commitlint config. Both dropped:

- the parser patch was over-built — a preset-internals import, a new devDependency, and a NUL-byte unmatchable prefix, with a comment documenting how it could silently break;
- testing the config is a rare practice that here amounted to either re-testing commitlint's own rules or guarding our bespoke scope plugin against its own requirements. If that plugin warranted that level of coverage, the honest move would be to extract it as its own package with its own tests — not test it in place and drag `@commitlint/load`/`lint` into the repo to do it.

The husky `commit-msg` hook already exercises the config on every commit.

## Dogfood

This PR's commit body cites `#365` / `#370` / `#397` mid-line — positions that failed before this change — and the hook validated it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
