### PR TITLE
chore(deps): bump fast-uri to 3.1.7 to clear a high-severity audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3863,9 +3863,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
CI's **Lint & Security** job fails on `main` today — `npm audit --audit-level=high` reports
four high-severity advisories against `fast-uri@3.1.5`:

- host confusion via skipped IDN canonicalization on scheme-relative references ([GHSA-5jgf-p345-68v8](https://github.com/advisories/GHSA-5jgf-p345-68v8))
- SSRF via malformed IPv6 normalization ([GHSA-f65p-4m7j-42xc](https://github.com/advisories/GHSA-f65p-4m7j-42xc))
- SSRF via repeated hostname percent-decoding ([GHSA-fph4-wmhf-6fwf](https://github.com/advisories/GHSA-fph4-wmhf-6fwf))
- host confusion via percent-encoded scheme normalization ([GHSA-jqff-g426-hqxp](https://github.com/advisories/GHSA-jqff-g426-hqxp))

Dev-only and transitive, so nothing reaches consumers:

```
@commitlint/cli -> @commitlint/load -> @commitlint/config-validator -> ajv -> fast-uri
```

`ajv@8.20.0` constrains it to `^3.0.1`, which `3.1.7` satisfies — lockfile-only, no
`package.json` change.

## Why the entry is hand-edited rather than `npm audit fix`

The lockfile was generated by the npm that ships with Node 26 (what CI runs). Running
`npm audit fix` under an older npm strips the `libc` fields from rollup's optional
platform packages — 45 unrelated deleted lines, and it changes how Linux glibc/musl
builds resolve. So this bumps the single `fast-uri` entry and leaves the file otherwise
byte-identical. The integrity hash was verified against the registry
(`npm view fast-uri@3.1.7 dist.integrity`).

## Verification

- `npm ci` → resolves `fast-uri@3.1.7`, lockfile unchanged afterwards (3-line diff holds)
- `npm audit --audit-level=high` → `found 0 vulnerabilities`
- `npm test` → 453 passing

Unblocks #434 and #428, both of which hit this on an untouched lockfile.