### PR TITLE
fix(ro-RO): insert "de" before the currency unit for 20+

### DIFF
--- a/src/ro-RO.js
+++ b/src/ro-RO.js
@@ -452,10 +452,11 @@ function toCurrency(value) {
     }
     else {
       const leuWord = integerToWords(dollars, 'masculine')
-      // Romanian inserts "de" before the noun when the count's last two digits
-      // are 00 or 20-99 (the CLDR `other` category): "douăzeci de lei", "o sută
-      // de lei", but "o sută unu lei". Mirrors the bani path below and the
-      // scale-word handling in buildScalePhrase.
+      // Romanian inserts "de" before the noun for the CLDR `other` category:
+      // count >= 20 whose last two digits are 00 or 20-99 — "douăzeci de lei",
+      // "o sută de lei", but "o sută unu lei" (101) and no "de" below 20. The
+      // bani path below applies the same rule; buildScalePhrase uses a related
+      // per-segment predicate for scale words.
       const m = dollars % 100n
       const needsDe = dollars >= 20n && (m === 0n || m >= 20n)
       parts.push(leuWord + (needsDe ? ' de ' : ' ') + LEU_PLURAL)

--- a/src/ro-RO.js
+++ b/src/ro-RO.js
@@ -452,7 +452,13 @@ function toCurrency(value) {
     }
     else {
       const leuWord = integerToWords(dollars, 'masculine')
-      parts.push(leuWord + ' ' + LEU_PLURAL)
+      // Romanian inserts "de" before the noun when the count's last two digits
+      // are 00 or 20-99 (the CLDR `other` category): "douăzeci de lei", "o sută
+      // de lei", but "o sută unu lei". Mirrors the bani path below and the
+      // scale-word handling in buildScalePhrase.
+      const m = dollars % 100n
+      const needsDe = dollars >= 20n && (m === 0n || m >= 20n)
+      parts.push(leuWord + (needsDe ? ' de ' : ' ') + LEU_PLURAL)
     }
   }
 

--- a/test/fixtures/ro-RO.js
+++ b/test/fixtures/ro-RO.js
@@ -212,6 +212,8 @@ export const currency = [
   [2, 'doi lei'],
   [5, 'cinci lei'],
   [10, 'zece lei'],
+  [19, 'nouăsprezece lei'],
+  [20, 'douăzeci de lei'],
   [21, 'douăzeci și unu de lei'],
   [42, 'patruzeci și doi de lei'],
   [100, 'o sută de lei'],

--- a/test/fixtures/ro-RO.js
+++ b/test/fixtures/ro-RO.js
@@ -212,10 +212,10 @@ export const currency = [
   [2, 'doi lei'],
   [5, 'cinci lei'],
   [10, 'zece lei'],
-  [21, 'douăzeci și unu lei'],
-  [42, 'patruzeci și doi lei'],
-  [100, 'o sută lei'],
-  [1000, 'o mie lei'],
+  [21, 'douăzeci și unu de lei'],
+  [42, 'patruzeci și doi de lei'],
+  [100, 'o sută de lei'],
+  [1000, 'o mie de lei'],
 
   // Bani only
   [0.01, 'un ban'],
@@ -229,12 +229,12 @@ export const currency = [
   [1.01, 'un leu un ban'],
   [1.50, 'un leu cincizeci de bani'],
   [2.02, 'doi lei doi bani'],
-  [42.50, 'patruzeci și doi lei cincizeci de bani'],
-  [100.99, 'o sută lei nouăzeci și nouă de bani'],
+  [42.50, 'patruzeci și doi de lei cincizeci de bani'],
+  [100.99, 'o sută de lei nouăzeci și nouă de bani'],
 
   // Negative amounts
   [-1, 'minus un leu'],
-  [-42.50, 'minus patruzeci și doi lei cincizeci de bani'],
+  [-42.50, 'minus patruzeci și doi de lei cincizeci de bani'],
 
   // Edge cases
   ['5.00', 'cinci lei'],


### PR DESCRIPTION
Romanian requires the particle **"de"** before a counted noun when the number's last two digits are 00 or 20–99. `toCurrency` got this right for the **bani** (cents) but never applied it to the **lei**, so it produced grammatically wrong output:

| input | before | after |
|---|---|---|
| 20 | `douăzeci lei` | `douăzeci **de** lei` |
| 21 | `douăzeci și unu lei` | `douăzeci și unu **de** lei` |
| 100 | `o sută lei` | `o sută **de** lei` |
| 1000 | `o mie lei` | `o mie **de** lei` |
| 101 | `o sută unu lei` | `o sută unu lei` *(unchanged — last two digits 01, no "de")* |

The fix mirrors the rule the codebase already applies in the bani path and in `buildScalePhrase` for scale words: `needsDe = n >= 20 && (n % 100 === 0 || n % 100 >= 20)`.

**The fixtures had encoded the de-less output** — which is why the suite was green on the bug. Seven `lei` cases (21, 42, 100, 1000, and the lei+bani combinations) are corrected to the proper forms; the `<20` cases and the already-correct bani cases are untouched.

## How it was found

Auditing each count-agreement language's `number → form` selection against `Intl.PluralRules` (using CLDR purely as a *verification oracle*, not a runtime dependency). Romanian's CLDR `few → other` category boundary at 20 is exactly the "de" boundary, which flagged the gap. `cs-CZ` turned up a second divergence from the same audit — handled separately, pending a CLDR-vs-colloquial call.

Lint clean, 453 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)