### PR TITLE
fix(scripts): stop lang:add overwriting work-in-progress files

### DIFF
--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -33,7 +33,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import * as readline from 'node:readline/promises'
 import chalk from 'chalk'
 import { getExportedForms } from '../test/helpers/language-helpers.js'
-import { getCanonicalCode, getLanguageName, isInCLDR, isValidLanguageCode, normalizeCode } from '../test/helpers/language-naming.js'
+import { getCanonicalCode, getLanguageName, isValidLanguageCode, normalizeCode } from '../test/helpers/language-naming.js'
 
 // ============================================================================
 // CLI Argument Parsing
@@ -279,20 +279,23 @@ function generateMaxExport(form) {
   return `export const ${form}Max = UNBOUNDED`
 }
 
-/**
- * The grouped `*Max` declaration block for a new language, with a TODO pointing
- * at the scale.js helpers.
- *
- * @param {Set<string>} forms Forms to include
- * @returns {string} Comment + one export per scaffolded form
- */
-function generateMaxExportsBlock(forms) {
-  const exports = FORM_ORDER.filter(f => forms.has(f)).map(generateMaxExport)
-  return `// TODO: set each form's ceiling — the smallest value it refuses. Use a scale.js
+const MAX_TODO_COMMENT = `// TODO: set each form's ceiling — the smallest value it refuses. Use a scale.js
 // helper (western / myriad / indian / longScale / bounded) derived from your scale
 // table, or keep UNBOUNDED for a recursive/compounding speller. The range gate
-// (test/range-contract.test.js) verifies whatever you declare — see docs/range-contract.md.
-${exports.join('\n')}`
+// (test/range-contract.test.js) verifies whatever you declare — see docs/range-contract.md.`
+
+/**
+ * The grouped `*Max` declaration block, with a TODO pointing at the scale.js
+ * helpers. The comment is skipped when the target file already carries it
+ * (adding a second form shouldn't duplicate the guidance).
+ *
+ * @param {Set<string>} forms Forms to include
+ * @param {boolean} [withComment] Include the TODO comment (default true)
+ * @returns {string} Comment + one export per scaffolded form
+ */
+function generateMaxExportsBlock(forms, withComment = true) {
+  const exports = FORM_ORDER.filter(f => forms.has(f)).map(generateMaxExport)
+  return withComment ? `${MAX_TODO_COMMENT}\n${exports.join('\n')}` : exports.join('\n')
 }
 
 /**
@@ -489,7 +492,8 @@ function addFormsToExistingFile(code, newForms) {
   // statement (re-find since content may have shifted).
   const updatedExportMatch = content.match(/export \{[^}]+\}/)
   const insertPos = content.indexOf(updatedExportMatch[0])
-  const insertion = `${generateMaxExportsBlock(newForms)}\n\n${newFunctions.join('\n\n')}\n\n`
+  const needsTodoComment = !content.includes('TODO: set each form')
+  const insertion = `${generateMaxExportsBlock(newForms, needsTodoComment)}\n\n${newFunctions.join('\n\n')}\n\n`
   content = content.slice(0, insertPos) + insertion + content.slice(insertPos)
 
   // Update export statement
@@ -622,9 +626,24 @@ async function main() {
   const langFilePath = `./src/${code}.js`
   const fixtureFilePath = `./test/fixtures/${code}.js`
 
-  // Check existing implementation (read from real exports, not source text)
+  // Check existing implementation (read from real exports, not source text).
+  // "New language" means the FILE doesn't exist — never "the import returned no
+  // forms": a work-in-progress file with a syntax error imports as zero forms,
+  // and treating that as new would silently overwrite the contributor's work.
   const existingForms = await getExportedForms(code)
-  const isNewLanguage = existingForms.size === 0
+  const isNewLanguage = !existsSync(langFilePath)
+  if (!isNewLanguage && existingForms.size === 0) {
+    console.error(chalk.red(`${langFilePath} exists but exports no working forms — likely a syntax error or unfinished file.`))
+    console.error(chalk.gray('Refusing to overwrite it. Fix (or delete) the file, then re-run.'))
+    process.exitCode = 1
+    return
+  }
+  if (isNewLanguage && existsSync(fixtureFilePath)) {
+    console.error(chalk.red(`${fixtureFilePath} exists but ${langFilePath} doesn't.`))
+    console.error(chalk.gray('Refusing to overwrite the fixture. Move it aside (or delete it), then re-run.'))
+    process.exitCode = 1
+    return
+  }
 
   // Determine which forms to scaffold
   let formsToScaffold
@@ -644,16 +663,19 @@ async function main() {
     }
   }
 
-  // Get language name
+  // Get language name — CLDR or the LANGUAGE_NAME_OVERRIDES in
+  // test/helpers/language-naming.js; prompt only when neither knows it.
   let languageName = getLanguageName(code)
+  let nameNeedsOverride = false
 
-  if (!isInCLDR(code)) {
+  if (languageName === null) {
     const userProvidedName = await promptForLanguageName(code)
     if (userProvidedName === null) {
       process.exitCode = 1
       return
     }
     languageName = userProvidedName
+    nameNeedsOverride = true
   }
 
   console.log(chalk.cyan(`\nAdding ${isNewLanguage ? 'language' : 'forms'}: ${languageName} (${code})`))
@@ -699,6 +721,11 @@ async function main() {
   console.log(chalk.gray(`3. Add at least one case per form to ${fixtureFilePath}`))
   console.log(chalk.gray('   — the suite rejects empty fixtures, so it fails until you do'))
   console.log(chalk.gray('4. Run: npm test  (runs the suite and builds types)'))
+  if (nameNeedsOverride) {
+    console.log(chalk.yellow(`5. "${code}" isn't in CLDR: add it to LANGUAGE_NAME_OVERRIDES in`))
+    console.log(chalk.yellow(`   test/helpers/language-naming.js ('${code}': '${languageName}')`))
+    console.log(chalk.yellow('   so LANGUAGES.md shows the name instead of the code'))
+  }
 }
 
 main().catch((err) => {

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -21,11 +21,6 @@ import { getLanguageName } from '../test/helpers/language-naming.js'
 // Language Discovery
 // ============================================================================
 
-// Manual overrides for languages not in CLDR
-const LANGUAGE_NAME_OVERRIDES = {
-  'hbo-IL': 'Biblical Hebrew (Israel)',
-}
-
 /**
  * Get all language codes from src/ directory.
  *
@@ -42,15 +37,13 @@ function getLanguageCodes() {
 }
 
 /**
- * Get display name for a language code.
+ * Get display name for a language code (non-CLDR overrides live in
+ * test/helpers/language-naming.js, the single source for naming).
  *
  * @param {string} code Language code
  * @returns {string} Human-readable language name
  */
 function getDisplayName(code) {
-  if (LANGUAGE_NAME_OVERRIDES[code]) {
-    return LANGUAGE_NAME_OVERRIDES[code]
-  }
   return getLanguageName(code) || code
 }
 

--- a/test/helpers/language-naming.js
+++ b/test/helpers/language-naming.js
@@ -69,16 +69,29 @@ export function normalizeCode(code) {
 // ============================================================================
 
 /**
- * Gets the human-readable language name from CLDR via Intl.DisplayNames.
+ * Display names for valid BCP 47 codes that CLDR doesn't know. The single
+ * source for these — the LANGUAGES.md generator and lang:add both resolve
+ * names through getLanguageName, so an entry here covers every consumer.
+ */
+export const LANGUAGE_NAME_OVERRIDES = {
+  'hbo-IL': 'Biblical Hebrew (Israel)',
+}
+
+/**
+ * Gets the human-readable language name — from the overrides for codes CLDR
+ * doesn't know, otherwise from CLDR via Intl.DisplayNames.
  *
  * @param {string} code BCP 47 language code
- * @returns {string|null} Language name in English, or null if not in CLDR
+ * @returns {string|null} Language name in English, or null if unknown
  * @example
  * getLanguageName('en-US')       // 'American English'
  * getLanguageName('zh-Hans-CN')  // 'Simplified Chinese (China)'
- * getLanguageName('hbo')      // null (not in CLDR)
+ * getLanguageName('hbo-IL')      // 'Biblical Hebrew (Israel)' (override; not in CLDR)
  */
 export function getLanguageName(code) {
+  if (LANGUAGE_NAME_OVERRIDES[code]) {
+    return LANGUAGE_NAME_OVERRIDES[code]
+  }
   try {
     const displayNames = new Intl.DisplayNames(['en'], { type: 'language' })
     const name = displayNames.of(code)

--- a/test/helpers/language-naming.js
+++ b/test/helpers/language-naming.js
@@ -102,19 +102,3 @@ export function getLanguageName(code) {
     return null
   }
 }
-
-/**
- * Checks if a language code is known in CLDR.
- * Uses Intl.DisplayNames which is backed by CLDR data.
- *
- * Note: Valid BCP 47 codes may not be in CLDR (e.g., 'hbo' for Ancient Hebrew).
- *
- * @param {string} code BCP 47 language code
- * @returns {boolean} True if the code has a CLDR entry
- * @example
- * isInCLDR('en')   // true
- * isInCLDR('hbo')  // false (valid BCP 47 but not in CLDR)
- */
-export function isInCLDR(code) {
-  return getLanguageName(code) !== null
-}


### PR DESCRIPTION
Audit of `scripts/add-language.js` (707 lines) with the contracts now complete. Verdict: **no structural rewrite warranted** — the script is coherent and its output is contract-gated — but three real defects, one of them data-loss.

## 1. The glaring one: silent clobber of WIP (reproduced, then fixed)

"New language" was decided by `getExportedForms(code).size === 0` — but `getExportedForms` swallows import errors into an empty set. So a contributor mid-implementation with a **syntax error** who re-runs `lang:add` got their language file **and** fixture silently overwritten. Reproduced with a WIP file before fixing.

Now: *new language* means **the file doesn't exist**. An existing file that exports nothing is **refused** (`exists but exports no working forms — likely a syntax error or unfinished file. Refusing to overwrite it.`), and an orphaned fixture is refused rather than overwritten. Both refusal paths verified against the original repro — WIP survives intact.

## 2. Duplicate TODO guidance

Adding a form to an existing language re-emitted the full "set each form's ceiling" comment block every invocation (two scaffold runs = two copies). The guidance now lands once; subsequent additions emit only the `*Max` export lines. Verified: two-step scaffold → exactly one block.

## 3. Non-CLDR names dead-ended

The prompted display name went only into file comments — LANGUAGES.md silently rendered the raw code because the generator's private `LANGUAGE_NAME_OVERRIDES` never learned it. The map is hoisted into `test/helpers/language-naming.js` as the single source for naming (generator + scaffolder both resolve through `getLanguageName`); the prompt now fires only when the name is truly unknown (an override-listed code like `hbo-IL` no longer re-prompts); and the next-steps output tells the contributor exactly where to add the override. LANGUAGES.md regen is **byte-identical**.

## Verification

All three teeth proven against live repros (clobber refused both directions, single TODO block, byte-stable regen with `Biblical Hebrew` rendering) · lint clean · 453 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)