### PR TITLE
feat(core)!: stop bare tags from inheriting a country's default currency

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,32 @@ es(42)           // 'cuarenta y dos'
 
 n2words converts numbers to words in multiple forms:
 
-| Form     | Function             | Example                             |
-| -------- | -------------------- | ----------------------------------- |
-| Cardinal | `toCardinal(42)`     | "forty-two"                         |
-| Ordinal  | `toOrdinal(42)`      | "forty-second"                      |
-| Currency | `toCurrency(42.50)`  | "forty-two dollars and fifty cents" |
+| Form     | Function                              | Example                             |
+| -------- | ------------------------------------- | ----------------------------------- |
+| Cardinal | `toCardinal(42)`                      | "forty-two"                         |
+| Ordinal  | `toOrdinal(42)`                       | "forty-second"                      |
+| Currency | `toCurrency(42.50, { currency })`     | "forty-two dollars and fifty cents" |
 
 ```js
 import { toCardinal, toOrdinal, toCurrency } from 'n2words/en'
 
-toCardinal(1234)      // 'one thousand two hundred thirty-four'
-toOrdinal(1234)       // 'one thousand two hundred thirty-fourth'
-toCurrency(1234.56)   // 'one thousand two hundred thirty-four dollars and fifty-six cents'
+toCardinal(1234)                        // 'one thousand two hundred thirty-four'
+toOrdinal(1234)                         // 'one thousand two hundred thirty-fourth'
+toCurrency(1234.56, { currency: 'USD' }) // 'one thousand two hundred thirty-four dollars and fifty-six cents'
+```
+
+`toCurrency` is the one form a bare tag won't guess at. `en` names a *language*,
+and a default currency belongs to a *country*, so `n2words/en` requires the
+currency to be named. Import the region-qualified code when you want its
+default:
+
+```js
+import { toCurrency } from 'n2words/en'
+import { toCurrency as usd } from 'n2words/en-US'
+
+toCurrency(42.50)                      // throws TypeError — en is a language, not a locale
+toCurrency(42.50, { currency: 'GBP' }) // 'forty-two pounds and fifty pence'
+usd(42.50)                             // 'forty-two dollars and fifty cents'
 ```
 
 A currency-supporting language can also name an amount in a currency other than its own
@@ -112,6 +126,12 @@ Serbian, Amharic) require the full code:
 ```js
 import { toCardinal } from 'n2words/zh-Hans-CN'
 ```
+
+A bare tag forwards `toCardinal` and `toOrdinal` untouched — they're the same
+functions its target exports. The one difference is `toCurrency`, which
+requires an explicit `currency` because a language tag carries no country to
+take a default from (see
+[docs/bare-tag-aliases.md](docs/bare-tag-aliases.md#bare-tags-carry-no-default-currency)).
 
 **Browser (CDN):**
 

--- a/docs/bare-tag-aliases.md
+++ b/docs/bare-tag-aliases.md
@@ -74,6 +74,82 @@ each alias file's own comment) — most-used variant for `en`, conventional
 default for bare `es`/`fr` across BCP-47 tooling generally. This part isn't
 mechanically checkable and the gate doesn't try.
 
+## Bare tags carry no default currency
+
+Everything above is about *numerals*, where an alias forwards its target's
+bindings untouched. `toCurrency` is the one exception, and it falls out of the
+layer model rather than being a special case: **a bare tag names a language,
+and a default currency belongs to a country.**
+
+`en-US` defaults to USD because a locale has a country and a country has a
+currency. `en` has no country. Inheriting `en-US`'s default would mean
+`n2words/en`'s `toCurrency(42.50)` quietly returns dollars to a caller who
+asked only for English — and English is official in sixteen of this package's
+variants, spanning USD, GBP, INR, KES, NGN, ZAR and more. So an alias strips
+the key and requires the caller to name one:
+
+```js
+import { toCurrency } from 'n2words/en'
+
+toCurrency(42.50)                      // TypeError: names a language, not a locale
+toCurrency(42.50, { currency: 'GBP' }) // 'forty-two pounds and fifty pence'
+
+import { toCurrency as toCurrencyUS } from 'n2words/en-US'
+toCurrencyUS(42.50)                    // 'forty-two dollars and fifty cents'
+```
+
+This applies to every alias, not only the families whose variants visibly
+disagree. `de` looks safe because de-DE is the only German variant here, but
+German is also spoken in Austria and Switzerland, and CHF is not EUR — the
+rule holds because of what a language tag *is*, not because of which variants
+happen to be implemented today.
+
+The shape, in each alias file:
+
+```js
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './de-DE.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow
+export * from './de-DE.js'
+export const aliasOf = 'de-DE'
+
+// eslint-disable-next-line no-unused-vars -- named only so the rest excludes it
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+// eslint-disable-next-line import-x/export -- deliberate shadow
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+function toCurrency(value, options) {
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/de names a language, not a locale: ...')
+  }
+  return toCurrencyBase(value, options)
+}
+// eslint-disable-next-line import-x/export -- deliberate shadow
+export { toCurrency }
+```
+
+Three details worth keeping:
+
+- **`currencyDefaults` is derived, not hand-listed.** Every option other than
+  `currency` keeps the target's default, so an option added to the target
+  later can't silently go missing from the bare tag.
+- **The target's options contract runs first.** `resolveOptions` is called
+  before the missing-currency check so a typo'd key reports itself
+  (`Unknown option "currencey"`) instead of being masked by the
+  missing-currency error. `TypeError` is right for both: `resolve-options.js`
+  reserves `TypeError` for shape errors and `RangeError` for values outside a
+  declared set, and an absent required option is a shape error.
+- **Only `toCurrency` and `currencyDefaults` are shadowed.** `currencyValues`,
+  `currencyMax` and both other forms stay reference-identical to the target's,
+  and the gate still asserts that.
+
+A language that names one hardcoded currency has no `currency` option and so
+has nothing to strip — its alias stays a plain `export *`. The gate keys off
+exactly that condition, so the wrapper becomes mandatory the moment such a
+language gains the option.
+
 ## `aliasOf` vs `variantOf`
 
 A bare-tag alias is one of two thin, `export *`-based file shapes in
@@ -95,10 +171,16 @@ Two things, both mechanical:
   `src/` must have a matching alias file. This is what keeps "must exist for
   every non-diverging language" true over time instead of being a one-time
   cleanup.
-- **Fidelity** — every alias's re-exported bindings (`toCardinal`,
-  `cardinalMax`, `currencyDefaults`, ...) are reference-identical (`===`) to
+- **Fidelity** — every alias's forwarded bindings (`toCardinal`,
+  `cardinalMax`, `currencyValues`, ...) are reference-identical (`===`) to
   its target's, proving `export *` is forwarding live bindings rather than a
   stale copy.
+- **No inherited currency** — for a family whose target declares a `currency`
+  option, the alias must wrap `toCurrency` and strip the default (see above):
+  the wrapper is a distinct function, `currencyDefaults` has no `currency`
+  key, calling it without one throws `TypeError`, every *other* default is
+  kept, and naming the target's own currency reproduces the target's output
+  exactly.
 
 Because fidelity is covered here, `contract.test.js`, `range-contract.test.js`,
 and `options-contract.test.js` skip alias files entirely (an `aliasOf`

--- a/scripts/add-language.js
+++ b/scripts/add-language.js
@@ -447,6 +447,13 @@ function generateAliasFile(primary, code, name) {
  * without requiring a region subtag; it is not a claim that ${code} speaks
  * for every ${name}-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * A plain \`export *\` while ${code} names a single hardcoded currency. If it
+ * ever gains a \`currency\` option, this file must stop forwarding
+ * \`toCurrency\`/\`currencyDefaults\` and wrap them instead — a bare tag names a
+ * language and has no country to take a default currency from. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency" for the
+ * shape to copy; test/bare-tag-contract.test.js fails until it's there.
  */
 
 export * from './${code}.js'
@@ -783,6 +790,10 @@ async function main() {
       writeFileSync(aliasFilePath, generateAliasFile(primary, code, familyName))
       writeFileSync(`./test/fixtures/${primary}.js`, `export * from './${code}.js'\n`)
       console.log(chalk.green(`✓ Created bare-tag alias: ${primary} -> ${code} (first ${primary}-* variant)`))
+      if (formsToScaffold.has('currency')) {
+        console.log(chalk.yellow(`Note: src/${primary}.js forwards toCurrency as-is, which is right while ${code} names one hardcoded currency.`))
+        console.log(chalk.yellow('If you give it a `currency` option, wrap toCurrency in the alias so the bare tag requires an explicit currency — see docs/bare-tag-aliases.md.'))
+      }
     }
     else if (siblings.length > 0) {
       console.log(chalk.yellow(`\nNote: ${primary}-* already has ${siblings.length === 1 ? 'a variant' : 'variants'} (${siblings.join(', ')}).`))

--- a/src/ar.js
+++ b/src/ar.js
@@ -5,8 +5,67 @@
  * implements. This file exists purely so `n2words/ar` works without
  * requiring a region subtag; it is not a claim that ar-SA speaks for every
  * Arabic-speaking region. See LANGUAGES.md's "Bare-tag aliases" section.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ar-SA.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ar-SA — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ar-SA.js'
 
 export const aliasOf = 'ar-SA'
+
+/**
+ * Currency options for the bare `ar` entry point — ar-SA's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ar-SA.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ar-SA.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ar-SA currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ar-SA currency default except the currency itself.
+ * @type {Omit<Required<import('./ar-SA.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Arabic currency words.
+ *
+ * Unlike ar-SA's, this needs an explicit `currency`: `ar` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Arabic currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'SAR' }) // 'اثنان وأربعون ريالاً وخمسون هللة'
+ */
+function toCurrency(value, options) {
+  // Run ar-SA's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ar names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ar-SA')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/az.js
+++ b/src/az.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that az-AZ speaks
  * for every Azerbaijani-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './az-AZ.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from az-AZ — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './az-AZ.js'
 
 export const aliasOf = 'az-AZ'
+
+/**
+ * Currency options for the bare `az` entry point — az-AZ's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./az-AZ.js').CurrencyOptions, 'currency'> & Required<Pick<import('./az-AZ.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new az-AZ currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every az-AZ currency default except the currency itself.
+ * @type {Omit<Required<import('./az-AZ.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Azerbaijani currency words.
+ *
+ * Unlike az-AZ's, this needs an explicit `currency`: `az` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Azerbaijani currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'AZN' }) // 'qırx iki manat əlli qəpik'
+ */
+function toCurrency(value, options) {
+  // Run az-AZ's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/az names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/az-AZ')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/bn.js
+++ b/src/bn.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that bn-BD speaks
  * for every Bangla-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './bn-BD.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from bn-BD — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './bn-BD.js'
 
 export const aliasOf = 'bn-BD'
+
+/**
+ * Currency options for the bare `bn` entry point — bn-BD's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./bn-BD.js').CurrencyOptions, 'currency'> & Required<Pick<import('./bn-BD.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new bn-BD currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every bn-BD currency default except the currency itself.
+ * @type {Omit<Required<import('./bn-BD.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Bangla currency words.
+ *
+ * Unlike bn-BD's, this needs an explicit `currency`: `bn` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Bangla currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'BDT' }) // 'বেয়াল্লিশ টাকা পঞ্চাশ পয়সা'
+ */
+function toCurrency(value, options) {
+  // Run bn-BD's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/bn names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/bn-BD')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/cs.js
+++ b/src/cs.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that cs-CZ speaks
  * for every Czech-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './cs-CZ.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from cs-CZ — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './cs-CZ.js'
 
 export const aliasOf = 'cs-CZ'
+
+/**
+ * Currency options for the bare `cs` entry point — cs-CZ's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./cs-CZ.js').CurrencyOptions, 'currency'> & Required<Pick<import('./cs-CZ.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new cs-CZ currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every cs-CZ currency default except the currency itself.
+ * @type {Omit<Required<import('./cs-CZ.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Czech currency words.
+ *
+ * Unlike cs-CZ's, this needs an explicit `currency`: `cs` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Czech currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'CZK' }) // 'čtyřicet dva koruny padesát haléřů'
+ */
+function toCurrency(value, options) {
+  // Run cs-CZ's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/cs names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/cs-CZ')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/da.js
+++ b/src/da.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that da-DK speaks
  * for every Danish-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './da-DK.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from da-DK — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './da-DK.js'
 
 export const aliasOf = 'da-DK'
+
+/**
+ * Currency options for the bare `da` entry point — da-DK's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./da-DK.js').CurrencyOptions, 'currency'> & Required<Pick<import('./da-DK.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new da-DK currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every da-DK currency default except the currency itself.
+ * @type {Omit<Required<import('./da-DK.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Danish currency words.
+ *
+ * Unlike da-DK's, this needs an explicit `currency`: `da` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Danish currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'DKK' }) // 'toogfyrre kroner og halvtreds øre'
+ */
+function toCurrency(value, options) {
+  // Run da-DK's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/da names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/da-DK')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/de.js
+++ b/src/de.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that de-DE speaks
  * for every German-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './de-DE.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from de-DE — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './de-DE.js'
 
 export const aliasOf = 'de-DE'
+
+/**
+ * Currency options for the bare `de` entry point — de-DE's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./de-DE.js').CurrencyOptions, 'currency'> & Required<Pick<import('./de-DE.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new de-DE currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every de-DE currency default except the currency itself.
+ * @type {Omit<Required<import('./de-DE.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to German currency words.
+ *
+ * Unlike de-DE's, this needs an explicit `currency`: `de` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in German currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'zweiundvierzig Euro und fünfzig Cent'
+ */
+function toCurrency(value, options) {
+  // Run de-DE's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/de names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/de-DE')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/el.js
+++ b/src/el.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that el-GR speaks
  * for every Greek-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './el-GR.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from el-GR — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './el-GR.js'
 
 export const aliasOf = 'el-GR'
+
+/**
+ * Currency options for the bare `el` entry point — el-GR's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./el-GR.js').CurrencyOptions, 'currency'> & Required<Pick<import('./el-GR.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new el-GR currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every el-GR currency default except the currency itself.
+ * @type {Omit<Required<import('./el-GR.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Greek currency words.
+ *
+ * Unlike el-GR's, this needs an explicit `currency`: `el` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Greek currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'σαράντα δύο ευρώ πενήντα λεπτά'
+ */
+function toCurrency(value, options) {
+  // Run el-GR's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/el names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/el-GR')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/en.js
+++ b/src/en.js
@@ -9,8 +9,67 @@
  * proved to be a near-duplicate of). It does NOT speak for en-GB, en-CA,
  * en-IN, or any other regional variant — see LANGUAGES.md's "Bare-tag
  * aliases" section for the full rationale.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './en-US.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from en-US — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './en-US.js'
 
 export const aliasOf = 'en-US'
+
+/**
+ * Currency options for the bare `en` entry point — en-US's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./en-US.js').CurrencyOptions, 'currency'> & Required<Pick<import('./en-US.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new en-US currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every en-US currency default except the currency itself.
+ * @type {Omit<Required<import('./en-US.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to English currency words.
+ *
+ * Unlike en-US's, this needs an explicit `currency`: `en` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in English currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'USD' }) // 'forty-two dollars and fifty cents'
+ */
+function toCurrency(value, options) {
+  // Run en-US's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/en names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/en-US')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/es.js
+++ b/src/es.js
@@ -10,8 +10,67 @@
  * It does NOT speak for es-MX or es-US — a caller who cares about Mexican
  * or US Spanish currency/grammar should import that variant explicitly.
  * See LANGUAGES.md's "Bare-tag aliases" section for the full rationale.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './es-ES.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from es-ES — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './es-ES.js'
 
 export const aliasOf = 'es-ES'
+
+/**
+ * Currency options for the bare `es` entry point — es-ES's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./es-ES.js').CurrencyOptions, 'currency'> & Required<Pick<import('./es-ES.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new es-ES currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every es-ES currency default except the currency itself.
+ * @type {Omit<Required<import('./es-ES.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Spanish currency words.
+ *
+ * Unlike es-ES's, this needs an explicit `currency`: `es` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Spanish currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'cuarenta y dos euros con cincuenta céntimos'
+ */
+function toCurrency(value, options) {
+  // Run es-ES's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/es names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/es-ES')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/fa.js
+++ b/src/fa.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that fa-IR speaks
  * for every Persian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './fa-IR.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from fa-IR — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fa-IR.js'
 
 export const aliasOf = 'fa-IR'
+
+/**
+ * Currency options for the bare `fa` entry point — fa-IR's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./fa-IR.js').CurrencyOptions, 'currency'> & Required<Pick<import('./fa-IR.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new fa-IR currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every fa-IR currency default except the currency itself.
+ * @type {Omit<Required<import('./fa-IR.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Persian currency words.
+ *
+ * Unlike fa-IR's, this needs an explicit `currency`: `fa` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Persian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42, { currency: 'IRR' }) // 'چهل و دو ریال'
+ */
+function toCurrency(value, options) {
+  // Run fa-IR's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/fa names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/fa-IR')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/fi.js
+++ b/src/fi.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that fi-FI speaks
  * for every Finnish-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './fi-FI.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from fi-FI — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fi-FI.js'
 
 export const aliasOf = 'fi-FI'
+
+/**
+ * Currency options for the bare `fi` entry point — fi-FI's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./fi-FI.js').CurrencyOptions, 'currency'> & Required<Pick<import('./fi-FI.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new fi-FI currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every fi-FI currency default except the currency itself.
+ * @type {Omit<Required<import('./fi-FI.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Finnish currency words.
+ *
+ * Unlike fi-FI's, this needs an explicit `currency`: `fi` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Finnish currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'neljäkymmentäkaksi euroa viisikymmentä senttiä'
+ */
+function toCurrency(value, options) {
+  // Run fi-FI's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/fi names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/fi-FI')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/fil.js
+++ b/src/fil.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that fil-PH speaks
  * for every Filipino-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './fil-PH.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from fil-PH — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fil-PH.js'
 
 export const aliasOf = 'fil-PH'
+
+/**
+ * Currency options for the bare `fil` entry point — fil-PH's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./fil-PH.js').CurrencyOptions, 'currency'> & Required<Pick<import('./fil-PH.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new fil-PH currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every fil-PH currency default except the currency itself.
+ * @type {Omit<Required<import('./fil-PH.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Filipino currency words.
+ *
+ * Unlike fil-PH's, this needs an explicit `currency`: `fil` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Filipino currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'PHP' }) // 'apatnapu dalawang piso at limampung sentimo'
+ */
+function toCurrency(value, options) {
+  // Run fil-PH's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/fil names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/fil-PH')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/fr.js
+++ b/src/fr.js
@@ -8,8 +8,67 @@
  * subtag, defaulting to fr-FR (the most widely used variant). It does NOT
  * speak for fr-BE or any other regional variant — see LANGUAGES.md's
  * "Bare-tag aliases" section for the full rationale.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './fr-FR.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from fr-FR — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fr-FR.js'
 
 export const aliasOf = 'fr-FR'
+
+/**
+ * Currency options for the bare `fr` entry point — fr-FR's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./fr-FR.js').CurrencyOptions, 'currency'> & Required<Pick<import('./fr-FR.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new fr-FR currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every fr-FR currency default except the currency itself.
+ * @type {Omit<Required<import('./fr-FR.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to French currency words.
+ *
+ * Unlike fr-FR's, this needs an explicit `currency`: `fr` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in French currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'quarante-deux euros et cinquante centimes'
+ */
+function toCurrency(value, options) {
+  // Run fr-FR's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/fr names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/fr-FR')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/gu.js
+++ b/src/gu.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that gu-IN speaks
  * for every Gujarati-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './gu-IN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from gu-IN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './gu-IN.js'
 
 export const aliasOf = 'gu-IN'
+
+/**
+ * Currency options for the bare `gu` entry point — gu-IN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./gu-IN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./gu-IN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new gu-IN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every gu-IN currency default except the currency itself.
+ * @type {Omit<Required<import('./gu-IN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Gujarati currency words.
+ *
+ * Unlike gu-IN's, this needs an explicit `currency`: `gu` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Gujarati currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'INR' }) // 'બેતાળીસ રૂપિયા પચાસ પૈસા'
+ */
+function toCurrency(value, options) {
+  // Run gu-IN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/gu names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/gu-IN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ha.js
+++ b/src/ha.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ha-NG speaks
  * for every Hausa-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ha-NG.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ha-NG — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ha-NG.js'
 
 export const aliasOf = 'ha-NG'
+
+/**
+ * Currency options for the bare `ha` entry point — ha-NG's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ha-NG.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ha-NG.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ha-NG currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ha-NG currency default except the currency itself.
+ * @type {Omit<Required<import('./ha-NG.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Hausa currency words.
+ *
+ * Unlike ha-NG's, this needs an explicit `currency`: `ha` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Hausa currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'NGN' }) // 'arba\'in da biyu naira da hamsin kobo'
+ */
+function toCurrency(value, options) {
+  // Run ha-NG's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ha names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ha-NG')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/hbo.js
+++ b/src/hbo.js
@@ -5,8 +5,67 @@
  * package implements. This file exists purely so `n2words/hbo` works
  * without requiring a region subtag. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './hbo-IL.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from hbo-IL — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hbo-IL.js'
 
 export const aliasOf = 'hbo-IL'
+
+/**
+ * Currency options for the bare `hbo` entry point — hbo-IL's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./hbo-IL.js').CurrencyOptions, 'currency'> & Required<Pick<import('./hbo-IL.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new hbo-IL currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every hbo-IL currency default except the currency itself.
+ * @type {Omit<Required<import('./hbo-IL.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Biblical Hebrew currency words.
+ *
+ * Unlike hbo-IL's, this needs an explicit `currency`: `hbo` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Biblical Hebrew currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'ILS' }) // 'ארבעים ושניים שקלים חמישים גרות'
+ */
+function toCurrency(value, options) {
+  // Run hbo-IL's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/hbo names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/hbo-IL')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/he.js
+++ b/src/he.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that he-IL speaks
  * for every Hebrew-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './he-IL.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from he-IL — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './he-IL.js'
 
 export const aliasOf = 'he-IL'
+
+/**
+ * Currency options for the bare `he` entry point — he-IL's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./he-IL.js').CurrencyOptions, 'currency'> & Required<Pick<import('./he-IL.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new he-IL currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every he-IL currency default except the currency itself.
+ * @type {Omit<Required<import('./he-IL.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Hebrew currency words.
+ *
+ * Unlike he-IL's, this needs an explicit `currency`: `he` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Hebrew currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'ILS' }) // 'ארבעים ושניים שקלים חמישים אגורות'
+ */
+function toCurrency(value, options) {
+  // Run he-IL's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/he names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/he-IL')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/hi.js
+++ b/src/hi.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that hi-IN speaks
  * for every Hindi-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './hi-IN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from hi-IN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hi-IN.js'
 
 export const aliasOf = 'hi-IN'
+
+/**
+ * Currency options for the bare `hi` entry point — hi-IN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./hi-IN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./hi-IN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new hi-IN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every hi-IN currency default except the currency itself.
+ * @type {Omit<Required<import('./hi-IN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Hindi currency words.
+ *
+ * Unlike hi-IN's, this needs an explicit `currency`: `hi` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Hindi currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'INR' }) // 'बयालीस रुपये पचास पैसे'
+ */
+function toCurrency(value, options) {
+  // Run hi-IN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/hi names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/hi-IN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/hr.js
+++ b/src/hr.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that hr-HR speaks
  * for every Croatian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './hr-HR.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from hr-HR — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hr-HR.js'
 
 export const aliasOf = 'hr-HR'
+
+/**
+ * Currency options for the bare `hr` entry point — hr-HR's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./hr-HR.js').CurrencyOptions, 'currency'> & Required<Pick<import('./hr-HR.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new hr-HR currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every hr-HR currency default except the currency itself.
+ * @type {Omit<Required<import('./hr-HR.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Croatian currency words.
+ *
+ * Unlike hr-HR's, this needs an explicit `currency`: `hr` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Croatian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'četrdeset dva eura pedeset centi'
+ */
+function toCurrency(value, options) {
+  // Run hr-HR's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/hr names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/hr-HR')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/hu.js
+++ b/src/hu.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that hu-HU speaks
  * for every Hungarian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './hu-HU.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from hu-HU — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hu-HU.js'
 
 export const aliasOf = 'hu-HU'
+
+/**
+ * Currency options for the bare `hu` entry point — hu-HU's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./hu-HU.js').CurrencyOptions, 'currency'> & Required<Pick<import('./hu-HU.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new hu-HU currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every hu-HU currency default except the currency itself.
+ * @type {Omit<Required<import('./hu-HU.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Hungarian currency words.
+ *
+ * Unlike hu-HU's, this needs an explicit `currency`: `hu` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Hungarian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'HUF' }) // 'negyvenkettő forint ötven fillér'
+ */
+function toCurrency(value, options) {
+  // Run hu-HU's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/hu names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/hu-HU')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/id.js
+++ b/src/id.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that id-ID speaks
  * for every Indonesian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './id-ID.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from id-ID — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './id-ID.js'
 
 export const aliasOf = 'id-ID'
+
+/**
+ * Currency options for the bare `id` entry point — id-ID's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./id-ID.js').CurrencyOptions, 'currency'> & Required<Pick<import('./id-ID.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new id-ID currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every id-ID currency default except the currency itself.
+ * @type {Omit<Required<import('./id-ID.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Indonesian currency words.
+ *
+ * Unlike id-ID's, this needs an explicit `currency`: `id` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Indonesian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42, { currency: 'IDR' }) // 'empat puluh dua rupiah'
+ */
+function toCurrency(value, options) {
+  // Run id-ID's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/id names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/id-ID')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/it.js
+++ b/src/it.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that it-IT speaks
  * for every Italian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './it-IT.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from it-IT — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './it-IT.js'
 
 export const aliasOf = 'it-IT'
+
+/**
+ * Currency options for the bare `it` entry point — it-IT's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./it-IT.js').CurrencyOptions, 'currency'> & Required<Pick<import('./it-IT.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new it-IT currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every it-IT currency default except the currency itself.
+ * @type {Omit<Required<import('./it-IT.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Italian currency words.
+ *
+ * Unlike it-IT's, this needs an explicit `currency`: `it` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Italian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'quarantadue euro e cinquanta centesimi'
+ */
+function toCurrency(value, options) {
+  // Run it-IT's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/it names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/it-IT')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ja.js
+++ b/src/ja.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ja-JP speaks
  * for every Japanese-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ja-JP.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ja-JP — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ja-JP.js'
 
 export const aliasOf = 'ja-JP'
+
+/**
+ * Currency options for the bare `ja` entry point — ja-JP's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ja-JP.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ja-JP.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ja-JP currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ja-JP currency default except the currency itself.
+ * @type {Omit<Required<import('./ja-JP.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Japanese currency words.
+ *
+ * Unlike ja-JP's, this needs an explicit `currency`: `ja` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Japanese currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42, { currency: 'JPY' }) // '四十二円'
+ */
+function toCurrency(value, options) {
+  // Run ja-JP's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ja names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ja-JP')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ka.js
+++ b/src/ka.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ka-GE speaks
  * for every Georgian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ka-GE.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ka-GE — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ka-GE.js'
 
 export const aliasOf = 'ka-GE'
+
+/**
+ * Currency options for the bare `ka` entry point — ka-GE's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ka-GE.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ka-GE.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ka-GE currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ka-GE currency default except the currency itself.
+ * @type {Omit<Required<import('./ka-GE.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Georgian currency words.
+ *
+ * Unlike ka-GE's, this needs an explicit `currency`: `ka` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Georgian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'GEL' }) // 'ორმოცდაორი ლარი ორმოცდაათი თეთრი'
+ */
+function toCurrency(value, options) {
+  // Run ka-GE's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ka names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ka-GE')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/kn.js
+++ b/src/kn.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that kn-IN speaks
  * for every Kannada-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './kn-IN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from kn-IN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './kn-IN.js'
 
 export const aliasOf = 'kn-IN'
+
+/**
+ * Currency options for the bare `kn` entry point — kn-IN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./kn-IN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./kn-IN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new kn-IN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every kn-IN currency default except the currency itself.
+ * @type {Omit<Required<import('./kn-IN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Kannada currency words.
+ *
+ * Unlike kn-IN's, this needs an explicit `currency`: `kn` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Kannada currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'INR' }) // 'ನಲವತ್ತೆರಡು ರೂಪಾಯಿಗಳು ಐವತ್ತು ಪೈಸೆಗಳು'
+ */
+function toCurrency(value, options) {
+  // Run kn-IN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/kn names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/kn-IN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ko.js
+++ b/src/ko.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ko-KR speaks
  * for every Korean-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ko-KR.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ko-KR — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ko-KR.js'
 
 export const aliasOf = 'ko-KR'
+
+/**
+ * Currency options for the bare `ko` entry point — ko-KR's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ko-KR.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ko-KR.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ko-KR currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ko-KR currency default except the currency itself.
+ * @type {Omit<Required<import('./ko-KR.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Korean currency words.
+ *
+ * Unlike ko-KR's, this needs an explicit `currency`: `ko` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Korean currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42, { currency: 'KRW' }) // '사십이원'
+ */
+function toCurrency(value, options) {
+  // Run ko-KR's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ko names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ko-KR')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/lt.js
+++ b/src/lt.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that lt-LT speaks
  * for every Lithuanian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './lt-LT.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from lt-LT — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './lt-LT.js'
 
 export const aliasOf = 'lt-LT'
+
+/**
+ * Currency options for the bare `lt` entry point — lt-LT's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./lt-LT.js').CurrencyOptions, 'currency'> & Required<Pick<import('./lt-LT.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new lt-LT currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every lt-LT currency default except the currency itself.
+ * @type {Omit<Required<import('./lt-LT.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Lithuanian currency words.
+ *
+ * Unlike lt-LT's, this needs an explicit `currency`: `lt` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Lithuanian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'keturiasdešimt du eurai penkiasdešimt centų'
+ */
+function toCurrency(value, options) {
+  // Run lt-LT's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/lt names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/lt-LT')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/lv.js
+++ b/src/lv.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that lv-LV speaks
  * for every Latvian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './lv-LV.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from lv-LV — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './lv-LV.js'
 
 export const aliasOf = 'lv-LV'
+
+/**
+ * Currency options for the bare `lv` entry point — lv-LV's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./lv-LV.js').CurrencyOptions, 'currency'> & Required<Pick<import('./lv-LV.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new lv-LV currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every lv-LV currency default except the currency itself.
+ * @type {Omit<Required<import('./lv-LV.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Latvian currency words.
+ *
+ * Unlike lv-LV's, this needs an explicit `currency`: `lv` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Latvian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'četrdesmit divi eiro piecdesmit centu'
+ */
+function toCurrency(value, options) {
+  // Run lv-LV's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/lv names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/lv-LV')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/mr.js
+++ b/src/mr.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that mr-IN speaks
  * for every Marathi-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './mr-IN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from mr-IN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './mr-IN.js'
 
 export const aliasOf = 'mr-IN'
+
+/**
+ * Currency options for the bare `mr` entry point — mr-IN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./mr-IN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./mr-IN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new mr-IN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every mr-IN currency default except the currency itself.
+ * @type {Omit<Required<import('./mr-IN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Marathi currency words.
+ *
+ * Unlike mr-IN's, this needs an explicit `currency`: `mr` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Marathi currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'INR' }) // 'बेचाळीस रुपये पन्नास पैसे'
+ */
+function toCurrency(value, options) {
+  // Run mr-IN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/mr names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/mr-IN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ms.js
+++ b/src/ms.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ms-MY speaks
  * for every Malay-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ms-MY.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ms-MY — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ms-MY.js'
 
 export const aliasOf = 'ms-MY'
+
+/**
+ * Currency options for the bare `ms` entry point — ms-MY's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ms-MY.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ms-MY.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ms-MY currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ms-MY currency default except the currency itself.
+ * @type {Omit<Required<import('./ms-MY.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Malay currency words.
+ *
+ * Unlike ms-MY's, this needs an explicit `currency`: `ms` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Malay currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'MYR' }) // 'empat puluh dua ringgit lima puluh sen'
+ */
+function toCurrency(value, options) {
+  // Run ms-MY's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ms names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ms-MY')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/nb.js
+++ b/src/nb.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that nb-NO speaks
  * for every Norwegian Bokmål-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './nb-NO.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from nb-NO — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './nb-NO.js'
 
 export const aliasOf = 'nb-NO'
+
+/**
+ * Currency options for the bare `nb` entry point — nb-NO's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./nb-NO.js').CurrencyOptions, 'currency'> & Required<Pick<import('./nb-NO.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new nb-NO currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every nb-NO currency default except the currency itself.
+ * @type {Omit<Required<import('./nb-NO.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Norwegian Bokmål currency words.
+ *
+ * Unlike nb-NO's, this needs an explicit `currency`: `nb` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Norwegian Bokmål currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'NOK' }) // 'førti-to kroner og femti øre'
+ */
+function toCurrency(value, options) {
+  // Run nb-NO's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/nb names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/nb-NO')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/nl.js
+++ b/src/nl.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that nl-NL speaks
  * for every Dutch-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './nl-NL.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from nl-NL — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './nl-NL.js'
 
 export const aliasOf = 'nl-NL'
+
+/**
+ * Currency options for the bare `nl` entry point — nl-NL's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./nl-NL.js').CurrencyOptions, 'currency'> & Required<Pick<import('./nl-NL.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new nl-NL currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every nl-NL currency default except the currency itself.
+ * @type {Omit<Required<import('./nl-NL.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Dutch currency words.
+ *
+ * Unlike nl-NL's, this needs an explicit `currency`: `nl` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Dutch currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'EUR' }) // 'tweeënveertig euro en vijftig cent'
+ */
+function toCurrency(value, options) {
+  // Run nl-NL's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/nl names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/nl-NL')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/pa.js
+++ b/src/pa.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that pa-IN speaks
  * for every Punjabi-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './pa-IN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from pa-IN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './pa-IN.js'
 
 export const aliasOf = 'pa-IN'
+
+/**
+ * Currency options for the bare `pa` entry point — pa-IN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./pa-IN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./pa-IN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new pa-IN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every pa-IN currency default except the currency itself.
+ * @type {Omit<Required<import('./pa-IN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Punjabi currency words.
+ *
+ * Unlike pa-IN's, this needs an explicit `currency`: `pa` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Punjabi currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'INR' }) // 'ਬਿਆਲੀ ਰੁਪਏ ਪੰਜਾਹ ਪੈਸੇ'
+ */
+function toCurrency(value, options) {
+  // Run pa-IN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/pa names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/pa-IN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/pl.js
+++ b/src/pl.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that pl-PL speaks
  * for every Polish-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './pl-PL.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from pl-PL — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './pl-PL.js'
 
 export const aliasOf = 'pl-PL'
+
+/**
+ * Currency options for the bare `pl` entry point — pl-PL's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./pl-PL.js').CurrencyOptions, 'currency'> & Required<Pick<import('./pl-PL.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new pl-PL currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every pl-PL currency default except the currency itself.
+ * @type {Omit<Required<import('./pl-PL.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Polish currency words.
+ *
+ * Unlike pl-PL's, this needs an explicit `currency`: `pl` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Polish currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'PLN' }) // 'czterdzieści dwa złote pięćdziesiąt groszy'
+ */
+function toCurrency(value, options) {
+  // Run pl-PL's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/pl names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/pl-PL')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ro.js
+++ b/src/ro.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ro-RO speaks
  * for every Romanian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ro-RO.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ro-RO — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ro-RO.js'
 
 export const aliasOf = 'ro-RO'
+
+/**
+ * Currency options for the bare `ro` entry point — ro-RO's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ro-RO.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ro-RO.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ro-RO currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ro-RO currency default except the currency itself.
+ * @type {Omit<Required<import('./ro-RO.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Romanian currency words.
+ *
+ * Unlike ro-RO's, this needs an explicit `currency`: `ro` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Romanian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'RON' }) // 'patruzeci și doi de lei cincizeci de bani'
+ */
+function toCurrency(value, options) {
+  // Run ro-RO's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ro names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ro-RO')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ru.js
+++ b/src/ru.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ru-RU speaks
  * for every Russian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ru-RU.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ru-RU — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ru-RU.js'
 
 export const aliasOf = 'ru-RU'
+
+/**
+ * Currency options for the bare `ru` entry point — ru-RU's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ru-RU.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ru-RU.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ru-RU currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ru-RU currency default except the currency itself.
+ * @type {Omit<Required<import('./ru-RU.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Russian currency words.
+ *
+ * Unlike ru-RU's, this needs an explicit `currency`: `ru` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Russian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'RUB' }) // 'сорок два рубля и пятьдесят копеек'
+ */
+function toCurrency(value, options) {
+  // Run ru-RU's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ru names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ru-RU')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/sv.js
+++ b/src/sv.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that sv-SE speaks
  * for every Swedish-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './sv-SE.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from sv-SE — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './sv-SE.js'
 
 export const aliasOf = 'sv-SE'
+
+/**
+ * Currency options for the bare `sv` entry point — sv-SE's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./sv-SE.js').CurrencyOptions, 'currency'> & Required<Pick<import('./sv-SE.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new sv-SE currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every sv-SE currency default except the currency itself.
+ * @type {Omit<Required<import('./sv-SE.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Swedish currency words.
+ *
+ * Unlike sv-SE's, this needs an explicit `currency`: `sv` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Swedish currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'SEK' }) // 'fyrtio-två kronor och femtio öre'
+ */
+function toCurrency(value, options) {
+  // Run sv-SE's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/sv names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/sv-SE')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/sw.js
+++ b/src/sw.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that sw-KE speaks
  * for every Swahili-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './sw-KE.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from sw-KE — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './sw-KE.js'
 
 export const aliasOf = 'sw-KE'
+
+/**
+ * Currency options for the bare `sw` entry point — sw-KE's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./sw-KE.js').CurrencyOptions, 'currency'> & Required<Pick<import('./sw-KE.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new sw-KE currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every sw-KE currency default except the currency itself.
+ * @type {Omit<Required<import('./sw-KE.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Swahili currency words.
+ *
+ * Unlike sw-KE's, this needs an explicit `currency`: `sw` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Swahili currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'KES' }) // 'shilingi arobaini na mbili na senti hamsini'
+ */
+function toCurrency(value, options) {
+  // Run sw-KE's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/sw names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/sw-KE')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ta.js
+++ b/src/ta.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ta-IN speaks
  * for every Tamil-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ta-IN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ta-IN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ta-IN.js'
 
 export const aliasOf = 'ta-IN'
+
+/**
+ * Currency options for the bare `ta` entry point — ta-IN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ta-IN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ta-IN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ta-IN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ta-IN currency default except the currency itself.
+ * @type {Omit<Required<import('./ta-IN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Tamil currency words.
+ *
+ * Unlike ta-IN's, this needs an explicit `currency`: `ta` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Tamil currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'INR' }) // 'நாற்பத்திரண்டு ரூபாய் ஐம்பது பைசா'
+ */
+function toCurrency(value, options) {
+  // Run ta-IN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ta names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ta-IN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/te.js
+++ b/src/te.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that te-IN speaks
  * for every Telugu-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './te-IN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from te-IN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './te-IN.js'
 
 export const aliasOf = 'te-IN'
+
+/**
+ * Currency options for the bare `te` entry point — te-IN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./te-IN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./te-IN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new te-IN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every te-IN currency default except the currency itself.
+ * @type {Omit<Required<import('./te-IN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Telugu currency words.
+ *
+ * Unlike te-IN's, this needs an explicit `currency`: `te` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Telugu currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'INR' }) // 'నలభై రెండు రూపాయలు యాభై పైసలు'
+ */
+function toCurrency(value, options) {
+  // Run te-IN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/te names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/te-IN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/th.js
+++ b/src/th.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that th-TH speaks
  * for every Thai-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './th-TH.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from th-TH — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './th-TH.js'
 
 export const aliasOf = 'th-TH'
+
+/**
+ * Currency options for the bare `th` entry point — th-TH's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./th-TH.js').CurrencyOptions, 'currency'> & Required<Pick<import('./th-TH.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new th-TH currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every th-TH currency default except the currency itself.
+ * @type {Omit<Required<import('./th-TH.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Thai currency words.
+ *
+ * Unlike th-TH's, this needs an explicit `currency`: `th` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Thai currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'THB' }) // 'สี่สิบสองบาทห้าสิบสตางค์'
+ */
+function toCurrency(value, options) {
+  // Run th-TH's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/th names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/th-TH')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/tr.js
+++ b/src/tr.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that tr-TR speaks
  * for every Turkish-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './tr-TR.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from tr-TR — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './tr-TR.js'
 
 export const aliasOf = 'tr-TR'
+
+/**
+ * Currency options for the bare `tr` entry point — tr-TR's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./tr-TR.js').CurrencyOptions, 'currency'> & Required<Pick<import('./tr-TR.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new tr-TR currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every tr-TR currency default except the currency itself.
+ * @type {Omit<Required<import('./tr-TR.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Turkish currency words.
+ *
+ * Unlike tr-TR's, this needs an explicit `currency`: `tr` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Turkish currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'TRY' }) // 'kırk iki lira elli kuruş'
+ */
+function toCurrency(value, options) {
+  // Run tr-TR's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/tr names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/tr-TR')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/uk.js
+++ b/src/uk.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that uk-UA speaks
  * for every Ukrainian-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './uk-UA.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from uk-UA — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './uk-UA.js'
 
 export const aliasOf = 'uk-UA'
+
+/**
+ * Currency options for the bare `uk` entry point — uk-UA's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./uk-UA.js').CurrencyOptions, 'currency'> & Required<Pick<import('./uk-UA.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new uk-UA currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every uk-UA currency default except the currency itself.
+ * @type {Omit<Required<import('./uk-UA.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Ukrainian currency words.
+ *
+ * Unlike uk-UA's, this needs an explicit `currency`: `uk` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Ukrainian currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'UAH' }) // 'сорок двi гривнi п\'ятдесят копiйок'
+ */
+function toCurrency(value, options) {
+  // Run uk-UA's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/uk names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/uk-UA')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/ur.js
+++ b/src/ur.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that ur-PK speaks
  * for every Urdu-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './ur-PK.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from ur-PK — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ur-PK.js'
 
 export const aliasOf = 'ur-PK'
+
+/**
+ * Currency options for the bare `ur` entry point — ur-PK's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./ur-PK.js').CurrencyOptions, 'currency'> & Required<Pick<import('./ur-PK.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new ur-PK currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every ur-PK currency default except the currency itself.
+ * @type {Omit<Required<import('./ur-PK.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Urdu currency words.
+ *
+ * Unlike ur-PK's, this needs an explicit `currency`: `ur` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Urdu currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'PKR' }) // 'بیالیس روپے پچاس پیسے'
+ */
+function toCurrency(value, options) {
+  // Run ur-PK's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/ur names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/ur-PK')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/vi.js
+++ b/src/vi.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that vi-VN speaks
  * for every Vietnamese-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './vi-VN.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from vi-VN — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './vi-VN.js'
 
 export const aliasOf = 'vi-VN'
+
+/**
+ * Currency options for the bare `vi` entry point — vi-VN's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./vi-VN.js').CurrencyOptions, 'currency'> & Required<Pick<import('./vi-VN.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new vi-VN currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every vi-VN currency default except the currency itself.
+ * @type {Omit<Required<import('./vi-VN.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Vietnamese currency words.
+ *
+ * Unlike vi-VN's, this needs an explicit `currency`: `vi` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Vietnamese currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42, { currency: 'VND' }) // 'bốn mươi hai đồng'
+ */
+function toCurrency(value, options) {
+  // Run vi-VN's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/vi names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/vi-VN')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/src/yo.js
+++ b/src/yo.js
@@ -6,8 +6,67 @@
  * without requiring a region subtag; it is not a claim that yo-NG speaks
  * for every Yoruba-speaking region. See docs/bare-tag-aliases.md for the
  * full rationale and LANGUAGES.md for the complete family/variant table.
+ *
+ * `toCurrency` is the one form this file doesn't forward untouched: a bare
+ * tag names a language, and a default currency belongs to a country, so
+ * `currency` is required here rather than inherited. See
+ * docs/bare-tag-aliases.md's "Bare tags carry no default currency".
  */
 
+import { resolveOptions } from './utils/resolve-options.js'
+import { toCurrency as toCurrencyBase, currencyDefaults as baseCurrencyDefaults, currencyValues } from './yo-NG.js'
+
+// currencyDefaults and toCurrency are deliberately re-declared below,
+// shadowing the star-exported ones from yo-NG — the same mechanism a locale
+// profile uses to override a default (see docs/language-layers.md). A local
+// export legally overrides a star-export of the same name; this isn't a
+// naming collision.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './yo-NG.js'
 
 export const aliasOf = 'yo-NG'
+
+/**
+ * Currency options for the bare `yo` entry point — yo-NG's, but with
+ * `currency` required instead of defaulted.
+ * @typedef {Omit<import('./yo-NG.js').CurrencyOptions, 'currency'> & Required<Pick<import('./yo-NG.js').CurrencyOptions, 'currency'>>} CurrencyOptions
+ */
+
+// `currency` is named only so the rest element excludes it; derived rather than
+// hand-listed so a new yo-NG currency option can't silently go missing here.
+// eslint-disable-next-line no-unused-vars -- see above
+const { currency: _baseCurrency, ...baseDefaultsWithoutCurrency } = baseCurrencyDefaults
+
+/**
+ * Every yo-NG currency default except the currency itself.
+ * @type {Omit<Required<import('./yo-NG.js').CurrencyOptions>, 'currency'>}
+ */
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currencyDefaults = baseDefaultsWithoutCurrency
+
+/**
+ * Converts a numeric value to Yoruba currency words.
+ *
+ * Unlike yo-NG's, this needs an explicit `currency`: `yo` is a language
+ * and has no country to take a default from.
+ * @param {number | string | bigint} value - The currency amount to convert
+ * @param {CurrencyOptions} options - Configuration; `currency` is required
+ * @returns {string} The amount in Yoruba currency words
+ * @throws {TypeError} If `currency` is omitted, or options are malformed
+ * @example
+ * toCurrency(42.50, { currency: 'NGN' }) // 'èjì lé lógójì náírà àti àádọ́ta kọ́bọ̀'
+ */
+function toCurrency(value, options) {
+  // Run yo-NG's own options contract first so a malformed argument reports
+  // itself — an unknown key names the key, a bad currency lists the valid set
+  // — instead of being masked by the missing-currency error below. The base
+  // validates again on delegation; toCurrency isn't hot enough to care.
+  resolveOptions(options, baseCurrencyDefaults, currencyValues)
+  if (options?.currency === undefined) {
+    throw new TypeError('n2words/yo names a language, not a locale: toCurrency needs an explicit { currency }, or import a region-qualified entry point such as n2words/yo-NG')
+  }
+  return toCurrencyBase(value, options)
+}
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export { toCurrency }

--- a/test/bare-tag-contract.test.js
+++ b/test/bare-tag-contract.test.js
@@ -60,13 +60,18 @@ for (const [primary, variants] of byPrimary) {
   })
 }
 
-// Every named export an alias could plausibly forward — asserting identity
-// on all of them (not just the three forms) covers the range and options
-// contracts too, since `export *` should forward every binding equally.
+// Every named export an alias forwards untouched — asserting identity on all
+// of them (not just the two forms) covers the range and options contracts
+// too, since `export *` should forward every binding equally.
+//
+// `toCurrency` and `currencyDefaults` are deliberately absent: a bare tag
+// names a language and has no country to take a default currency from, so it
+// wraps toCurrency to require an explicit `currency` and strips that key from
+// its defaults. Both are asserted separately below.
 const REEXPORTED_KEYS = [
-  'toCardinal', 'toOrdinal', 'toCurrency',
+  'toCardinal', 'toOrdinal',
   'cardinalMax', 'ordinalMax', 'currencyMax',
-  'cardinalDefaults', 'ordinalDefaults', 'currencyDefaults',
+  'cardinalDefaults', 'ordinalDefaults',
   'cardinalValues', 'ordinalValues', 'currencyValues',
 ]
 
@@ -88,5 +93,79 @@ for (const code of aliasCodes) {
     for (const key of REEXPORTED_KEYS) {
       t.is(mod[key], targetMod[key], `${code}.${key} must be the exact same binding as ${target}.${key}`)
     }
+  })
+}
+
+// Compare a call by its result *or* its error type, so two functions that
+// both legitimately reject an input compare as equal without a conditional
+// assertion around the throwing case.
+const outcome = (fn) => {
+  try {
+    return fn()
+  }
+  catch (error) {
+    return `throws ${error.constructor.name}`
+  }
+}
+
+// A bare tag names a language; a default currency belongs to a country. An
+// alias therefore does NOT inherit its target's default currency — it requires
+// the caller to name one, and otherwise behaves exactly as the target does.
+// See docs/bare-tag-aliases.md's "Bare tags carry no default currency".
+for (const code of aliasCodes) {
+  const mod = mods.get(code)
+  const targetMod = mods.get(mod.aliasOf)
+  // Only families whose target actually declares a `currency` option have a
+  // default to strip. A language that hardcodes one currency (or exports no
+  // toCurrency at all) has nothing to inherit, so its alias stays a plain
+  // `export *` — and the moment that language gains a `currency` option, this
+  // gate starts requiring the wrapper.
+  if (typeof targetMod?.toCurrency !== 'function') continue
+  if (targetMod.currencyDefaults?.currency === undefined) continue
+
+  test(`${code} carries no default currency`, (t) => {
+    const target = mod.aliasOf
+
+    // The wrapper is a distinct function — an `export *` passthrough here
+    // would silently reinstate the target's default.
+    t.not(mod.toCurrency, targetMod.toCurrency, `${code}.toCurrency must wrap ${target}'s, not re-export it`)
+
+    // The declared contract must agree with the behaviour: no `currency` key
+    // in the alias's defaults, though the target still declares its own.
+    t.false(Object.hasOwn(mod.currencyDefaults, 'currency'), `${code}.currencyDefaults must not declare a default currency`)
+    t.true(Object.hasOwn(targetMod.currencyDefaults, 'currency'), `${target}.currencyDefaults should still declare its own default currency`)
+
+    // Every other option keeps the target's default, so the alias doesn't
+    // quietly drop an option while removing the currency.
+    for (const [key, value] of Object.entries(targetMod.currencyDefaults)) {
+      if (key === 'currency') continue
+      t.is(mod.currencyDefaults[key], value, `${code}.currencyDefaults.${key} must keep ${target}'s default`)
+    }
+
+    // Omitting the currency is a shape error, not an out-of-range value.
+    const missing = t.throws(() => mod.toCurrency(42.5), { instanceOf: TypeError }, `${code}.toCurrency() must throw without an explicit currency`)
+    t.true(missing?.message.includes(target), `${code}'s error should point at ${target} as the region-qualified alternative`)
+
+    // Given a currency, it must be the target function in every other respect.
+    // Compared through `outcome` so a currency the language legitimately
+    // rejects (a fractional amount in a currency with no minor unit) compares
+    // as equal-and-throwing rather than needing a conditional assertion.
+    for (const currency of targetMod.currencyValues.currency) {
+      t.is(
+        outcome(() => mod.toCurrency(42.5, { currency })),
+        outcome(() => targetMod.toCurrency(42.5, { currency })),
+        `${code}.toCurrency(42.5, { currency: '${currency}' }) must match ${target}'s`,
+      )
+    }
+
+    // Naming the target's own default must reproduce what the target produces
+    // with no options at all — the exact behaviour a caller gives up by
+    // importing the bare tag instead of the region-qualified code.
+    const { currency: targetDefault } = targetMod.currencyDefaults
+    t.is(
+      outcome(() => mod.toCurrency(42.5, { currency: targetDefault })),
+      outcome(() => targetMod.toCurrency(42.5)),
+      `${code}.toCurrency(42.5, { currency: '${targetDefault}' }) must equal ${target}.toCurrency(42.5)`,
+    )
   })
 }

--- a/test/fixtures/ar.js
+++ b/test/fixtures/ar.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ar-SA.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ar requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ar-SA's cases are
+// replayed with SAR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ar-SA.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'SAR')

--- a/test/fixtures/az.js
+++ b/test/fixtures/az.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './az-AZ.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/az requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). az-AZ's cases are
+// replayed with AZN named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './az-AZ.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'AZN')

--- a/test/fixtures/bn.js
+++ b/test/fixtures/bn.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './bn-BD.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/bn requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). bn-BD's cases are
+// replayed with BDT named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './bn-BD.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'BDT')

--- a/test/fixtures/cs.js
+++ b/test/fixtures/cs.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './cs-CZ.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/cs requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). cs-CZ's cases are
+// replayed with CZK named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './cs-CZ.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'CZK')

--- a/test/fixtures/da.js
+++ b/test/fixtures/da.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './da-DK.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/da requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). da-DK's cases are
+// replayed with DKK named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './da-DK.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'DKK')

--- a/test/fixtures/de.js
+++ b/test/fixtures/de.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './de-DE.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/de requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). de-DE's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './de-DE.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/el.js
+++ b/test/fixtures/el.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './el-GR.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/el requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). el-GR's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './el-GR.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/en.js
+++ b/test/fixtures/en.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './en-US.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/en requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). en-US's cases are
+// replayed with USD named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './en-US.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'USD')

--- a/test/fixtures/es.js
+++ b/test/fixtures/es.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './es-ES.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/es requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). es-ES's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './es-ES.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/fa.js
+++ b/test/fixtures/fa.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './fa-IR.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/fa requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). fa-IR's cases are
+// replayed with IRR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fa-IR.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'IRR')

--- a/test/fixtures/fi.js
+++ b/test/fixtures/fi.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './fi-FI.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/fi requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). fi-FI's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fi-FI.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/fil.js
+++ b/test/fixtures/fil.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './fil-PH.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/fil requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). fil-PH's cases are
+// replayed with PHP named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fil-PH.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'PHP')

--- a/test/fixtures/fr.js
+++ b/test/fixtures/fr.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './fr-FR.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/fr requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). fr-FR's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './fr-FR.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/gu.js
+++ b/test/fixtures/gu.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './gu-IN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/gu requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). gu-IN's cases are
+// replayed with INR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './gu-IN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'INR')

--- a/test/fixtures/ha.js
+++ b/test/fixtures/ha.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ha-NG.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ha requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ha-NG's cases are
+// replayed with NGN named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ha-NG.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'NGN')

--- a/test/fixtures/hbo.js
+++ b/test/fixtures/hbo.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './hbo-IL.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/hbo requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). hbo-IL's cases are
+// replayed with ILS named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hbo-IL.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'ILS')

--- a/test/fixtures/he.js
+++ b/test/fixtures/he.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './he-IL.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/he requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). he-IL's cases are
+// replayed with ILS named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './he-IL.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'ILS')

--- a/test/fixtures/hi.js
+++ b/test/fixtures/hi.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './hi-IN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/hi requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). hi-IN's cases are
+// replayed with INR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hi-IN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'INR')

--- a/test/fixtures/hr.js
+++ b/test/fixtures/hr.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './hr-HR.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/hr requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). hr-HR's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hr-HR.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/hu.js
+++ b/test/fixtures/hu.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './hu-HU.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/hu requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). hu-HU's cases are
+// replayed with HUF named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './hu-HU.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'HUF')

--- a/test/fixtures/id.js
+++ b/test/fixtures/id.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './id-ID.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/id requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). id-ID's cases are
+// replayed with IDR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './id-ID.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'IDR')

--- a/test/fixtures/it.js
+++ b/test/fixtures/it.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './it-IT.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/it requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). it-IT's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './it-IT.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/ja.js
+++ b/test/fixtures/ja.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ja-JP.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ja requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ja-JP's cases are
+// replayed with JPY named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ja-JP.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'JPY')

--- a/test/fixtures/ka.js
+++ b/test/fixtures/ka.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ka-GE.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ka requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ka-GE's cases are
+// replayed with GEL named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ka-GE.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'GEL')

--- a/test/fixtures/kn.js
+++ b/test/fixtures/kn.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './kn-IN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/kn requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). kn-IN's cases are
+// replayed with INR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './kn-IN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'INR')

--- a/test/fixtures/ko.js
+++ b/test/fixtures/ko.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ko-KR.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ko requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ko-KR's cases are
+// replayed with KRW named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ko-KR.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'KRW')

--- a/test/fixtures/lt.js
+++ b/test/fixtures/lt.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './lt-LT.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/lt requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). lt-LT's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './lt-LT.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/lv.js
+++ b/test/fixtures/lv.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './lv-LV.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/lv requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). lv-LV's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './lv-LV.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/mr.js
+++ b/test/fixtures/mr.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './mr-IN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/mr requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). mr-IN's cases are
+// replayed with INR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './mr-IN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'INR')

--- a/test/fixtures/ms.js
+++ b/test/fixtures/ms.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ms-MY.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ms requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ms-MY's cases are
+// replayed with MYR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ms-MY.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'MYR')

--- a/test/fixtures/nb.js
+++ b/test/fixtures/nb.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './nb-NO.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/nb requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). nb-NO's cases are
+// replayed with NOK named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './nb-NO.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'NOK')

--- a/test/fixtures/nl.js
+++ b/test/fixtures/nl.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './nl-NL.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/nl requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). nl-NL's cases are
+// replayed with EUR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './nl-NL.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'EUR')

--- a/test/fixtures/pa.js
+++ b/test/fixtures/pa.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './pa-IN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/pa requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). pa-IN's cases are
+// replayed with INR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './pa-IN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'INR')

--- a/test/fixtures/pl.js
+++ b/test/fixtures/pl.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './pl-PL.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/pl requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). pl-PL's cases are
+// replayed with PLN named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './pl-PL.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'PLN')

--- a/test/fixtures/ro.js
+++ b/test/fixtures/ro.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ro-RO.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ro requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ro-RO's cases are
+// replayed with RON named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ro-RO.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'RON')

--- a/test/fixtures/ru.js
+++ b/test/fixtures/ru.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ru-RU.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ru requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ru-RU's cases are
+// replayed with RUB named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ru-RU.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'RUB')

--- a/test/fixtures/sv.js
+++ b/test/fixtures/sv.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './sv-SE.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/sv requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). sv-SE's cases are
+// replayed with SEK named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './sv-SE.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'SEK')

--- a/test/fixtures/sw.js
+++ b/test/fixtures/sw.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './sw-KE.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/sw requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). sw-KE's cases are
+// replayed with KES named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './sw-KE.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'KES')

--- a/test/fixtures/ta.js
+++ b/test/fixtures/ta.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ta-IN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ta requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ta-IN's cases are
+// replayed with INR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ta-IN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'INR')

--- a/test/fixtures/te.js
+++ b/test/fixtures/te.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './te-IN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/te requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). te-IN's cases are
+// replayed with INR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './te-IN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'INR')

--- a/test/fixtures/th.js
+++ b/test/fixtures/th.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './th-TH.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/th requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). th-TH's cases are
+// replayed with THB named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './th-TH.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'THB')

--- a/test/fixtures/tr.js
+++ b/test/fixtures/tr.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './tr-TR.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/tr requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). tr-TR's cases are
+// replayed with TRY named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './tr-TR.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'TRY')

--- a/test/fixtures/uk.js
+++ b/test/fixtures/uk.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './uk-UA.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/uk requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). uk-UA's cases are
+// replayed with UAH named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './uk-UA.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'UAH')

--- a/test/fixtures/ur.js
+++ b/test/fixtures/ur.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './ur-PK.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/ur requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). ur-PK's cases are
+// replayed with PKR named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './ur-PK.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'PKR')

--- a/test/fixtures/vi.js
+++ b/test/fixtures/vi.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './vi-VN.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/vi requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). vi-VN's cases are
+// replayed with VND named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './vi-VN.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'VND')

--- a/test/fixtures/yo.js
+++ b/test/fixtures/yo.js
@@ -1,1 +1,14 @@
+import { currency as baseCurrency } from './yo-NG.js'
+import { withCurrency } from '../helpers/alias-fixtures.js'
+
+// n2words/yo requires an explicit currency — a bare tag names a language and
+// has no country to default from (docs/bare-tag-aliases.md). yo-NG's cases are
+// replayed with NGN named, so the alias is checked against the same expected
+// strings its target is, while the local `currency` below shadows the
+// star-exported one. That it *throws* without a currency is asserted in
+// test/bare-tag-contract.test.js, which the fixture format can't express.
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
 export * from './yo-NG.js'
+
+// eslint-disable-next-line import-x/export -- deliberate shadow, see comment above
+export const currency = withCurrency(baseCurrency, 'NGN')

--- a/test/helpers/alias-fixtures.js
+++ b/test/helpers/alias-fixtures.js
@@ -1,0 +1,27 @@
+/**
+ * Fixture helpers for bare-tag alias files.
+ *
+ * A bare-tag alias re-exports its target's fixtures wholesale
+ * (`export * from './de-DE.js'`), which is right for cardinal and ordinal —
+ * the alias forwards those bindings untouched, so replaying the target's
+ * cases proves the re-export works.
+ *
+ * Currency is the exception. A bare tag names a language and has no country
+ * to take a default currency from, so `n2words/de`'s toCurrency requires an
+ * explicit `currency` (see docs/bare-tag-aliases.md). The target's own cases
+ * pass no options, so they can't be replayed as-is.
+ * @module alias-fixtures
+ */
+
+/**
+ * Replay a target's currency cases with a currency named explicitly.
+ *
+ * The code goes in before the case's own options, so a case that already
+ * names a different currency keeps it rather than being overwritten.
+ * @param {Array<[number | string | bigint, string, object?]>} cases - The target's currency fixture cases
+ * @param {string} code - ISO 4217 code to name, normally the target's own default
+ * @returns {Array<[number | string | bigint, string, object]>} The same cases, each with `currency` set
+ */
+export function withCurrency(cases, code) {
+  return cases.map(([input, expected, options]) => [input, expected, { currency: code, ...options }])
+}


### PR DESCRIPTION
Stacked on #428, which is stacked on #434. **Review #434 → #428 → this.**

@TylerVigario flagged this on #428:

> `src/fr.js` re-exports `fr-FR`, whose `currencyDefaults` is `{ currency: 'EUR' }`, so
> `toCurrency` from the bare tag quietly returns euros for an `fr-CH` caller. […] Same
> shape for `en → USD` and `es → EUR`.

He's right, and it's worth stating as a rule rather than patching three files: **a bare tag
names a language; a default currency belongs to a country.**

`en-US` defaults to USD because a locale has a country and a country has a currency. `en`
has no country. Inheriting en-US's default meant `n2words/en`'s `toCurrency(42.50)` quietly
returned dollars to a caller who asked only for English — across sixteen variants spanning
USD, GBP, INR, KES, NGN and ZAR.

```js
import { toCurrency } from 'n2words/en'

toCurrency(42.50)                      // TypeError: names a language, not a locale
toCurrency(42.50, { currency: 'GBP' }) // 'forty-two pounds and fifty pence'
```

Region-qualified entry points are untouched — `n2words/en-US` still defaults to USD, which
is the whole point of the distinction. This is the same separation #428 makes between
numerals, currency words and locale defaults, applied one layer up.

## Why it's a separate PR

This is the part of #428 you asked for, so it shouldn't wait on the part still being
discussed (the vocab tree-shaking question). #428 is now 96 files of currency matrix; this
is 97 files of bare-tag rule; #434 is 101 files of entry points. Each reviewable alone.

It couldn't go in #434 either: the `currency` option doesn't exist until #428 — on `main`
today `toCurrency` hardcodes one currency per language, so there's no default to remove.

## Applies to all 46 aliases, not just the divergent families

`de` looks safe because de-DE is the only German variant here — but German is also spoken
in Austria and Switzerland, and CHF is not EUR. The rule holds because of what a language
tag *is*, not which variants happen to be implemented today. (Note `fr` was the weakest of
the three examples: fr-FR and fr-BE really are both EUR, and `fr-CH` isn't shipped. The
rule covers it anyway.)

## Three details worth a look

- **`currencyDefaults` is derived, not hand-listed** — every option other than `currency`
  keeps the target's default, so an option added to a target later can't silently go
  missing from its bare tag.
- **The target's options contract runs first** — `resolveOptions` is called before the
  missing-currency check, so a typo'd key reports itself (`Unknown option "currencey"`)
  instead of being masked. `TypeError` for both: `resolve-options.js` reserves `TypeError`
  for shape errors and `RangeError` for values outside a declared set, and an absent
  required option is a shape error.
- **A language with no `currency` option has nothing to strip** — its alias stays a plain
  `export *`, and the gate keys off exactly that condition, so the wrapper becomes
  mandatory the moment such a language gains the option.

## Gate

`test/bare-tag-contract.test.js` drops `toCurrency`/`currencyDefaults` from the blanket
identity list (the other ten keys still assert `===`) and asserts the real contract: the
wrapper is a distinct function, no `currency` key in defaults, every *other* default kept,
`TypeError` naming the region-qualified alternative, and per-currency output parity with
the target.

Alias fixtures replay the target's currency cases through a new `withCurrency()` helper —
the fixture format has no expect-throw shape, so "throws without a currency" lives in the
gate instead.

## Verification

- `npm test` — 808 passing (762 on #428 + 46 new gate tests)
- `npm run lint` — clean
- `npm run docs:languages` — regenerates byte-identical
- Every one of the 46 aliases checked for: no advertised default, `TypeError` without a
  currency, per-currency parity with its target, and `toCardinal`/`toOrdinal` still
  reference-identical

## Breaking

`toCurrency()` through a bare tag now throws `TypeError` unless `currency` is named. Pass
one, or import the region-qualified entry point to keep a default. Ships in the same major
as #428.