### PR TITLE
build(esm): emit one bundle per form so a CDN page pays for what it uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,32 @@ import { toCardinal as fr } from 'n2words/fr-FR'       // Aliased import
 </script>
 ```
 
+`dist/{code}.js` carries all three forms. A page that needs only one can fetch
+just that form from `dist/{code}/{form}.js` — `cardinal`, `ordinal` or
+`currency`:
+
+```html
+<script type="module">
+  import { toCurrency } from 'https://cdn.jsdelivr.net/npm/n2words/dist/en-US/currency.js'
+  console.log(toCurrency(42.50))  // 'forty-two dollars and fifty cents'
+</script>
+```
+
+Roughly half the bytes, since the other two forms and everything only they
+reach are never in the file:
+
+|`en-US`|bytes|
+|-------|-----|
+|`dist/en-US.js` (all three forms)|7,778|
+|`dist/en-US/cardinal.js`|4,293|
+|`dist/en-US/ordinal.js`|3,815|
+|`dist/en-US/currency.js`|3,827|
+
+This is for CDN consumers only. If you install from npm and use a bundler,
+`import { toCurrency } from 'n2words/en-US'` already drops the forms you don't
+import — the package is `sideEffects`-free and each form is an independent
+export, so there is nothing to opt into.
+
 See [LANGUAGES.md](LANGUAGES.md) for all language codes and available forms.
 
 ## Supported Languages

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,7 +1,7 @@
 import terser from '@rollup/plugin-terser'
 import virtual from '@rollup/plugin-virtual'
 import { readFileSync } from 'node:fs'
-import { getExportedForms, getLanguageCodes } from './test/helpers/language-helpers.js'
+import { FORM_EXPORTS, getExportedForms, getLanguageCodes } from './test/helpers/language-helpers.js'
 import { normalizeCode } from './test/helpers/language-naming.js'
 
 // Read package.json for version
@@ -23,8 +23,21 @@ const languageCodes = getLanguageCodes()
  *
  * Generates:
  * - Individual ESM bundles (dist/{langCode}.js): One per language, for browsers
+ * - Per-form ESM bundles (dist/{langCode}/{form}.js): One per language *and*
+ *   form, for a page that needs only one of the three
  * - Individual UMD bundles (dist/{langCode}.umd.js): One per language, for
  *   browser <script> tags
+ *
+ * Why per-form bundles exist, and only for ESM: a dist bundle is a prebuilt
+ * file fetched from a CDN, so whatever it contains is what the page downloads
+ * — there is no bundler on the other end to prune the forms it didn't ask
+ * for. dist/en.js carries all three, which is most of its weight for a page
+ * that only spells prices. npm consumers never needed this: src/{lang}.js
+ * exports the three forms independently and the package is sideEffects-free,
+ * so `import { toCurrency } from 'n2words/en'` already tree-shakes cardinals
+ * and ordinals away. UMD gets no per-form split — it is the legacy path, its
+ * globals are already namespaced by form (n2words.currency.en), and doubling
+ * the file count for it buys the least.
  *
  * Node.js users import directly from src/ (ESM source). No CJS bundle is generated -
  * Node.js 22.12+ can require() ESM modules directly.
@@ -72,6 +85,37 @@ const languageEsmConfigs = languageCodes.map(langCode => ({
 }))
 
 /**
+ * Build the ESM config for one (language, form) pair.
+ *
+ * A virtual entry re-exports the single form, so Rollup's dead-code
+ * elimination drops the other two and everything only they reach — the
+ * currency vocabulary for a cardinal bundle, the scale tables for a currency
+ * one. Same terser settings as the combined bundle, so the sizes are
+ * directly comparable.
+ * @param {string} langCode - The language code (e.g. 'en-US')
+ * @param {string} form - A key of FORM_EXPORTS ('cardinal' | 'ordinal' | 'currency')
+ * @returns {import('rollup').RollupOptions} Config for that one form's bundle
+ */
+function formEsmConfig(langCode, form) {
+  const virtualEntryId = `\0virtual:form:${langCode}:${form}`
+
+  return {
+    input: virtualEntryId,
+    output: {
+      file: `dist/${langCode}/${form}.js`,
+      format: 'es',
+      banner: `/*! n2words/${langCode} ${form} v${pkg.version} | MIT License | github.com/forzagreen/n2words */`,
+    },
+    plugins: [
+      virtual({
+        [virtualEntryId]: `export { ${FORM_EXPORTS[form]} } from './src/${langCode}.js';\n`,
+      }),
+      individualTerserConfig,
+    ],
+  }
+}
+
+/**
  * Build the UMD config for one language. `forms` is the Set of forms the
  * language actually exports (read from the module, not scanned from text).
  */
@@ -117,12 +161,21 @@ function umdConfig(langCode, forms) {
 // Async config: resolve each language's exported forms (an import() per
 // module), then build the UMD entries from real exports.
 export default async () => {
-  const languageUmdConfigs = await Promise.all(
-    languageCodes.map(async langCode => umdConfig(langCode, await getExportedForms(langCode))),
+  const formsByCode = await Promise.all(
+    languageCodes.map(async langCode => /** @type {const} */ ([langCode, await getExportedForms(langCode)])),
+  )
+
+  const languageUmdConfigs = formsByCode.map(([langCode, forms]) => umdConfig(langCode, forms))
+
+  // Only for forms the language actually exports — a language without
+  // toOrdinal gets no dist/{lang}/ordinal.js rather than an empty bundle.
+  const formEsmConfigs = formsByCode.flatMap(
+    ([langCode, forms]) => [...forms].map(form => formEsmConfig(langCode, form)),
   )
 
   return [
     ...languageEsmConfigs,
+    ...formEsmConfigs,
     ...languageUmdConfigs,
   ]
 }

--- a/test/helpers/language-helpers.js
+++ b/test/helpers/language-helpers.js
@@ -30,7 +30,9 @@ export function getLanguageCodes() {
 }
 
 // Form key -> the export a language provides when it supports that form.
-const FORM_EXPORTS = {
+// Exported because rollup.config.js builds one bundle per form and needs the
+// same mapping; a second copy there could drift from this one.
+export const FORM_EXPORTS = {
   cardinal: 'toCardinal',
   ordinal: 'toOrdinal',
   currency: 'toCurrency',


### PR DESCRIPTION
Follows up @TylerVigario's `proto/form-split` numbers on #428. This takes the per-form half of that idea — the larger half by bytes — as a standalone change against `main`, independent of the currency-matrix discussion.

3 files, +85/−4.

## The problem

A dist bundle is a prebuilt file fetched from a CDN, so whatever it contains is what the page downloads — there's no bundler on the other end to prune the forms it didn't ask for. `dist/en-US.js` carries all three, which is most of its weight for a page that only spells prices.

## The change

Adds `dist/{langCode}/{form}.js` alongside the existing combined bundle, built from a virtual entry that re-exports the single form so Rollup drops the other two and everything only they reach — the currency vocabulary for a cardinal bundle, the scale tables for a currency one.

```html
<script type="module">
  import { toCurrency } from 'https://cdn.jsdelivr.net/npm/n2words/dist/en-US/currency.js'
  toCurrency(42.50)  // 'forty-two dollars and fifty cents'
</script>
```

Measured from an actual `npm run build`:

|`en-US`|bytes| |
|---|---|---|
|`dist/en-US.js` (all three)|7,778| |
|`dist/en-US/cardinal.js`|4,293|−45%|
|`dist/en-US/ordinal.js`|3,815|−51%|
|`dist/en-US/currency.js`|3,827|−51%|

Holds across languages — `ja-JP` 5,100 → 2,706/2,766/2,799, `fr-FR` 7,602 → 4,400/4,583/4,733.

## Scope decisions

- **ESM only.** UMD is the legacy path, its globals are already namespaced by form (`n2words.currency.enUS`), and splitting it would double the file count for the consumers least likely to be counting bytes.
- **Only forms a language exports**, read from real module exports via `getExportedForms` — a language without `toOrdinal` gets no `ordinal.js` rather than an empty bundle.
- **216 new files** for the current 72 languages. That's tarball weight for a benefit only CDN consumers get; ESM-only keeps it to half of what a full split would cost.
- `FORM_EXPORTS` moves from module-private to exported in `language-helpers.js` so `rollup.config.js` uses the same form → export-name mapping rather than a second copy that could drift.

## npm consumers are unaffected and need nothing

`src/{lang}.js` already exports the three forms independently and the package is `sideEffects`-free, so `import { toCurrency } from 'n2words/en-US'` has always tree-shaken cardinals and ordinals away. This only closes the gap for the one consumer that couldn't.

No `exports` map changes — these are fetched by URL, not resolved as bare specifiers.

## Verification

- `npm test` — 453 tests pass
- `npm run lint` — clean
- `npm run build` — clean; 216 per-form bundles emitted, spot-checked that `dist/en-US/currency.js` runs and `dist/en-US/cardinal.js` contains no currency vocabulary