### PR TITLE
feat(core): add bare-tag language entry points

### DIFF
--- a/LANGUAGES.md
+++ b/LANGUAGES.md
@@ -2,11 +2,106 @@
 
 > **Auto-generated** — Do not edit manually. Run `npm run docs:languages` to update.
 
-n2words supports **72 languages** with cardinal number conversion, 72 with ordinal support, 72 with currency support.
+n2words supports **50 languages** (72 regional/script variants total) with
+cardinal number conversion, 72 variants with ordinal support, 72 variants
+with currency support.
+
+46 languages have a **bare-tag entry point** that resolves without a region
+subtag (e.g. `n2words/de`) — this is the primary, recommended way to import
+them. The other 4 require picking a specific variant explicitly, because
+their variants genuinely diverge in script or core numbering grammar, not
+just vocabulary — see [docs/bare-tag-aliases.md](docs/bare-tag-aliases.md).
 
 Language codes follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) standards.
 
-## All Languages
+## Languages
+
+|Entry point|Language|Variants|
+|-----------|--------|--------|
+|—|Amharic|`am-ET`, `am-Latn-ET`|
+|[`ar`](#arabic-saudi-arabia-ar-sa)|Arabic|[`ar-SA`](#arabic-saudi-arabia-ar-sa) (default)|
+|`az`|Azerbaijani|`az-AZ` (default)|
+|`bn`|Bangla|`bn-BD` (default)|
+|[`hbo`](#biblical-hebrew-israel-hbo-il)|Biblical Hebrew|[`hbo-IL`](#biblical-hebrew-israel-hbo-il) (default)|
+|—|Chinese|[`zh-Hans-CN`](#chinese-simplified-china-zh-hans-cn), [`zh-Hant-TW`](#chinese-traditional-taiwan-zh-hant-tw)|
+|[`hr`](#croatian-croatia-hr-hr)|Croatian|[`hr-HR`](#croatian-croatia-hr-hr) (default)|
+|`cs`|Czech|`cs-CZ` (default)|
+|`da`|Danish|`da-DK` (default)|
+|[`nl`](#dutch-netherlands-nl-nl)|Dutch|[`nl-NL`](#dutch-netherlands-nl-nl) (default)|
+|[`en`](#american-english-en-us)|English|[`en-AU`](#australian-english-en-au), [`en-BD`](#english-bangladesh-en-bd), [`en-CA`](#canadian-english-en-ca), [`en-GB`](#british-english-en-gb), [`en-GH`](#english-ghana-en-gh), [`en-IE`](#english-ireland-en-ie), [`en-IN`](#english-india-en-in), [`en-KE`](#english-kenya-en-ke), [`en-MY`](#english-malaysia-en-my), [`en-NG`](#english-nigeria-en-ng), [`en-NZ`](#english-new-zealand-en-nz), [`en-PH`](#english-philippines-en-ph), [`en-PK`](#english-pakistan-en-pk), [`en-SG`](#english-singapore-en-sg), [`en-US`](#american-english-en-us) (default), [`en-ZA`](#english-south-africa-en-za)|
+|`fil`|Filipino|`fil-PH` (default)|
+|`fi`|Finnish|`fi-FI` (default)|
+|[`fr`](#french-france-fr-fr)|French|[`fr-BE`](#french-belgium-fr-be), [`fr-FR`](#french-france-fr-fr) (default)|
+|`ka`|Georgian|`ka-GE` (default)|
+|[`de`](#german-germany-de-de)|German|[`de-DE`](#german-germany-de-de) (default)|
+|`el`|Greek|`el-GR` (default)|
+|`gu`|Gujarati|`gu-IN` (default)|
+|`ha`|Hausa|`ha-NG` (default)|
+|[`he`](#hebrew-israel-he-il)|Hebrew|[`he-IL`](#hebrew-israel-he-il) (default)|
+|`hi`|Hindi|`hi-IN` (default)|
+|`hu`|Hungarian|`hu-HU` (default)|
+|`id`|Indonesian|`id-ID` (default)|
+|[`it`](#italian-italy-it-it)|Italian|[`it-IT`](#italian-italy-it-it) (default)|
+|`ja`|Japanese|`ja-JP` (default)|
+|`kn`|Kannada|`kn-IN` (default)|
+|`ko`|Korean|`ko-KR` (default)|
+|[`lv`](#latvian-latvia-lv-lv)|Latvian|[`lv-LV`](#latvian-latvia-lv-lv) (default)|
+|[`lt`](#lithuanian-lithuania-lt-lt)|Lithuanian|[`lt-LT`](#lithuanian-lithuania-lt-lt) (default)|
+|`ms`|Malay|`ms-MY` (default)|
+|`mr`|Marathi|`mr-IN` (default)|
+|`nb`|Norwegian Bokmål|`nb-NO` (default)|
+|`fa`|Persian|`fa-IR` (default)|
+|[`pl`](#polish-poland-pl-pl)|Polish|[`pl-PL`](#polish-poland-pl-pl) (default)|
+|—|Portuguese|[`pt-BR`](#brazilian-portuguese-pt-br), [`pt-PT`](#european-portuguese-pt-pt)|
+|`pa`|Punjabi|`pa-IN` (default)|
+|[`ro`](#romanian-romania-ro-ro)|Romanian|[`ro-RO`](#romanian-romania-ro-ro) (default)|
+|[`ru`](#russian-russia-ru-ru)|Russian|[`ru-RU`](#russian-russia-ru-ru) (default)|
+|—|Serbian|[`sr-Cyrl-RS`](#serbian-cyrillic-serbia-sr-cyrl-rs), [`sr-Latn-RS`](#serbian-latin-serbia-sr-latn-rs)|
+|[`es`](#european-spanish-es-es)|Spanish|[`es-ES`](#european-spanish-es-es) (default), [`es-MX`](#mexican-spanish-es-mx), [`es-US`](#spanish-united-states-es-us)|
+|`sw`|Swahili|`sw-KE` (default)|
+|`sv`|Swedish|`sv-SE` (default)|
+|`ta`|Tamil|`ta-IN` (default)|
+|`te`|Telugu|`te-IN` (default)|
+|`th`|Thai|`th-TH` (default)|
+|[`tr`](#turkish-türkiye-tr-tr)|Turkish|[`tr-TR`](#turkish-türkiye-tr-tr) (default)|
+|[`uk`](#ukrainian-ukraine-uk-ua)|Ukrainian|[`uk-UA`](#ukrainian-ukraine-uk-ua) (default)|
+|`ur`|Urdu|`ur-PK` (default)|
+|`vi`|Vietnamese|`vi-VN` (default)|
+|`yo`|Yoruba|`yo-NG` (default)|
+
+`Entry point` is `—` for the 4 languages with no safe default variant.
+Where a family has more than one variant, `(default)` marks the one its
+entry point resolves to.
+
+## Usage
+
+```js
+// Most languages: import via their bare-tag entry point
+import { toCardinal } from 'n2words/de'
+import { toCardinal, toOrdinal, toCurrency } from 'n2words/de'
+
+toCardinal(42)     // 'zweiundvierzig'
+toOrdinal(42)      // 'zweiundvierzigste' (if supported)
+toCurrency(42.50)  // 'zweiundvierzig Euro und fünfzig Cent' (if supported)
+
+// Need a specific regional/script variant, or one of the 4 languages with
+// no single default? Import the full BCP 47 code instead
+import { toCardinal } from 'n2words/en-GB'
+```
+
+### Import Paths
+
+Bare-tag entry points (`n2words/de`, `n2words/en`, ...) resolve without a region
+subtag for every language with a linked `Entry point` above. Full BCP 47 codes
+always work too (`n2words/en-GB`, `n2words/fr-BE`, ...), and are required for
+the 4 languages with no entry point (`—` above) — e.g. `n2words/pt-BR`,
+`n2words/zh-Hans-CN`.
+
+## All Regional Variants
+
+Per-variant detail — the largest value each form converts, and per-variant
+options where declared. Grouped by language above; this is the flat
+reference.
 
 |Code|Language|Cardinal|Ordinal|Currency|
 |----|--------|:------:|:-----:|:------:|
@@ -87,25 +182,9 @@ Each form column shows the largest value it converts (`10^N - 1`), `∞` when un
 
 \* Has options — click to jump to that language's options.
 
-## Usage
-
-```js
-// Import language modules directly
-import { toCardinal } from 'n2words/en-US'
-import { toCardinal, toOrdinal, toCurrency } from 'n2words/en-US'
-
-toCardinal(42)     // 'forty-two'
-toOrdinal(42)      // 'forty-second' (if supported)
-toCurrency(42.50)  // 'forty-two dollars and fifty cents' (if supported)
-```
-
-### Import Paths
-
-Import paths use BCP 47 language codes: `n2words/en-US`, `n2words/zh-Hans-CN`, `n2words/fr-BE`
-
 ## Language Options
 
-41 languages support options via a second parameter. Options are passed as an object:
+41 variants support options via a second parameter. Options are passed as an object:
 
 ```js
 toCardinal(value, { optionName: value })

--- a/docs/bare-tag-aliases.md
+++ b/docs/bare-tag-aliases.md
@@ -1,0 +1,108 @@
+# Bare-tag alias contract
+
+n2words counts *languages*, not regional or script variants — English is one
+language with 16 regional variants, not 16 languages. A bare BCP 47 tag
+(`en`, `de`, `ja`, ...) is the primary way to import a language: it resolves
+without forcing a region subtag, defaulting to one specific, documented
+variant. A region-qualified code (`en-GB`, `fr-BE`) always still works, for
+when you need precision or the language has no single safe default.
+
+> Status: every language whose variants aren't "very different" (see below)
+> has a bare-tag alias, and the completeness half of that rule is enforced
+> in CI.
+
+## The fact: one alias file per single-variant family
+
+A family with exactly one regional/script variant today has **no room for
+ambiguity** — there's nothing to pick a default *among* — so its bare tag
+must exist:
+
+```js
+// src/de.js
+export * from './de-DE.js'
+export const aliasOf = 'de-DE'
+```
+
+Thin, `export *`-based, identical in shape to every other language file in
+`src/`. Nothing about it is language-specific; see
+[CLAUDE.md](../CLAUDE.md)'s Quick Reference for the current list.
+
+## The "very different" test
+
+A family with **two or more** variants gets a bare-tag alias only when one
+variant can serve as a safe, unsurprising default for the whole family. The
+test is deliberately narrow — it's about the *shape* of the output, not how
+much vocabulary differs:
+
+- **Different script.** `zh-Hans-CN` vs `zh-Hant-TW`, `sr-Cyrl-RS` vs
+  `sr-Latn-RS`, `am-ET` vs `am-Latn-ET` — diffing the actual source for each
+  pair shows identical grammar and identical words, just transliterated into
+  a different Unicode script. A bare tag would silently choose a script for
+  the caller. No alias.
+- **Different core numbering grammar.** `pt-BR` vs `pt-PT` — diffing the
+  source shows more than vocabulary drift: short scale (`bilhão` = 10⁹) vs
+  long scale (`bilião` = 10¹², `mil milhões` = 10⁹), different teen words
+  (`dezesseis` vs `dezasseis`), different "e"-insertion rules. This is a
+  different numbering system, not a dialect difference — the same category
+  as a script split, even though currency (BRL vs EUR) also differs. No
+  alias, and it would stay excluded even if the two used the same currency.
+
+Neither test is about currency, and neither is about how many words differ —
+`en-US` vs `en-GB` differ in plenty of words too. The question is narrowly
+"would defaulting silently produce a different *shape* of output than the
+caller expects" (a different script, a different scale system) — not "do
+these variants sound different."
+
+## Multi-variant families that do get an entry point
+
+`en` (→ `en-US`), `es` (→ `es-ES`), `fr` (→ `fr-FR`) all have multiple
+variants but pass the test above: same script, same core numbering grammar
+(short-scale Western grouping) across every variant in each family. Note
+that this holds even though some variants in these families diverge in
+other ways that don't matter for the test — `en-IN`/`en-BD`/`en-PK` use
+Indian lakh/crore grouping rather than Western grouping, and `es-MX`/`es-US`
+diverge from `es-ES` in default currency and cardinal ceiling. Neither
+threatens the alias, because a bare-tag alias is a **fixed pointer to one
+variant**, not a dispatcher that tries to speak for the whole family — `en`
+resolving to `en-US` makes no claim about what `en-IN` does.
+
+Picking the default itself is a one-time human judgment call (documented in
+each alias file's own comment) — most-used variant for `en`, conventional
+default for bare `es`/`fr` across BCP-47 tooling generally. This part isn't
+mechanically checkable and the gate doesn't try.
+
+## The gate: `test/bare-tag-contract.test.js`
+
+Two things, both mechanical:
+
+- **Completeness** — every BCP 47 primary subtag with exactly one variant in
+  `src/` must have a matching alias file. This is what keeps "must exist for
+  every non-diverging language" true over time instead of being a one-time
+  cleanup.
+- **Fidelity** — every alias's re-exported bindings (`toCardinal`,
+  `cardinalMax`, `currencyDefaults`, ...) are reference-identical (`===`) to
+  its target's, proving `export *` is forwarding live bindings rather than a
+  stale copy.
+
+Because fidelity is covered here, `contract.test.js`, `range-contract.test.js`,
+and `options-contract.test.js` skip alias files entirely (an `aliasOf`
+check) rather than re-running their fuzz suites against what's already
+proven to be the exact same function.
+
+The "very different" judgment itself is *not* in this gate — a family with
+two or more variants is simply not asserted either way. That call belongs to
+a human, same as which scale words a language uses isn't something a
+contract can derive on its own.
+
+## Adding a language
+
+Run `npm run lang:add -- <code>` as usual. If the new code is the **first**
+variant in its family, its bare-tag alias is scaffolded automatically —
+`lang:add` refuses a bare (no region/script subtag) code outright, since
+that namespace is reserved for these auto-generated files.
+
+If the new code joins an **existing** family, nothing is automated: the tool
+prints a note pointing here, and it's a human call whether the family is
+still close enough to share its existing default (usually yes — most
+additions are close, like `en`'s many variants) or different enough that the
+alias needs revisiting (rare — matches the test above).

--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -29,7 +29,7 @@
  */
 
 import { execSync } from 'node:child_process'
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs'
 import * as readline from 'node:readline/promises'
 import chalk from 'chalk'
 import { getExportedForms } from '../test/helpers/language-helpers.js'
@@ -408,6 +408,53 @@ export const currency = [
   return exports.join('\n\n') + '\n'
 }
 
+/**
+ * Existing canonical (non-alias) sibling variants sharing `code`'s BCP 47
+ * primary subtag — e.g. for a new `de-AT`, an existing `de-DE` is a sibling.
+ * Region/script variant codes always contain a hyphen after the primary
+ * subtag, and a bare-tag alias file's code never does, so a prefix filter
+ * cleanly finds siblings without needing to import anything.
+ *
+ * @param {string} primary BCP 47 primary language subtag (e.g. 'de')
+ * @param {string} excludeCode Code to exclude from the results (the one just added)
+ * @returns {string[]} Existing sibling variant codes
+ */
+function getSiblingVariants(primary, excludeCode) {
+  return readdirSync('./src')
+    .filter(f => f.endsWith('.js') && !f.startsWith('utils'))
+    .map(f => f.replace('.js', ''))
+    .filter(c => c !== excludeCode && c.startsWith(`${primary}-`))
+}
+
+/**
+ * Generate a bare-tag alias file — the same thin `export *` re-export shape
+ * as every other alias (src/en.js, src/de.js, ...). Only called when `code`
+ * is the first (and so far only) variant in its family; see
+ * docs/bare-tag-aliases.md for why a second variant doesn't get one
+ * automatically.
+ *
+ * @param {string} primary BCP 47 primary language subtag (e.g. 'de')
+ * @param {string} code The sole existing variant (e.g. 'de-DE')
+ * @param {string} name Family display name (e.g. 'German')
+ * @returns {string} File content
+ */
+function generateAliasFile(primary, code, name) {
+  return `/**
+ * ${name} (bare-tag alias)
+ *
+ * \`${primary}\` resolves to ${code}, currently the only ${name} variant this
+ * package implements. This file exists purely so \`n2words/${primary}\` works
+ * without requiring a region subtag; it is not a claim that ${code} speaks
+ * for every ${name}-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './${code}.js'
+
+export const aliasOf = '${code}'
+`
+}
+
 // ============================================================================
 // File Update Functions
 // ============================================================================
@@ -626,6 +673,19 @@ async function main() {
   const langFilePath = `./src/${code}.js`
   const fixtureFilePath = `./test/fixtures/${code}.js`
 
+  // Bare (no region/script subtag) codes are reserved for auto-generated
+  // bare-tag alias files (see docs/bare-tag-aliases.md) — a real
+  // implementation always carries a region or script subtag. Without this,
+  // a typo'd `lang:add -- de` would scaffold a full implementation at the
+  // exact path the alias-completeness gate (test/bare-tag-contract.test.js)
+  // expects to be a thin re-export.
+  if (!existsSync(langFilePath) && !code.includes('-')) {
+    console.error(chalk.red(`"${code}" has no region/script subtag — bare codes are reserved for bare-tag aliases.`))
+    console.log(chalk.gray(`Scaffold a region/script-qualified variant instead (e.g. "${code}-XX"); its bare-tag alias is created automatically when it's the first ${code}-* variant.`))
+    process.exitCode = 1
+    return
+  }
+
   // Check existing implementation (read from real exports, not source text).
   // "New language" means the FILE doesn't exist — never "the import returned no
   // forms": a work-in-progress file with a syntax error imports as zero forms,
@@ -710,6 +770,24 @@ async function main() {
     }
     writeFileSync(fixtureFilePath, generateTestFixture(code, languageName, formsToScaffold))
     console.log(chalk.green('✓ Created test fixture'))
+
+    // Bare-tag alias: auto-scaffold one when this is the first variant in
+    // its family (docs/bare-tag-aliases.md's completeness rule). A second+
+    // variant is a human judgment call, not automated — see that doc.
+    const primary = code.split('-')[0]
+    const siblings = getSiblingVariants(primary, code)
+    const aliasFilePath = `./src/${primary}.js`
+    if (siblings.length === 0 && !existsSync(aliasFilePath)) {
+      const familyName = getLanguageName(primary) ?? languageName
+      console.log(chalk.gray(`\nCreating ${aliasFilePath}...`))
+      writeFileSync(aliasFilePath, generateAliasFile(primary, code, familyName))
+      writeFileSync(`./test/fixtures/${primary}.js`, `export * from './${code}.js'\n`)
+      console.log(chalk.green(`✓ Created bare-tag alias: ${primary} -> ${code} (first ${primary}-* variant)`))
+    }
+    else if (siblings.length > 0) {
+      console.log(chalk.yellow(`\nNote: ${primary}-* already has ${siblings.length === 1 ? 'a variant' : 'variants'} (${siblings.join(', ')}).`))
+      console.log(chalk.yellow(`Decide by hand whether ${code} keeps the family "close enough" to share a bare-tag default — see docs/bare-tag-aliases.md.`))
+    }
   }
   else {
     // Add forms to existing files

--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -632,6 +632,20 @@ async function main() {
   // and treating that as new would silently overwrite the contributor's work.
   const existingForms = await getExportedForms(code)
   const isNewLanguage = !existsSync(langFilePath)
+
+  // A bare-tag alias (e.g. en.js re-exporting en-US.js, marked by its own
+  // `aliasOf` export) has real forms via `export *`, so it would otherwise
+  // pass every check below and get mutated by addFormsToExistingFile —
+  // corrupting a two-line re-export file. Refuse and point at the real target.
+  if (!isNewLanguage) {
+    const existingMod = await import(`../src/${code}.js`).catch(() => undefined)
+    if (existingMod?.aliasOf !== undefined) {
+      console.error(chalk.red(`${langFilePath} is a bare-tag alias for ${existingMod.aliasOf}.js — edit src/${existingMod.aliasOf}.js directly, or pick a different code.`))
+      process.exitCode = 1
+      return
+    }
+  }
+
   if (!isNewLanguage && existingForms.size === 0) {
     console.error(chalk.red(`${langFilePath} exists but exports no working forms — likely a syntax error or unfinished file.`))
     console.error(chalk.gray('Refusing to overwrite it. Fix (or delete) the file, then re-run.'))

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -24,7 +24,11 @@ import { getLanguageName } from '../test/helpers/language-naming.js'
 // ============================================================================
 
 /**
- * Get all language codes from src/ directory.
+ * Get all language codes from src/ directory — canonical languages and
+ * bare-tag aliases alike. Callers that need just one or the other partition
+ * this list themselves once each module is imported (see main()); a plain
+ * directory scan can't tell an alias from a canonical file without reading
+ * its `aliasOf` export.
  *
  * @returns {string[]} Sorted array of language codes
  */
@@ -312,14 +316,45 @@ function formatOptionsTable(options) {
 }
 
 /**
+ * Format the bare-tag alias table — one row per alias, linking to the
+ * target's options anchor when it has one (every current target does, but a
+ * future alias might point at a variant with no options, hence the fallback
+ * to plain code text rather than assuming an anchor always exists).
+ *
+ * @param {Map<string, string>} aliases Alias code -> target code
+ * @param {Map<string, string>} optionAnchors Target code -> anchor (only entries with options)
+ * @param {(code: string) => string} displayName Code -> human-readable name
+ * @returns {string} Markdown section
+ */
+function formatAliasSection(aliases, optionAnchors, displayName) {
+  const lines = [
+    '## Bare-tag aliases',
+    '',
+    'These import paths resolve without a region subtag, for convenience. Each is a',
+    'thin re-export of one specific regional variant — not a new language, and not',
+    'a guess: the target is fixed and documented here.',
+    '',
+    '|Alias|Resolves to|',
+    '|-----|-----------|',
+  ]
+  for (const [alias, target] of [...aliases].sort(([a], [b]) => a.localeCompare(b))) {
+    const anchor = optionAnchors.get(target)
+    const targetRef = anchor ? `[\`${target}\`](#${anchor})` : `\`${target}\``
+    lines.push(`|\`${alias}\`|${targetRef} (${displayName(target)})|`)
+  }
+  return lines.join('\n')
+}
+
+/**
  * Generate the LANGUAGES.md content.
  *
- * @param {string[]} codes Array of language codes
+ * @param {string[]} codes Array of canonical (non-alias) language codes
  * @param {Map<string, Set<string>>} forms Code -> set of exported forms
  * @param {Map<string, Record<string, bigint|null|undefined>>} mods Code -> module namespace (for the *Max range exports)
+ * @param {Map<string, string>} aliases Alias code -> target code
  * @returns {string} Markdown content
  */
-function generateMarkdown(codes, forms, mods) {
+function generateMarkdown(codes, forms, mods, aliases) {
   const hasOrdinal = code => forms.get(code).has('ordinal')
   const hasCurrency = code => forms.get(code).has('currency')
 
@@ -398,6 +433,8 @@ Each form column shows the largest value it converts (\`10^N - 1\`), \`∞\` whe
 
 \\* Has options — click to jump to that language's options.
 
+${formatAliasSection(aliases, optionAnchors, getDisplayName)}
+
 ## Usage
 
 \`\`\`js
@@ -432,18 +469,31 @@ ${optionSections.join('\n\n')}
 // ============================================================================
 
 async function main() {
-  const codes = getLanguageCodes()
+  const allCodes = getLanguageCodes()
+  const allMods = new Map(
+    await Promise.all(allCodes.map(async code => [code, await import(`../src/${code}.js`)])),
+  )
+
+  // Bare-tag alias files (aliasOf exported) are re-exports, not their own
+  // language: excluded from the main table/count/options so they can't
+  // inflate "n2words supports N languages", and surfaced instead as their
+  // own documented section (see formatAliasSection).
+  const codes = allCodes.filter(code => allMods.get(code).aliasOf === undefined)
+  const aliases = new Map(
+    allCodes
+      .filter(code => allMods.get(code).aliasOf !== undefined)
+      .map(code => [code, allMods.get(code).aliasOf]),
+  )
+  const mods = new Map(codes.map(code => [code, allMods.get(code)]))
+
   const forms = new Map(
     await Promise.all(codes.map(async code => [code, await getExportedForms(code)])),
   )
-  const mods = new Map(
-    await Promise.all(codes.map(async code => [code, await import(`../src/${code}.js`)])),
-  )
   optionsIndex = buildOptionsIndex(codes, mods)
-  const markdown = generateMarkdown(codes, forms, mods)
+  const markdown = generateMarkdown(codes, forms, mods, aliases)
 
   writeFileSync('./LANGUAGES.md', markdown)
-  console.log(`✓ Generated LANGUAGES.md (${codes.length} languages)`)
+  console.log(`✓ Generated LANGUAGES.md (${codes.length} languages, ${aliases.size} bare-tag aliases)`)
 }
 
 main()

--- a/scripts/generate-languages-md.js
+++ b/scripts/generate-languages-md.js
@@ -316,31 +316,62 @@ function formatOptionsTable(options) {
 }
 
 /**
- * Format the bare-tag alias table — one row per alias, linking to the
- * target's options anchor when it has one (every current target does, but a
- * future alias might point at a variant with no options, hence the fallback
- * to plain code text rather than assuming an anchor always exists).
+ * Group canonical (non-alias) codes by BCP 47 primary language subtag, e.g.
+ * en-US/en-CA/... all group under "en", zh-Hans-CN/zh-Hant-TW under "zh".
+ * This is what "language" means for the headline count and the family
+ * table below — a regional/script variant isn't counted as its own
+ * language (see docs/bare-tag-aliases.md).
  *
- * @param {Map<string, string>} aliases Alias code -> target code
- * @param {Map<string, string>} optionAnchors Target code -> anchor (only entries with options)
- * @param {(code: string) => string} displayName Code -> human-readable name
- * @returns {string} Markdown section
+ * @param {string[]} codes Canonical (non-alias) codes
+ * @returns {Map<string, string[]>} Primary subtag -> sorted variant codes
  */
-function formatAliasSection(aliases, optionAnchors, displayName) {
+function groupByFamily(codes) {
+  const families = new Map()
+  for (const code of codes) {
+    const primary = code.split('-')[0]
+    if (!families.has(primary)) families.set(primary, [])
+    families.get(primary).push(code)
+  }
+  for (const variants of families.values()) variants.sort((a, b) => a.localeCompare(b))
+  return families
+}
+
+/**
+ * Format the family-level summary table — one row per language family, the
+ * primary place a reader sees "how many languages" n2words supports. A
+ * family's `Entry point` is its bare-tag alias when one exists (see
+ * docs/bare-tag-aliases.md for why some families don't get one — script or
+ * core numbering grammar genuinely diverges between their variants);
+ * `Variants` links each actual regional/script code to its detail section
+ * further down. An alias code (e.g. `en`) is always the same string as its
+ * family's primary subtag by construction, so `aliases.get(primary)` finds
+ * a family's alias directly with no extra lookup table.
+ *
+ * @param {Map<string, string[]>} families Primary subtag -> variant codes
+ * @param {Map<string, string>} aliases Alias code -> target code
+ * @param {Map<string, string>} optionAnchors Code -> anchor (only entries with options)
+ * @param {(code: string) => string} displayName Code -> human-readable name
+ * @returns {string} Markdown table
+ */
+function formatFamilyTable(families, aliases, optionAnchors, displayName) {
   const lines = [
-    '## Bare-tag aliases',
-    '',
-    'These import paths resolve without a region subtag, for convenience. Each is a',
-    'thin re-export of one specific regional variant — not a new language, and not',
-    'a guess: the target is fixed and documented here.',
-    '',
-    '|Alias|Resolves to|',
-    '|-----|-----------|',
+    '|Entry point|Language|Variants|',
+    '|-----------|--------|--------|',
   ]
-  for (const [alias, target] of [...aliases].sort(([a], [b]) => a.localeCompare(b))) {
-    const anchor = optionAnchors.get(target)
-    const targetRef = anchor ? `[\`${target}\`](#${anchor})` : `\`${target}\``
-    lines.push(`|\`${alias}\`|${targetRef} (${displayName(target)})|`)
+  // `label` is the visible code text; `anchorCode` is whose anchor it links
+  // to — for the entry-point cell these differ (the bare alias's own code
+  // has no detail section of its own; it links to its target's).
+  const ref = (label, anchorCode = label) => {
+    const anchor = optionAnchors.get(anchorCode)
+    return anchor ? `[\`${label}\`](#${anchor})` : `\`${label}\``
+  }
+  const sortedPrimaries = [...families.keys()].sort((a, b) => displayName(a).localeCompare(displayName(b)))
+  for (const primary of sortedPrimaries) {
+    const variants = families.get(primary)
+    const entryTarget = aliases.get(primary)
+    const entryCell = entryTarget ? ref(primary, entryTarget) : '—'
+    const variantCells = variants.map(v => v === entryTarget ? `${ref(v)} (default)` : ref(v))
+    lines.push(`|${entryCell}|${displayName(primary)}|${variantCells.join(', ')}|`)
   }
   return lines.join('\n')
 }
@@ -358,7 +389,15 @@ function generateMarkdown(codes, forms, mods, aliases) {
   const hasOrdinal = code => forms.get(code).has('ordinal')
   const hasCurrency = code => forms.get(code).has('currency')
 
-  const languageCount = codes.length
+  // "Language" means BCP 47 primary subtag, not regional/script variant —
+  // en-US/en-CA/... are one language (English) with 16 variants, not 16
+  // languages. See docs/bare-tag-aliases.md.
+  const families = groupByFamily(codes)
+  const familyCount = families.size
+  const variantCount = codes.length
+  const bareTagFamilyCount = aliases.size
+  const noEntryPointFamilyCount = familyCount - bareTagFamilyCount
+
   const codesWithOrdinal = codes.filter(hasOrdinal)
   const ordinalCount = codesWithOrdinal.length
   const codesWithCurrency = codes.filter(hasCurrency)
@@ -419,11 +458,55 @@ function generateMarkdown(codes, forms, mods, aliases) {
 
 > **Auto-generated** — Do not edit manually. Run \`npm run docs:languages\` to update.
 
-n2words supports **${languageCount} languages** with cardinal number conversion, ${ordinalCount} with ordinal support, ${currencyCount} with currency support.
+n2words supports **${familyCount} languages** (${variantCount} regional/script variants total) with
+cardinal number conversion, ${ordinalCount} variants with ordinal support, ${currencyCount} variants
+with currency support.
+
+${bareTagFamilyCount} languages have a **bare-tag entry point** that resolves without a region
+subtag (e.g. \`n2words/de\`) — this is the primary, recommended way to import
+them. The other ${noEntryPointFamilyCount} require picking a specific variant explicitly, because
+their variants genuinely diverge in script or core numbering grammar, not
+just vocabulary — see [docs/bare-tag-aliases.md](docs/bare-tag-aliases.md).
 
 Language codes follow [IETF BCP 47](https://tools.ietf.org/html/bcp47) standards.
 
-## All Languages
+## Languages
+
+${formatFamilyTable(families, aliases, optionAnchors, getDisplayName)}
+
+\`Entry point\` is \`—\` for the ${noEntryPointFamilyCount} languages with no safe default variant.
+Where a family has more than one variant, \`(default)\` marks the one its
+entry point resolves to.
+
+## Usage
+
+\`\`\`js
+// Most languages: import via their bare-tag entry point
+import { toCardinal } from 'n2words/de'
+import { toCardinal, toOrdinal, toCurrency } from 'n2words/de'
+
+toCardinal(42)     // 'zweiundvierzig'
+toOrdinal(42)      // 'zweiundvierzigste' (if supported)
+toCurrency(42.50)  // 'zweiundvierzig Euro und fünfzig Cent' (if supported)
+
+// Need a specific regional/script variant, or one of the 4 languages with
+// no single default? Import the full BCP 47 code instead
+import { toCardinal } from 'n2words/en-GB'
+\`\`\`
+
+### Import Paths
+
+Bare-tag entry points (\`n2words/de\`, \`n2words/en\`, ...) resolve without a region
+subtag for every language with a linked \`Entry point\` above. Full BCP 47 codes
+always work too (\`n2words/en-GB\`, \`n2words/fr-BE\`, ...), and are required for
+the ${noEntryPointFamilyCount} languages with no entry point (\`—\` above) — e.g. \`n2words/pt-BR\`,
+\`n2words/zh-Hans-CN\`.
+
+## All Regional Variants
+
+Per-variant detail — the largest value each form converts, and per-variant
+options where declared. Grouped by language above; this is the flat
+reference.
 
 |Code|Language|Cardinal|Ordinal|Currency|
 |----|--------|:------:|:-----:|:------:|
@@ -433,27 +516,9 @@ Each form column shows the largest value it converts (\`10^N - 1\`), \`∞\` whe
 
 \\* Has options — click to jump to that language's options.
 
-${formatAliasSection(aliases, optionAnchors, getDisplayName)}
-
-## Usage
-
-\`\`\`js
-// Import language modules directly
-import { toCardinal } from 'n2words/en-US'
-import { toCardinal, toOrdinal, toCurrency } from 'n2words/en-US'
-
-toCardinal(42)     // 'forty-two'
-toOrdinal(42)      // 'forty-second' (if supported)
-toCurrency(42.50)  // 'forty-two dollars and fifty cents' (if supported)
-\`\`\`
-
-### Import Paths
-
-Import paths use BCP 47 language codes: \`n2words/en-US\`, \`n2words/zh-Hans-CN\`, \`n2words/fr-BE\`
-
 ## Language Options
 
-${optionsCount} languages support options via a second parameter. Options are passed as an object:
+${optionsCount} variants support options via a second parameter. Options are passed as an object:
 
 \`\`\`js
 toCardinal(value, { optionName: value })
@@ -475,9 +540,9 @@ async function main() {
   )
 
   // Bare-tag alias files (aliasOf exported) are re-exports, not their own
-  // language: excluded from the main table/count/options so they can't
-  // inflate "n2words supports N languages", and surfaced instead as their
-  // own documented section (see formatAliasSection).
+  // language: excluded from the variant table/count/options so they can't
+  // inflate "n2words supports N languages", and surfaced instead via the
+  // family table's Entry point column (see formatFamilyTable).
   const codes = allCodes.filter(code => allMods.get(code).aliasOf === undefined)
   const aliases = new Map(
     allCodes
@@ -493,7 +558,8 @@ async function main() {
   const markdown = generateMarkdown(codes, forms, mods, aliases)
 
   writeFileSync('./LANGUAGES.md', markdown)
-  console.log(`✓ Generated LANGUAGES.md (${codes.length} languages, ${aliases.size} bare-tag aliases)`)
+  const familyCount = new Set(codes.map(code => code.split('-')[0])).size
+  console.log(`✓ Generated LANGUAGES.md (${familyCount} languages, ${codes.length} variants, ${aliases.size} bare-tag entry points)`)
 }
 
 main()

--- a/src/ar.js
+++ b/src/ar.js
@@ -1,0 +1,12 @@
+/**
+ * Arabic (bare-tag alias)
+ *
+ * `ar` resolves to ar-SA, currently the only Arabic variant this package
+ * implements. This file exists purely so `n2words/ar` works without
+ * requiring a region subtag; it is not a claim that ar-SA speaks for every
+ * Arabic-speaking region. See LANGUAGES.md's "Bare-tag aliases" section.
+ */
+
+export * from './ar-SA.js'
+
+export const aliasOf = 'ar-SA'

--- a/src/az.js
+++ b/src/az.js
@@ -1,0 +1,13 @@
+/**
+ * Azerbaijani (bare-tag alias)
+ *
+ * `az` resolves to az-AZ, currently the only Azerbaijani variant this
+ * package implements. This file exists purely so `n2words/az` works
+ * without requiring a region subtag; it is not a claim that az-AZ speaks
+ * for every Azerbaijani-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './az-AZ.js'
+
+export const aliasOf = 'az-AZ'

--- a/src/bn.js
+++ b/src/bn.js
@@ -1,0 +1,13 @@
+/**
+ * Bangla (bare-tag alias)
+ *
+ * `bn` resolves to bn-BD, currently the only Bangla variant this
+ * package implements. This file exists purely so `n2words/bn` works
+ * without requiring a region subtag; it is not a claim that bn-BD speaks
+ * for every Bangla-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './bn-BD.js'
+
+export const aliasOf = 'bn-BD'

--- a/src/cs.js
+++ b/src/cs.js
@@ -1,0 +1,13 @@
+/**
+ * Czech (bare-tag alias)
+ *
+ * `cs` resolves to cs-CZ, currently the only Czech variant this
+ * package implements. This file exists purely so `n2words/cs` works
+ * without requiring a region subtag; it is not a claim that cs-CZ speaks
+ * for every Czech-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './cs-CZ.js'
+
+export const aliasOf = 'cs-CZ'

--- a/src/da.js
+++ b/src/da.js
@@ -1,0 +1,13 @@
+/**
+ * Danish (bare-tag alias)
+ *
+ * `da` resolves to da-DK, currently the only Danish variant this
+ * package implements. This file exists purely so `n2words/da` works
+ * without requiring a region subtag; it is not a claim that da-DK speaks
+ * for every Danish-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './da-DK.js'
+
+export const aliasOf = 'da-DK'

--- a/src/de.js
+++ b/src/de.js
@@ -1,0 +1,13 @@
+/**
+ * German (bare-tag alias)
+ *
+ * `de` resolves to de-DE, currently the only German variant this
+ * package implements. This file exists purely so `n2words/de` works
+ * without requiring a region subtag; it is not a claim that de-DE speaks
+ * for every German-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './de-DE.js'
+
+export const aliasOf = 'de-DE'

--- a/src/el.js
+++ b/src/el.js
@@ -1,0 +1,13 @@
+/**
+ * Greek (bare-tag alias)
+ *
+ * `el` resolves to el-GR, currently the only Greek variant this
+ * package implements. This file exists purely so `n2words/el` works
+ * without requiring a region subtag; it is not a claim that el-GR speaks
+ * for every Greek-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './el-GR.js'
+
+export const aliasOf = 'el-GR'

--- a/src/en.js
+++ b/src/en.js
@@ -1,0 +1,16 @@
+/**
+ * English (bare-tag alias)
+ *
+ * `en` has no single "correct" region — English is official in dozens of
+ * countries with genuinely different cardinal grammar (US vs. British
+ * "and") and different default currencies. This file exists so
+ * `n2words/en` resolves without forcing a region subtag, defaulting to
+ * en-US (the most widely used variant, and the one en-CA/en-AU already
+ * proved to be a near-duplicate of). It does NOT speak for en-GB, en-CA,
+ * en-IN, or any other regional variant — see LANGUAGES.md's "Bare-tag
+ * aliases" section for the full rationale.
+ */
+
+export * from './en-US.js'
+
+export const aliasOf = 'en-US'

--- a/src/es.js
+++ b/src/es.js
@@ -1,0 +1,17 @@
+/**
+ * Spanish (bare-tag alias)
+ *
+ * `es` has no single "correct" region, and unlike `fr`, the es-* variants
+ * genuinely diverge in both cardinal ceiling and default currency
+ * (es-ES/EUR, es-MX/MXN, es-US/USD) — closer to a pt-BR/pt-PT split than a
+ * fr-FR/fr-BE one. This file exists so `n2words/es` resolves without
+ * forcing a region subtag anyway, defaulting to es-ES (Spain's variant, the
+ * conventional default for bare `es` across most software/BCP-47 tooling).
+ * It does NOT speak for es-MX or es-US — a caller who cares about Mexican
+ * or US Spanish currency/grammar should import that variant explicitly.
+ * See LANGUAGES.md's "Bare-tag aliases" section for the full rationale.
+ */
+
+export * from './es-ES.js'
+
+export const aliasOf = 'es-ES'

--- a/src/fa.js
+++ b/src/fa.js
@@ -1,0 +1,13 @@
+/**
+ * Persian (bare-tag alias)
+ *
+ * `fa` resolves to fa-IR, currently the only Persian variant this
+ * package implements. This file exists purely so `n2words/fa` works
+ * without requiring a region subtag; it is not a claim that fa-IR speaks
+ * for every Persian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './fa-IR.js'
+
+export const aliasOf = 'fa-IR'

--- a/src/fi.js
+++ b/src/fi.js
@@ -1,0 +1,13 @@
+/**
+ * Finnish (bare-tag alias)
+ *
+ * `fi` resolves to fi-FI, currently the only Finnish variant this
+ * package implements. This file exists purely so `n2words/fi` works
+ * without requiring a region subtag; it is not a claim that fi-FI speaks
+ * for every Finnish-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './fi-FI.js'
+
+export const aliasOf = 'fi-FI'

--- a/src/fil.js
+++ b/src/fil.js
@@ -1,0 +1,13 @@
+/**
+ * Filipino (bare-tag alias)
+ *
+ * `fil` resolves to fil-PH, currently the only Filipino variant this
+ * package implements. This file exists purely so `n2words/fil` works
+ * without requiring a region subtag; it is not a claim that fil-PH speaks
+ * for every Filipino-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './fil-PH.js'
+
+export const aliasOf = 'fil-PH'

--- a/src/fr.js
+++ b/src/fr.js
@@ -1,0 +1,15 @@
+/**
+ * French (bare-tag alias)
+ *
+ * `fr` has no single "correct" region, but unlike English, fr-FR and fr-BE
+ * are currency-identical (both EUR euros/centimes) and diverge only in
+ * cardinal grammar (septante/nonante vs. soixante-dix/quatre-vingt-dix).
+ * This file exists so `n2words/fr` resolves without forcing a region
+ * subtag, defaulting to fr-FR (the most widely used variant). It does NOT
+ * speak for fr-BE or any other regional variant — see LANGUAGES.md's
+ * "Bare-tag aliases" section for the full rationale.
+ */
+
+export * from './fr-FR.js'
+
+export const aliasOf = 'fr-FR'

--- a/src/gu.js
+++ b/src/gu.js
@@ -1,0 +1,13 @@
+/**
+ * Gujarati (bare-tag alias)
+ *
+ * `gu` resolves to gu-IN, currently the only Gujarati variant this
+ * package implements. This file exists purely so `n2words/gu` works
+ * without requiring a region subtag; it is not a claim that gu-IN speaks
+ * for every Gujarati-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './gu-IN.js'
+
+export const aliasOf = 'gu-IN'

--- a/src/ha.js
+++ b/src/ha.js
@@ -1,0 +1,13 @@
+/**
+ * Hausa (bare-tag alias)
+ *
+ * `ha` resolves to ha-NG, currently the only Hausa variant this
+ * package implements. This file exists purely so `n2words/ha` works
+ * without requiring a region subtag; it is not a claim that ha-NG speaks
+ * for every Hausa-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ha-NG.js'
+
+export const aliasOf = 'ha-NG'

--- a/src/hbo.js
+++ b/src/hbo.js
@@ -1,0 +1,12 @@
+/**
+ * Biblical Hebrew (bare-tag alias)
+ *
+ * `hbo` resolves to hbo-IL, currently the only Biblical Hebrew variant this
+ * package implements. This file exists purely so `n2words/hbo` works
+ * without requiring a region subtag. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './hbo-IL.js'
+
+export const aliasOf = 'hbo-IL'

--- a/src/he.js
+++ b/src/he.js
@@ -1,0 +1,13 @@
+/**
+ * Hebrew (bare-tag alias)
+ *
+ * `he` resolves to he-IL, currently the only Hebrew variant this
+ * package implements. This file exists purely so `n2words/he` works
+ * without requiring a region subtag; it is not a claim that he-IL speaks
+ * for every Hebrew-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './he-IL.js'
+
+export const aliasOf = 'he-IL'

--- a/src/hi.js
+++ b/src/hi.js
@@ -1,0 +1,13 @@
+/**
+ * Hindi (bare-tag alias)
+ *
+ * `hi` resolves to hi-IN, currently the only Hindi variant this
+ * package implements. This file exists purely so `n2words/hi` works
+ * without requiring a region subtag; it is not a claim that hi-IN speaks
+ * for every Hindi-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './hi-IN.js'
+
+export const aliasOf = 'hi-IN'

--- a/src/hr.js
+++ b/src/hr.js
@@ -1,0 +1,13 @@
+/**
+ * Croatian (bare-tag alias)
+ *
+ * `hr` resolves to hr-HR, currently the only Croatian variant this
+ * package implements. This file exists purely so `n2words/hr` works
+ * without requiring a region subtag; it is not a claim that hr-HR speaks
+ * for every Croatian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './hr-HR.js'
+
+export const aliasOf = 'hr-HR'

--- a/src/hu.js
+++ b/src/hu.js
@@ -1,0 +1,13 @@
+/**
+ * Hungarian (bare-tag alias)
+ *
+ * `hu` resolves to hu-HU, currently the only Hungarian variant this
+ * package implements. This file exists purely so `n2words/hu` works
+ * without requiring a region subtag; it is not a claim that hu-HU speaks
+ * for every Hungarian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './hu-HU.js'
+
+export const aliasOf = 'hu-HU'

--- a/src/id.js
+++ b/src/id.js
@@ -1,0 +1,13 @@
+/**
+ * Indonesian (bare-tag alias)
+ *
+ * `id` resolves to id-ID, currently the only Indonesian variant this
+ * package implements. This file exists purely so `n2words/id` works
+ * without requiring a region subtag; it is not a claim that id-ID speaks
+ * for every Indonesian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './id-ID.js'
+
+export const aliasOf = 'id-ID'

--- a/src/it.js
+++ b/src/it.js
@@ -1,0 +1,13 @@
+/**
+ * Italian (bare-tag alias)
+ *
+ * `it` resolves to it-IT, currently the only Italian variant this
+ * package implements. This file exists purely so `n2words/it` works
+ * without requiring a region subtag; it is not a claim that it-IT speaks
+ * for every Italian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './it-IT.js'
+
+export const aliasOf = 'it-IT'

--- a/src/ja.js
+++ b/src/ja.js
@@ -1,0 +1,13 @@
+/**
+ * Japanese (bare-tag alias)
+ *
+ * `ja` resolves to ja-JP, currently the only Japanese variant this
+ * package implements. This file exists purely so `n2words/ja` works
+ * without requiring a region subtag; it is not a claim that ja-JP speaks
+ * for every Japanese-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ja-JP.js'
+
+export const aliasOf = 'ja-JP'

--- a/src/ka.js
+++ b/src/ka.js
@@ -1,0 +1,13 @@
+/**
+ * Georgian (bare-tag alias)
+ *
+ * `ka` resolves to ka-GE, currently the only Georgian variant this
+ * package implements. This file exists purely so `n2words/ka` works
+ * without requiring a region subtag; it is not a claim that ka-GE speaks
+ * for every Georgian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ka-GE.js'
+
+export const aliasOf = 'ka-GE'

--- a/src/kn.js
+++ b/src/kn.js
@@ -1,0 +1,13 @@
+/**
+ * Kannada (bare-tag alias)
+ *
+ * `kn` resolves to kn-IN, currently the only Kannada variant this
+ * package implements. This file exists purely so `n2words/kn` works
+ * without requiring a region subtag; it is not a claim that kn-IN speaks
+ * for every Kannada-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './kn-IN.js'
+
+export const aliasOf = 'kn-IN'

--- a/src/ko.js
+++ b/src/ko.js
@@ -1,0 +1,13 @@
+/**
+ * Korean (bare-tag alias)
+ *
+ * `ko` resolves to ko-KR, currently the only Korean variant this
+ * package implements. This file exists purely so `n2words/ko` works
+ * without requiring a region subtag; it is not a claim that ko-KR speaks
+ * for every Korean-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ko-KR.js'
+
+export const aliasOf = 'ko-KR'

--- a/src/lt.js
+++ b/src/lt.js
@@ -1,0 +1,13 @@
+/**
+ * Lithuanian (bare-tag alias)
+ *
+ * `lt` resolves to lt-LT, currently the only Lithuanian variant this
+ * package implements. This file exists purely so `n2words/lt` works
+ * without requiring a region subtag; it is not a claim that lt-LT speaks
+ * for every Lithuanian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './lt-LT.js'
+
+export const aliasOf = 'lt-LT'

--- a/src/lv.js
+++ b/src/lv.js
@@ -1,0 +1,13 @@
+/**
+ * Latvian (bare-tag alias)
+ *
+ * `lv` resolves to lv-LV, currently the only Latvian variant this
+ * package implements. This file exists purely so `n2words/lv` works
+ * without requiring a region subtag; it is not a claim that lv-LV speaks
+ * for every Latvian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './lv-LV.js'
+
+export const aliasOf = 'lv-LV'

--- a/src/mr.js
+++ b/src/mr.js
@@ -1,0 +1,13 @@
+/**
+ * Marathi (bare-tag alias)
+ *
+ * `mr` resolves to mr-IN, currently the only Marathi variant this
+ * package implements. This file exists purely so `n2words/mr` works
+ * without requiring a region subtag; it is not a claim that mr-IN speaks
+ * for every Marathi-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './mr-IN.js'
+
+export const aliasOf = 'mr-IN'

--- a/src/ms.js
+++ b/src/ms.js
@@ -1,0 +1,13 @@
+/**
+ * Malay (bare-tag alias)
+ *
+ * `ms` resolves to ms-MY, currently the only Malay variant this
+ * package implements. This file exists purely so `n2words/ms` works
+ * without requiring a region subtag; it is not a claim that ms-MY speaks
+ * for every Malay-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ms-MY.js'
+
+export const aliasOf = 'ms-MY'

--- a/src/nb.js
+++ b/src/nb.js
@@ -1,0 +1,13 @@
+/**
+ * Norwegian Bokmål (bare-tag alias)
+ *
+ * `nb` resolves to nb-NO, currently the only Norwegian Bokmål variant this
+ * package implements. This file exists purely so `n2words/nb` works
+ * without requiring a region subtag; it is not a claim that nb-NO speaks
+ * for every Norwegian Bokmål-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './nb-NO.js'
+
+export const aliasOf = 'nb-NO'

--- a/src/nl.js
+++ b/src/nl.js
@@ -1,0 +1,13 @@
+/**
+ * Dutch (bare-tag alias)
+ *
+ * `nl` resolves to nl-NL, currently the only Dutch variant this
+ * package implements. This file exists purely so `n2words/nl` works
+ * without requiring a region subtag; it is not a claim that nl-NL speaks
+ * for every Dutch-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './nl-NL.js'
+
+export const aliasOf = 'nl-NL'

--- a/src/pa.js
+++ b/src/pa.js
@@ -1,0 +1,13 @@
+/**
+ * Punjabi (bare-tag alias)
+ *
+ * `pa` resolves to pa-IN, currently the only Punjabi variant this
+ * package implements. This file exists purely so `n2words/pa` works
+ * without requiring a region subtag; it is not a claim that pa-IN speaks
+ * for every Punjabi-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './pa-IN.js'
+
+export const aliasOf = 'pa-IN'

--- a/src/pl.js
+++ b/src/pl.js
@@ -1,0 +1,13 @@
+/**
+ * Polish (bare-tag alias)
+ *
+ * `pl` resolves to pl-PL, currently the only Polish variant this
+ * package implements. This file exists purely so `n2words/pl` works
+ * without requiring a region subtag; it is not a claim that pl-PL speaks
+ * for every Polish-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './pl-PL.js'
+
+export const aliasOf = 'pl-PL'

--- a/src/ro.js
+++ b/src/ro.js
@@ -1,0 +1,13 @@
+/**
+ * Romanian (bare-tag alias)
+ *
+ * `ro` resolves to ro-RO, currently the only Romanian variant this
+ * package implements. This file exists purely so `n2words/ro` works
+ * without requiring a region subtag; it is not a claim that ro-RO speaks
+ * for every Romanian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ro-RO.js'
+
+export const aliasOf = 'ro-RO'

--- a/src/ru.js
+++ b/src/ru.js
@@ -1,0 +1,13 @@
+/**
+ * Russian (bare-tag alias)
+ *
+ * `ru` resolves to ru-RU, currently the only Russian variant this
+ * package implements. This file exists purely so `n2words/ru` works
+ * without requiring a region subtag; it is not a claim that ru-RU speaks
+ * for every Russian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ru-RU.js'
+
+export const aliasOf = 'ru-RU'

--- a/src/sv.js
+++ b/src/sv.js
@@ -1,0 +1,13 @@
+/**
+ * Swedish (bare-tag alias)
+ *
+ * `sv` resolves to sv-SE, currently the only Swedish variant this
+ * package implements. This file exists purely so `n2words/sv` works
+ * without requiring a region subtag; it is not a claim that sv-SE speaks
+ * for every Swedish-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './sv-SE.js'
+
+export const aliasOf = 'sv-SE'

--- a/src/sw.js
+++ b/src/sw.js
@@ -1,0 +1,13 @@
+/**
+ * Swahili (bare-tag alias)
+ *
+ * `sw` resolves to sw-KE, currently the only Swahili variant this
+ * package implements. This file exists purely so `n2words/sw` works
+ * without requiring a region subtag; it is not a claim that sw-KE speaks
+ * for every Swahili-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './sw-KE.js'
+
+export const aliasOf = 'sw-KE'

--- a/src/ta.js
+++ b/src/ta.js
@@ -1,0 +1,13 @@
+/**
+ * Tamil (bare-tag alias)
+ *
+ * `ta` resolves to ta-IN, currently the only Tamil variant this
+ * package implements. This file exists purely so `n2words/ta` works
+ * without requiring a region subtag; it is not a claim that ta-IN speaks
+ * for every Tamil-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ta-IN.js'
+
+export const aliasOf = 'ta-IN'

--- a/src/te.js
+++ b/src/te.js
@@ -1,0 +1,13 @@
+/**
+ * Telugu (bare-tag alias)
+ *
+ * `te` resolves to te-IN, currently the only Telugu variant this
+ * package implements. This file exists purely so `n2words/te` works
+ * without requiring a region subtag; it is not a claim that te-IN speaks
+ * for every Telugu-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './te-IN.js'
+
+export const aliasOf = 'te-IN'

--- a/src/th.js
+++ b/src/th.js
@@ -1,0 +1,13 @@
+/**
+ * Thai (bare-tag alias)
+ *
+ * `th` resolves to th-TH, currently the only Thai variant this
+ * package implements. This file exists purely so `n2words/th` works
+ * without requiring a region subtag; it is not a claim that th-TH speaks
+ * for every Thai-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './th-TH.js'
+
+export const aliasOf = 'th-TH'

--- a/src/tr.js
+++ b/src/tr.js
@@ -1,0 +1,13 @@
+/**
+ * Turkish (bare-tag alias)
+ *
+ * `tr` resolves to tr-TR, currently the only Turkish variant this
+ * package implements. This file exists purely so `n2words/tr` works
+ * without requiring a region subtag; it is not a claim that tr-TR speaks
+ * for every Turkish-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './tr-TR.js'
+
+export const aliasOf = 'tr-TR'

--- a/src/uk.js
+++ b/src/uk.js
@@ -1,0 +1,13 @@
+/**
+ * Ukrainian (bare-tag alias)
+ *
+ * `uk` resolves to uk-UA, currently the only Ukrainian variant this
+ * package implements. This file exists purely so `n2words/uk` works
+ * without requiring a region subtag; it is not a claim that uk-UA speaks
+ * for every Ukrainian-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './uk-UA.js'
+
+export const aliasOf = 'uk-UA'

--- a/src/ur.js
+++ b/src/ur.js
@@ -1,0 +1,13 @@
+/**
+ * Urdu (bare-tag alias)
+ *
+ * `ur` resolves to ur-PK, currently the only Urdu variant this
+ * package implements. This file exists purely so `n2words/ur` works
+ * without requiring a region subtag; it is not a claim that ur-PK speaks
+ * for every Urdu-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './ur-PK.js'
+
+export const aliasOf = 'ur-PK'

--- a/src/vi.js
+++ b/src/vi.js
@@ -1,0 +1,13 @@
+/**
+ * Vietnamese (bare-tag alias)
+ *
+ * `vi` resolves to vi-VN, currently the only Vietnamese variant this
+ * package implements. This file exists purely so `n2words/vi` works
+ * without requiring a region subtag; it is not a claim that vi-VN speaks
+ * for every Vietnamese-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './vi-VN.js'
+
+export const aliasOf = 'vi-VN'

--- a/src/yo.js
+++ b/src/yo.js
@@ -1,0 +1,13 @@
+/**
+ * Yoruba (bare-tag alias)
+ *
+ * `yo` resolves to yo-NG, currently the only Yoruba variant this
+ * package implements. This file exists purely so `n2words/yo` works
+ * without requiring a region subtag; it is not a claim that yo-NG speaks
+ * for every Yoruba-speaking region. See docs/bare-tag-aliases.md for the
+ * full rationale and LANGUAGES.md for the complete family/variant table.
+ */
+
+export * from './yo-NG.js'
+
+export const aliasOf = 'yo-NG'

--- a/test/bare-tag-contract.test.js
+++ b/test/bare-tag-contract.test.js
@@ -1,0 +1,80 @@
+import test from 'ava'
+import { readdirSync } from 'node:fs'
+
+/**
+ * Bare-tag alias contract gate.
+ *
+ * Every BCP 47 primary language subtag with exactly one regional/script
+ * variant in src/ MUST have a matching bare-tag alias file (e.g. only
+ * de-DE exists, so src/de.js must exist and re-export it) — see
+ * docs/bare-tag-aliases.md for the full rule. A family with two or more
+ * variants is a human judgment call (some, like en/es/fr, still get a
+ * documented default; others, like zh/sr/am/pt, don't because their
+ * variants genuinely diverge in script or core numbering grammar) — this
+ * gate doesn't assert either way for those, since "very different" isn't
+ * mechanically checkable.
+ *
+ * Separately, every alias file's re-exported bindings (forms, *Max,
+ * *Defaults, *Values) must be reference-identical to its target module's —
+ * proof `export *` is forwarding live bindings, not a stale copy. This is
+ * why contract.test.js, range-contract.test.js, and options-contract.test.js
+ * skip alias files: identity here is a stronger, cheaper guarantee than
+ * re-running their fuzz suites against what's already proven to be the
+ * exact same function.
+ */
+
+const files = readdirSync('./src')
+  .filter(f => f.endsWith('.js') && !f.startsWith('utils'))
+  .sort()
+const codes = files.map(f => f.replace('.js', ''))
+
+const mods = new Map()
+for (const code of codes) {
+  mods.set(code, await import(`../src/${code}.js`))
+}
+
+const canonicalCodes = codes.filter(code => mods.get(code).aliasOf === undefined)
+const aliasCodes = codes.filter(code => mods.get(code).aliasOf !== undefined)
+
+// Group canonical (non-alias) codes by BCP 47 primary subtag, e.g.
+// zh-Hans-CN and zh-Hant-TW both group under "zh".
+const byPrimary = new Map()
+for (const code of canonicalCodes) {
+  const primary = code.split('-')[0]
+  if (!byPrimary.has(primary)) byPrimary.set(primary, [])
+  byPrimary.get(primary).push(code)
+}
+
+for (const [primary, variants] of byPrimary) {
+  if (variants.length !== 1) continue // multi-variant family: human judgment call, not asserted here
+
+  test(`${primary} (single-variant family) has a bare-tag alias`, (t) => {
+    const mod = mods.get(primary)
+    t.truthy(mod, `src/${primary}.js is missing — ${variants[0]} is the only ${primary}-* variant, so per docs/bare-tag-aliases.md it must have a bare-tag alias`)
+    t.is(mod?.aliasOf, variants[0], `src/${primary}.js exists but doesn't alias ${variants[0]}`)
+  })
+}
+
+// Every named export an alias could plausibly forward — asserting identity
+// on all of them (not just the three forms) covers the range and options
+// contracts too, since `export *` should forward every binding equally.
+const REEXPORTED_KEYS = [
+  'toCardinal', 'toOrdinal', 'toCurrency',
+  'cardinalMax', 'ordinalMax', 'currencyMax',
+  'cardinalDefaults', 'ordinalDefaults', 'currencyDefaults',
+  'cardinalValues', 'ordinalValues', 'currencyValues',
+]
+
+for (const code of aliasCodes) {
+  test(`${code} is a faithful re-export of its target`, (t) => {
+    const mod = mods.get(code)
+    const target = mod.aliasOf
+    const targetMod = mods.get(target)
+    t.truthy(targetMod, `${code} aliases "${target}" but src/${target}.js doesn't exist`)
+    if (!targetMod) return
+
+    for (const key of REEXPORTED_KEYS) {
+      t.is(mod[key], targetMod[key], `${code}.${key} must be the exact same binding as ${target}.${key}`)
+    }
+  })
+}

--- a/test/bare-tag-contract.test.js
+++ b/test/bare-tag-contract.test.js
@@ -73,6 +73,13 @@ for (const code of aliasCodes) {
     t.truthy(targetMod, `${code} aliases "${target}" but src/${target}.js doesn't exist`)
     if (!targetMod) return
 
+    // An alias is a *within-family* pointer: `en` must resolve to some en-*
+    // variant. Without this, `src/en.js` re-exporting './de-DE.js' would pass
+    // every other assertion here — bindings would be faithfully identical, just
+    // to the wrong language — and LANGUAGES.md would render English's entry
+    // point linking into German's section.
+    t.is(target.split('-')[0], code, `${code} must alias a ${code}-* variant, not "${target}"`)
+
     for (const key of REEXPORTED_KEYS) {
       t.is(mod[key], targetMod[key], `${code}.${key} must be the exact same binding as ${target}.${key}`)
     }

--- a/test/contract.test.js
+++ b/test/contract.test.js
@@ -18,6 +18,13 @@ import { readdirSync } from 'node:fs'
  * scanning `src/` — so a newly added `src/{code}.js` is gated automatically with
  * no change to this file. (Correct in-range *output* is covered by the fixtures
  * in conversions.test.js; this gate covers the contract's shape.)
+ *
+ * Bare-tag alias files (`aliasOf` exported) are skipped: `export *` makes their
+ * toCardinal/toOrdinal/toCurrency the exact same function objects as their
+ * target's, so fuzzing them again would just re-run this same property against
+ * an identical function — test/bare-tag-contract.test.js verifies that
+ * reference-identity directly instead, which is both cheaper and a stronger
+ * guarantee than re-running 200 fast-check iterations per form.
  */
 
 const languageFiles = readdirSync('./src')
@@ -73,11 +80,17 @@ function upholdsContract(fn, input) {
   return true
 }
 
+const languages = []
 for (const file of languageFiles) {
   const code = file.replace('.js', '')
+  const mod = await import('../src/' + file)
+  if (mod.aliasOf !== undefined) continue
+  languages.push({ code, mod })
+}
 
-  test(`${code} upholds the conversion contract`, async (t) => {
-    const { toCardinal, toOrdinal, toCurrency } = await import('../src/' + file)
+for (const { code, mod } of languages) {
+  test(`${code} upholds the conversion contract`, (t) => {
+    const { toCardinal, toOrdinal, toCurrency } = mod
 
     // Collect a property per exported form (built only when the form exists, so a
     // partial-form language isn't called on functions it doesn't ship). Assertions

--- a/test/fixtures/ar.js
+++ b/test/fixtures/ar.js
@@ -1,0 +1,1 @@
+export * from './ar-SA.js'

--- a/test/fixtures/az.js
+++ b/test/fixtures/az.js
@@ -1,0 +1,1 @@
+export * from './az-AZ.js'

--- a/test/fixtures/bn.js
+++ b/test/fixtures/bn.js
@@ -1,0 +1,1 @@
+export * from './bn-BD.js'

--- a/test/fixtures/cs.js
+++ b/test/fixtures/cs.js
@@ -1,0 +1,1 @@
+export * from './cs-CZ.js'

--- a/test/fixtures/da.js
+++ b/test/fixtures/da.js
@@ -1,0 +1,1 @@
+export * from './da-DK.js'

--- a/test/fixtures/de.js
+++ b/test/fixtures/de.js
@@ -1,0 +1,1 @@
+export * from './de-DE.js'

--- a/test/fixtures/el.js
+++ b/test/fixtures/el.js
@@ -1,0 +1,1 @@
+export * from './el-GR.js'

--- a/test/fixtures/en.js
+++ b/test/fixtures/en.js
@@ -1,0 +1,1 @@
+export * from './en-US.js'

--- a/test/fixtures/es.js
+++ b/test/fixtures/es.js
@@ -1,0 +1,1 @@
+export * from './es-ES.js'

--- a/test/fixtures/fa.js
+++ b/test/fixtures/fa.js
@@ -1,0 +1,1 @@
+export * from './fa-IR.js'

--- a/test/fixtures/fi.js
+++ b/test/fixtures/fi.js
@@ -1,0 +1,1 @@
+export * from './fi-FI.js'

--- a/test/fixtures/fil.js
+++ b/test/fixtures/fil.js
@@ -1,0 +1,1 @@
+export * from './fil-PH.js'

--- a/test/fixtures/fr.js
+++ b/test/fixtures/fr.js
@@ -1,0 +1,1 @@
+export * from './fr-FR.js'

--- a/test/fixtures/gu.js
+++ b/test/fixtures/gu.js
@@ -1,0 +1,1 @@
+export * from './gu-IN.js'

--- a/test/fixtures/ha.js
+++ b/test/fixtures/ha.js
@@ -1,0 +1,1 @@
+export * from './ha-NG.js'

--- a/test/fixtures/hbo.js
+++ b/test/fixtures/hbo.js
@@ -1,0 +1,1 @@
+export * from './hbo-IL.js'

--- a/test/fixtures/he.js
+++ b/test/fixtures/he.js
@@ -1,0 +1,1 @@
+export * from './he-IL.js'

--- a/test/fixtures/hi.js
+++ b/test/fixtures/hi.js
@@ -1,0 +1,1 @@
+export * from './hi-IN.js'

--- a/test/fixtures/hr.js
+++ b/test/fixtures/hr.js
@@ -1,0 +1,1 @@
+export * from './hr-HR.js'

--- a/test/fixtures/hu.js
+++ b/test/fixtures/hu.js
@@ -1,0 +1,1 @@
+export * from './hu-HU.js'

--- a/test/fixtures/id.js
+++ b/test/fixtures/id.js
@@ -1,0 +1,1 @@
+export * from './id-ID.js'

--- a/test/fixtures/it.js
+++ b/test/fixtures/it.js
@@ -1,0 +1,1 @@
+export * from './it-IT.js'

--- a/test/fixtures/ja.js
+++ b/test/fixtures/ja.js
@@ -1,0 +1,1 @@
+export * from './ja-JP.js'

--- a/test/fixtures/ka.js
+++ b/test/fixtures/ka.js
@@ -1,0 +1,1 @@
+export * from './ka-GE.js'

--- a/test/fixtures/kn.js
+++ b/test/fixtures/kn.js
@@ -1,0 +1,1 @@
+export * from './kn-IN.js'

--- a/test/fixtures/ko.js
+++ b/test/fixtures/ko.js
@@ -1,0 +1,1 @@
+export * from './ko-KR.js'

--- a/test/fixtures/lt.js
+++ b/test/fixtures/lt.js
@@ -1,0 +1,1 @@
+export * from './lt-LT.js'

--- a/test/fixtures/lv.js
+++ b/test/fixtures/lv.js
@@ -1,0 +1,1 @@
+export * from './lv-LV.js'

--- a/test/fixtures/mr.js
+++ b/test/fixtures/mr.js
@@ -1,0 +1,1 @@
+export * from './mr-IN.js'

--- a/test/fixtures/ms.js
+++ b/test/fixtures/ms.js
@@ -1,0 +1,1 @@
+export * from './ms-MY.js'

--- a/test/fixtures/nb.js
+++ b/test/fixtures/nb.js
@@ -1,0 +1,1 @@
+export * from './nb-NO.js'

--- a/test/fixtures/nl.js
+++ b/test/fixtures/nl.js
@@ -1,0 +1,1 @@
+export * from './nl-NL.js'

--- a/test/fixtures/pa.js
+++ b/test/fixtures/pa.js
@@ -1,0 +1,1 @@
+export * from './pa-IN.js'

--- a/test/fixtures/pl.js
+++ b/test/fixtures/pl.js
@@ -1,0 +1,1 @@
+export * from './pl-PL.js'

--- a/test/fixtures/ro.js
+++ b/test/fixtures/ro.js
@@ -1,0 +1,1 @@
+export * from './ro-RO.js'

--- a/test/fixtures/ru.js
+++ b/test/fixtures/ru.js
@@ -1,0 +1,1 @@
+export * from './ru-RU.js'

--- a/test/fixtures/sv.js
+++ b/test/fixtures/sv.js
@@ -1,0 +1,1 @@
+export * from './sv-SE.js'

--- a/test/fixtures/sw.js
+++ b/test/fixtures/sw.js
@@ -1,0 +1,1 @@
+export * from './sw-KE.js'

--- a/test/fixtures/ta.js
+++ b/test/fixtures/ta.js
@@ -1,0 +1,1 @@
+export * from './ta-IN.js'

--- a/test/fixtures/te.js
+++ b/test/fixtures/te.js
@@ -1,0 +1,1 @@
+export * from './te-IN.js'

--- a/test/fixtures/th.js
+++ b/test/fixtures/th.js
@@ -1,0 +1,1 @@
+export * from './th-TH.js'

--- a/test/fixtures/tr.js
+++ b/test/fixtures/tr.js
@@ -1,0 +1,1 @@
+export * from './tr-TR.js'

--- a/test/fixtures/uk.js
+++ b/test/fixtures/uk.js
@@ -1,0 +1,1 @@
+export * from './uk-UA.js'

--- a/test/fixtures/ur.js
+++ b/test/fixtures/ur.js
@@ -1,0 +1,1 @@
+export * from './ur-PK.js'

--- a/test/fixtures/vi.js
+++ b/test/fixtures/vi.js
@@ -1,0 +1,1 @@
+export * from './vi-VN.js'

--- a/test/fixtures/yo.js
+++ b/test/fixtures/yo.js
@@ -1,0 +1,1 @@
+export * from './yo-NG.js'

--- a/test/helpers/language-naming.js
+++ b/test/helpers/language-naming.js
@@ -75,6 +75,7 @@ export function normalizeCode(code) {
  */
 export const LANGUAGE_NAME_OVERRIDES = {
   'hbo-IL': 'Biblical Hebrew (Israel)',
+  'hbo': 'Biblical Hebrew',
 }
 
 /**

--- a/test/options-contract.test.js
+++ b/test/options-contract.test.js
@@ -56,9 +56,16 @@ function outOfSetProbe(set, type) {
 // Pre-load: a language registers when any form takes options OR declares the
 // contract, so neither side can dodge the other — options without a declaration
 // and a declaration without options both fail below.
+//
+// Bare-tag alias files (`aliasOf` exported) are skipped: `export *` makes their
+// forms and `<form>Defaults`/`<form>Values` the exact same objects as their
+// target's, so re-running this whole battery would just re-verify an identical
+// contract under a different name. test/bare-tag-contract.test.js checks the
+// re-export's fidelity directly instead.
 const languages = []
 for (const file of readdirSync('./src').filter(f => f.endsWith('.js') && !f.startsWith('utils')).sort()) {
   const mod = await import('../src/' + file)
+  if (mod.aliasOf !== undefined) continue
   const relevant = FORMS.filter(([form, fnName]) =>
     (typeof mod[fnName] === 'function' && mod[fnName].length >= 2) || mod[`${form}Defaults`] !== undefined,
   )

--- a/test/range-contract.test.js
+++ b/test/range-contract.test.js
@@ -75,9 +75,16 @@ function checkForm(fn, max) {
 
 // Every language registers — the declaration is required, not opt-in. A form
 // exported without its *Max (or a *Max without its form) fails below.
+//
+// Bare-tag alias files (`aliasOf` exported) are skipped: `export *` makes their
+// forms the exact same function objects — and their *Max the exact same
+// bigints — as their target's, so re-sweeping the range here would just
+// re-verify an identical declaration under a different name. test/bare-tag-
+// contract.test.js checks the re-export's fidelity directly instead.
 const languages = []
 for (const file of readdirSync('./src').filter(f => f.endsWith('.js') && !f.startsWith('utils')).sort()) {
   const mod = await import('../src/' + file)
+  if (mod.aliasOf !== undefined) continue
   languages.push({ code: file.replace('.js', ''), mod })
 }
 


### PR DESCRIPTION
Split out of #428, which was 191 files carrying two unrelated features. This is the half
that has nothing to do with currency: **bare BCP 47 tags as importable entry points.**

```js
import { toCardinal } from 'n2words/en'   // was: 'n2words/en-US'
import { toCardinal } from 'n2words/de'   // was: 'n2words/de-DE'
```

46 new entry points, one per language family whose variants aren't "very different".
`zh`, `pt`, `sr` and `am` stay region/script-qualified — their variants diverge in script
or core numbering grammar, so a bare tag would silently choose for the caller.

## What's here

Eight commits, cherry-picked unchanged from #428 apart from two resolutions noted below:

| commit | what |
| --- | --- |
| `20747f7` | aliases for en, fr, ar, es |
| `3fc1a9b` | aliases excluded from `LANGUAGES.md`'s language count |
| `5435eca` | `lang:add` refuses to scaffold onto an alias file |
| `21478f6` | backfill every single-variant family (→ 46) |
| `2c0dc9b` | `test/bare-tag-contract.test.js` — completeness + fidelity gate |
| `fb431f1` | `lang:add` auto-scaffolds an alias for a first-in-family code |
| `b0c3b3c` | `LANGUAGES.md` grouped by family + `docs/bare-tag-aliases.md` |
| `a5da555` | gate: an alias must point inside its own family |

An alias file is two lines plus a rationale comment:

```js
export * from './de-DE.js'
export const aliasOf = 'de-DE'
```

No resolution or registry layer — every gate already discovers the language list via
`readdirSync('./src')`, and `package.json`'s `"./*"` wildcard export already resolves
`n2words/de`. A new file is picked up automatically.

## The gate

`test/bare-tag-contract.test.js` asserts two mechanical things:

- **Completeness** — a family with exactly one variant in `src/` must have an alias, so
  this stays true as languages are added rather than being a one-time cleanup.
- **Fidelity** — every re-exported binding (`toCardinal`, `cardinalMax`,
  `currencyDefaults`, ...) is `===` to its target's, proving `export *` forwards live
  bindings rather than a stale copy. This is why `contract`, `range-contract` and
  `options-contract` skip alias files: identity is a stronger and cheaper guarantee than
  re-running a fuzz suite against a function already proven identical.

The "very different" judgment itself is deliberately **not** gated — a multi-variant
family is not asserted either way. That call belongs to a human, and the reasoning for
each is written down in `docs/bare-tag-aliases.md` and in each alias file's own comment.

## Resolutions during the cherry-pick

- `20747f7` also touched `test/currency-vocab-contract.test.js`, which only exists in
  #428. Dropped here; #428 keeps it.
- `LANGUAGES.md` conflicted, being generated. Resolved by running
  `npm run docs:languages` rather than hand-merging.

## Non-breaking

Purely additive: new entry points, no existing one changed. `n2words/en` is exactly
`n2words/en-US`, currency included — which is all an alias claims to be today. The
language/locale distinction for `toCurrency` needs the `currency` option, which doesn't
exist until #428, so that rule lands there with the layer it belongs to.

## Verification

- `npm test` — 588 passing
- `npm run lint` — clean
- `npm run docs:languages` — regenerates byte-identical (50 languages, 72 variants,
  46 bare-tag entry points)
- Resolved through a real `node_modules` symlink: `n2words/en`, `n2words/de`,
  `n2words/th` all import and convert correctly

cc @TylerVigario — this is the first of the three you asked for at #428. Currency stays
in #428, rebased on this.