### PR TITLE
fix(hr-HR): feminine number words before -arda scale words

### DIFF
--- a/src/hr-HR.js
+++ b/src/hr-HR.js
@@ -5,7 +5,8 @@
  *
  * Key features:
  * - Three-form pluralization (one/few/many)
- * - Gender: thousands are feminine, millions+ are masculine
+ * - Gender by scale word: tisuća and the -arda forms (milijarda, bilijarda, ...)
+ *   are feminine; the -un forms (milijun, bilijun, ...) are masculine
  * - Irregular hundreds (dvjesto, tristo, etc.)
  * - Long scale naming with -ard forms
  */
@@ -63,7 +64,8 @@ const EURO_FORMS = ['euro', 'eura', 'eura']
 const CENT_FORMS = ['cent', 'centa', 'centi']
 
 // Scale words: [singular, few, many]
-// Thousands (index 0) are feminine, rest are masculine
+// Indexed [scaleIndex - 1]; odd scales (tisuća, milijarda, bilijarda, ...) are
+// feminine, the -un forms (milijun, bilijun, ...) masculine
 const SCALE_FORMS = [
   ['tisuća', 'tisuće', 'tisuća'],
   ['milijun', 'milijuna', 'milijuna'],
@@ -221,8 +223,8 @@ function buildLargeNumberWords(n, gender) {
       else {
         const scaleForms = SCALE_FORMS[scaleIndex - 1]
         const scaleWord = pluralize(segment, scaleForms)
-        // Thousands (scaleIndex=1) are feminine, others masculine
-        const isFeminine = scaleIndex === 1
+        // tisuća and the -arda forms (milijarda, bilijarda, ...) are feminine; -un words masculine
+        const isFeminine = scaleIndex % 2 === 1
         const segmentWord = isFeminine ? buildSegmentFem(segment) : buildSegmentMasc(segment)
         parts.push(segmentWord + ' ' + scaleWord)
       }
@@ -429,7 +431,7 @@ function buildLargeOrdinal(n) {
             parts.push(ORDINAL_SCALES[scaleIndex - 1])
           }
           else {
-            const isFeminine = scaleIndex === 1
+            const isFeminine = scaleIndex % 2 === 1 // feminine at odd scales (tisuća, milijarda, ...)
             const segmentWord = isFeminine ? buildSegmentFem(segment) : buildSegmentMasc(segment)
             parts.push(segmentWord + ' ' + ORDINAL_SCALES[scaleIndex - 1])
           }
@@ -437,7 +439,7 @@ function buildLargeOrdinal(n) {
         else {
           const scaleForms = SCALE_FORMS[scaleIndex - 1]
           const scaleWord = pluralize(segment, scaleForms)
-          const isFeminine = scaleIndex === 1
+          const isFeminine = scaleIndex % 2 === 1
           const segmentWord = isFeminine ? buildSegmentFem(segment) : buildSegmentMasc(segment)
           parts.push(segmentWord + ' ' + scaleWord)
         }

--- a/test/fixtures/hr-HR.js
+++ b/test/fixtures/hr-HR.js
@@ -69,8 +69,12 @@ export const cardinal = [
   [1_000_000, 'jedan milijun'],
   [1_000_001, 'jedan milijun jedan'],
   [4_000_000, 'četiri milijuna'],
+  [1_000_000_000, 'jedna milijarda'],
+  [2_000_000_000, 'dvije milijarde'],
+  [5_000_000_000, 'pet milijarda'],
   [10_000_000_000_000, 'deset bilijuna'],
   [100_000_000_000_000, 'sto bilijuna'],
+  [1_000_000_000_000_000n, 'jedna bilijarda'],
   [1_000_000_000_000_000_000n, 'jedan trilijun'],
 
   // Feminine gender tests
@@ -130,6 +134,10 @@ export const ordinal = [
   // Millions
   [1000000, 'milijunti'],
   [2000000, 'dva milijunti'],
+
+  // Billions (milijarda is feminine, like tisuća)
+  [1_000_000_000, 'milijarditi'],
+  [2_000_000_000, 'dvije milijarditi'],
 ]
 
 /**


### PR DESCRIPTION
In Croatian the scale nouns alternate gender: tisuća (10^3), milijarda (10^9), bilijarda (10^15) and the higher `-arda` words are feminine, while milijun (10^6), bilijun (10^12) and the `-un` words are masculine. The count in front of a feminine scale word has to agree, so one billion is "jedna milijarda" and two billion is "dvije milijarde".

`hr-HR` only treated thousands as feminine (`isFeminine = scaleIndex === 1`), so every `-arda` scale above thousands printed the masculine count:

- `1_000_000_000` gave `"jedan milijarda"` (should be `"jedna milijarda"`)
- `2_000_000_000` gave `"dva milijarde"` (should be `"dvije milijarde"`)
- `1e15` gave `"jedan bilijarda"` (should be `"jedna bilijarda"`)

milijun and the other `-un` scales were already correct and stay unchanged (`1_000_000` -> `"jedan milijun"`).

## Fix

Change the gender test to `scaleIndex % 2 === 1`, which is feminine at every `-arda` scale and masculine at the `-un` scales, in both the cardinal and ordinal builders. This is the same change #413 made for `sr-Cyrl-RS` and `sr-Latn-RS`; Croatian shares the Serbo-Croatian milijarda-is-feminine grammar, and the file's existing feminine machinery (`ONES_FEM` / `buildSegmentFem`, already used for tisuća) handles it.

Added cardinal cases (milijarda, bilijarda) and ordinal cases (milijarditi) to `test/fixtures/hr-HR.js`. `npm test` and `npm run lint` pass; reverting only the source change makes the new cardinal case fail with `"jedan milijarda"` vs `"jedna milijarda"`.
