### PR TITLE
feat(cli): add a shipped n2words command

### DIFF
--- a/.commitlintrc.mjs
+++ b/.commitlintrc.mjs
@@ -50,6 +50,7 @@
 const PROJECT_SCOPES = [
   // Code Areas
   'core', // src/* - language files and shared utilities
+  'cli', // bin/* - the shipped n2words command
 
   // Build & Distribution
   'esm', // ESM bundle output (dist/*.js)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,10 @@ jobs:
   lint:
     name: Lint & Security
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # The job's own work (actionlint, audit, eslint, tsc) runs in well under a
+    # minute; the budget exists for `npm ci`, which is unpredictable whenever a
+    # lockfile change invalidates the setup-node cache. 10 matches the test jobs.
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -17,7 +17,9 @@ jobs:
   validate:
     name: Validate PR Title
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # Linting the title is instant; the budget is entirely for `npm ci`, which
+    # installs commitlint from the lockfile. See the CI lint job's note.
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,12 +229,15 @@ jobs:
         if: steps.version.outputs.skip != 'true'
         run: |
           VERSION=${{ steps.version.outputs.version }}
-          mkdir -p n2words-${VERSION}/{src,dist}
+          mkdir -p n2words-${VERSION}/{src,dist,bin}
           # Recursive copy so the zip mirrors the npm package's src/ tree —
           # a flat `src/*.js src/*.d.ts` glob silently drops src/utils/ (its
           # .js + .d.ts), which the package's `src/**/*.js` + `src/**/*.d.ts`
-          # files globs ship.
+          # files globs ship. Same reason bin/ is copied recursively: the CLI
+          # is a shipped entry point (package.json `bin`), and bin/lib/ would
+          # be dropped by a flat glob.
           cp -r src/. n2words-${VERSION}/src/
+          cp -r bin/. n2words-${VERSION}/bin/
           cp dist/*.js n2words-${VERSION}/dist/
           zip -r n2words-${VERSION}.zip n2words-${VERSION}/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,9 @@ n2words: Number to words converter. ESM + UMD, Node >=22, zero dependencies.
 ## Project Structure
 
 ```text
+bin/
+├── n2words.js           # The shipped `n2words` command (package.json `bin`)
+└── lib/                 # Arg parsing, language loading, output rendering
 src/
 ├── {lang-code}.js       # Full implementations: one per numerally-distinct variant (59)
 ├── {lang-code}.js       # Locale profiles (13): `export * from './{base}.js'` + `variantOf`,
@@ -269,6 +272,32 @@ build step of its own — `scripts/build-site.js` assembles `_site/` from three 
 picker entry, an options panel and a table row on the next deploy. Option metadata comes from
 `scripts/lib/options-index.js`, shared with the `LANGUAGES.md` generator, so the docs table and
 the demo can't disagree.
+
+## CLI
+
+`bin/` is the shipped `n2words` command (`npx n2words 42 -l en`). Because it ships, it may
+import only `node:` builtins and `src/` — no `chalk`, which is a devDependency and fine in
+`bench/` and `scripts/` but would break the zero-dependency guarantee.
+
+**Nothing about a language is hardcoded in `bin/`.** Flags, help text and validation are
+derived at runtime from each module's own declarations — `<form>Defaults` for the flag set
+and types, `<form>Values` for enum sets, `<form>Max` for the ceilings shown in help — the
+same contracts the gates in `test/` enforce. Adding a language or an option to `src/` gives
+the CLI a new flag with no edit in `bin/`. Option *value* validation stays in
+`resolveOptions`, whose errors already name the key and the allowed set; the CLI prints them
+rather than re-checking.
+
+Two seams to keep in mind when touching it:
+
+- `currency` is both a form name and an option key. `--currency <CODE>` means "as currency,
+  in CODE"; `--form currency` uses the locale default. It's forwarded even when a module's
+  `currencyDefaults` omits `currency`, since the 46 bare-tag aliases deliberately require an
+  explicit one (`docs/bare-tag-aliases.md`).
+- Flags are derived *after* `--lang` resolves, which is why nl-NL's `noHundredPairing` and
+  en-US's `hundredPairing` can both map to `--no-hundred-pairing` without colliding.
+
+Exit codes are part of the contract: `0` success, `1` usage error, `2` a value the library
+refused. `test/cli.test.js` spawns the real binary and pins all three.
 
 ## Git Workflow
 

--- a/README.md
+++ b/README.md
@@ -189,6 +189,51 @@ export, so there is nothing to opt into.
 
 See [LANGUAGES.md](LANGUAGES.md) for all language codes and available forms.
 
+## CLI
+
+The package ships an `n2words` command, so a number can be spelled without writing any code:
+
+```bash
+npx n2words 42 --lang en                   # forty-two
+npx n2words 42 -l fr-FR --ordinal          # quarante-deuxième
+npx n2words 42.50 -l en-US --currency EUR  # forty-two euro and fifty cents
+npx n2words 101 -l es-ES --gender feminine # ciento una
+```
+
+`--lang` takes any entry point the library exports — a bare tag (`en`, `de`) or a
+region/script-qualified code (`en-GB`, `zh-Hans-CN`), in any casing. `--cardinal` (the
+default), `--ordinal` and `--currency` pick the form; `--currency <CODE>` names the currency
+and selects the form in one flag, while `--form currency` keeps the locale's own default.
+
+**Options are the language's own.** Every flag past the built-ins is derived at runtime from
+the module you selected, so the CLI offers exactly what that language and form declare —
+`--gender` for Spanish, `--formal` for Chinese, `--and`/`--no-and` for English currency.
+Booleans also accept `--flag=false`, and `--option key=value` reaches any option by its
+declared name.
+
+Two commands make the whole library explorable:
+
+```bash
+npx n2words --list               # every entry point, its kind, and the forms it exports
+npx n2words --help --lang es-ES  # es-ES's forms, their ceilings, and its options
+```
+
+It composes in pipelines. With no values it reads stdin, one per line, streaming:
+
+```bash
+printf '1\n2\n3\n' | npx n2words -l de
+seq 1 100 | npx n2words -l fr --json > numbers.jsonl
+```
+
+`--json` emits one record per line (`{input, output, lang, form, options}`), with failures
+reported as `{input, error}` rather than on stderr. Values are read as text and passed
+through untouched, so precision is never lost — `n2words 12345678901234567890 -l en` is
+exact.
+
+Exit codes: `0` success, `1` a usage error (unknown flag, unknown language, missing
+`--lang`), `2` at least one value could not be converted — an out-of-range number, or an
+option value the language rejects. A bad line in a pipe doesn't stop the rest.
+
 ## Supported Languages
 
 See **[LANGUAGES.md](LANGUAGES.md)** for the complete list with codes and options.

--- a/bin/lib/args.js
+++ b/bin/lib/args.js
@@ -1,0 +1,322 @@
+/**
+ * Argument parsing for the CLI.
+ *
+ * The full flag set isn't knowable until the language and form are: option
+ * flags are derived from the selected module's own `<form>Defaults`, so a
+ * language gaining an option gains a flag with no edit here. That forces two
+ * passes over argv — a lenient one to find `--lang`/`--form`, then a strict one
+ * once the derived flags are known.
+ *
+ * Validation of option *values* stays the library's job: this module builds a
+ * plain options object and hands it over, so `resolveOptions` produces the
+ * errors (which already name the offending key and the allowed set).
+ *
+ * @module cli/args
+ */
+
+import { parseArgs } from 'node:util'
+import { FORMS } from './languages.js'
+
+/** An error in how the CLI was invoked, as opposed to a conversion failure. */
+export class UsageError extends Error {
+  /**
+   * @param {string} message What went wrong
+   * @param {string} [hint] An optional second line suggesting the fix
+   */
+  constructor(message, hint) {
+    super(message)
+    this.name = 'UsageError'
+    this.hint = hint
+  }
+}
+
+/**
+ * Flags the CLI owns. These are reserved: a language option of the same name is
+ * reachable only through `--option key=value`.
+ */
+export const BUILTIN_OPTIONS = {
+  lang: { type: 'string', short: 'l' },
+  form: { type: 'string', short: 'f' },
+  cardinal: { type: 'boolean' },
+  ordinal: { type: 'boolean' },
+  currency: { type: 'string' },
+  option: { type: 'string', multiple: true },
+  json: { type: 'boolean', short: 'j' },
+  list: { type: 'boolean' },
+  help: { type: 'boolean', short: 'h' },
+  version: { type: 'boolean', short: 'v' },
+}
+
+// Wrapper for negative numbers, which would otherwise parse as short-option
+// groups (`-42` -> `-4 -2`). Substitution is bounds-checked against what was
+// actually shielded, so this prefix is inert unless the run produced it.
+const SHIELD = 'n2words:negative:'
+
+/**
+ * camelCase option key -> kebab-case flag (`hundredPairing` -> `hundred-pairing`).
+ *
+ * @param {string} key An option key as declared in `<form>Defaults`
+ * @returns {string} The flag name, without leading dashes
+ */
+export function toFlag(key) {
+  return key.replace(/[A-Z]/g, char => `-${char.toLowerCase()}`)
+}
+
+/**
+ * Derives the parseArgs config for one form's declared options.
+ *
+ * Booleans get a `--no-` companion (parseArgs has no negation of its own).
+ * Note nl-NL declares an option literally named `noHundredPairing`, whose flag
+ * is therefore `--no-hundred-pairing` and whose negation is
+ * `--no-no-hundred-pairing`; that only reads as a collision with en-US's
+ * `hundredPairing` in the abstract, since flags are derived per-language after
+ * `--lang` resolves and no module declares both.
+ *
+ * @param {Record<string, unknown> | undefined} defaults The form's `<form>Defaults`
+ * @returns {{options: object, byFlag: Map<string, {key: string, value?: boolean}>, byKey: Map<string, {on: string, off?: string}>}}
+ */
+export function buildFlagIndex(defaults) {
+  /** @type {Record<string, {type: 'string' | 'boolean'}>} */
+  const options = {}
+  const byFlag = new Map()
+  const byKey = new Map()
+
+  for (const key of Object.keys(defaults ?? {})) {
+    const flag = toFlag(key)
+    // A built-in always wins. Today that's only `currency`, whose built-in
+    // doubles as the form shorthand and feeds this very option (see resolveForm).
+    if (Object.hasOwn(BUILTIN_OPTIONS, flag)) continue
+
+    if (typeof defaults[key] === 'boolean') {
+      const negated = `no-${flag}`
+      options[flag] = { type: 'boolean' }
+      byFlag.set(flag, { key, value: true })
+      byKey.set(key, { on: flag })
+
+      if (!Object.hasOwn(BUILTIN_OPTIONS, negated)) {
+        options[negated] = { type: 'boolean' }
+        byFlag.set(negated, { key, value: false })
+        byKey.set(key, { on: flag, off: negated })
+      }
+    }
+    else {
+      options[flag] = { type: 'string' }
+      byFlag.set(flag, { key })
+      byKey.set(key, { on: flag })
+    }
+  }
+
+  return { options, byFlag, byKey }
+}
+
+/**
+ * The lenient first pass: enough to learn the language and form.
+ *
+ * Declaring the built-ins keeps `--lang en` from parsing as a boolean plus a
+ * stray positional; everything not yet known is tolerated rather than rejected.
+ *
+ * @param {string[]} argv Raw arguments (process.argv.slice(2))
+ * @returns {Record<string, unknown>} The built-in flag values found
+ */
+export function parseGlobals(argv) {
+  const { values } = parseArgs({
+    args: argv,
+    options: BUILTIN_OPTIONS,
+    strict: false,
+    allowPositionals: true,
+  })
+  return values
+}
+
+/**
+ * Picks the conversion form from the built-in selectors.
+ *
+ * `--currency <CODE>` means "as currency, in CODE" — the form and the option in
+ * one flag. `--form currency` selects the form and leaves the locale's own
+ * default currency in place.
+ *
+ * @param {Record<string, unknown>} values Built-in flag values
+ * @returns {string} One of FORMS
+ * @throws {UsageError} On an unknown or contradictory form
+ */
+export function resolveForm(values) {
+  const selectors = []
+  if (values.form !== undefined) selectors.push(String(values.form))
+  if (values.cardinal === true) selectors.push('cardinal')
+  if (values.ordinal === true) selectors.push('ordinal')
+  if (values.currency !== undefined) selectors.push('currency')
+
+  const unique = [...new Set(selectors)]
+  if (unique.length > 1) {
+    throw new UsageError(`Conflicting forms requested: ${unique.join(', ')}`, 'Pick one of --cardinal, --ordinal, --currency.')
+  }
+
+  const form = unique[0] ?? 'cardinal'
+  if (!FORMS.includes(form)) {
+    throw new UsageError(`Unknown form: ${form}`, `Known forms: ${FORMS.join(', ')}`)
+  }
+  return form
+}
+
+/**
+ * Does this token consume the next one as its value?
+ *
+ * @param {string | undefined} token The preceding argv token
+ * @param {Record<string, {type: string, short?: string}>} options The full parseArgs config
+ * @returns {boolean} True when the following token is that flag's value
+ */
+function takesValue(token, options) {
+  if (typeof token !== 'string' || !token.startsWith('-') || token === '-') return false
+
+  if (token.startsWith('--')) {
+    if (token.includes('=')) return false
+    return options[token.slice(2)]?.type === 'string'
+  }
+
+  // Short groups (`-jl en`): only the last letter can take a value.
+  const short = token.at(-1)
+  return Object.values(options).some(option => option.short === short && option.type === 'string')
+}
+
+/**
+ * Interprets `--flag=false` for boolean flags, which strict parseArgs rejects
+ * outright ("does not take an argument").
+ *
+ * @param {string} text The text after the `=`
+ * @param {string} flag The flag it came from, for the error message
+ * @returns {boolean} The parsed boolean
+ * @throws {UsageError} If the text isn't a boolean
+ */
+function parseBoolean(text, flag) {
+  if (['true', '1', 'yes', 'on'].includes(text)) return true
+  if (['false', '0', 'no', 'off'].includes(text)) return false
+  throw new UsageError(`Option "${flag}" must be a boolean, got "${text}"`, 'Use true or false.')
+}
+
+/**
+ * Rewrites `--flag=<bool>` into the canonical `--flag` / `--no-flag`, and wraps
+ * negative numbers so they survive parsing as positionals.
+ *
+ * The negative-number rule is exact rather than a guess: a `-4…` token is a
+ * value only when the preceding token is a flag that takes one, and the
+ * complete option config is known by this point.
+ *
+ * @param {string[]} argv Raw arguments
+ * @param {object} config The full parseArgs options config
+ * @param {Map<string, {key: string, value?: boolean}>} byFlag Derived flag index
+ * @param {Map<string, {on: string, off?: string}>} byKey Per-key flag names
+ * @returns {{args: string[], shielded: string[]}} Rewritten argv and the originals it hid
+ */
+function rewriteArgs(argv, config, byFlag, byKey) {
+  const args = []
+  const shielded = []
+  let literal = false
+
+  for (const [position, token] of argv.entries()) {
+    if (literal) {
+      args.push(token)
+      continue
+    }
+    if (token === '--') {
+      literal = true
+      args.push(token)
+      continue
+    }
+
+    const assignment = /^--([^=]+)=([\s\S]*)$/.exec(token)
+    const entry = assignment === null ? undefined : byFlag.get(assignment[1])
+    if (entry !== undefined && typeof entry.value === 'boolean') {
+      // `--no-and=true` means and=false, so fold the flag's own polarity in.
+      const wanted = entry.value === parseBoolean(assignment[2], assignment[1])
+      const flags = byKey.get(entry.key)
+      if (!wanted && flags.off === undefined) {
+        throw new UsageError(`Option "${assignment[1]}" cannot be negated`, `Use --option ${entry.key}=false instead.`)
+      }
+      args.push(`--${wanted ? flags.on : flags.off}`)
+      continue
+    }
+
+    if (/^-\d/.test(token) && !takesValue(argv[position - 1], config)) {
+      args.push(`${SHIELD}${shielded.length}`)
+      shielded.push(token)
+      continue
+    }
+
+    args.push(token)
+  }
+
+  return { args, shielded }
+}
+
+/**
+ * Restores a shielded negative number, if that's what this positional is.
+ *
+ * @param {string} positional A parsed positional
+ * @param {string[]} shielded The originals hidden by rewriteArgs
+ * @returns {string} The original token
+ */
+function unshield(positional, shielded) {
+  if (!positional.startsWith(SHIELD)) return positional
+  const index = Number(positional.slice(SHIELD.length))
+  return Number.isInteger(index) && index < shielded.length ? shielded[index] : positional
+}
+
+/**
+ * The strict second pass, once the language's own option flags are known.
+ *
+ * @param {string[]} argv Raw arguments
+ * @param {Record<string, unknown> | undefined} defaults The form's `<form>Defaults`
+ * @returns {{values: Record<string, unknown>, positionals: string[], options: Map<string, unknown>}}
+ * @throws {UsageError} On an unknown flag, a missing value, or contradictory flags
+ */
+export function parseInvocation(argv, defaults) {
+  const { options: derived, byFlag, byKey } = buildFlagIndex(defaults)
+  const config = { ...BUILTIN_OPTIONS, ...derived }
+  const { args, shielded } = rewriteArgs(argv, config, byFlag, byKey)
+
+  let parsed
+  try {
+    parsed = parseArgs({ args, options: config, strict: true, allowPositionals: true })
+  }
+  catch (error) {
+    const supported = [...byFlag.keys()].filter(flag => !flag.startsWith('no-'))
+    throw new UsageError(
+      error.message,
+      supported.length > 0
+        ? `Options for this language and form: ${supported.map(flag => `--${flag}`).join(', ')}`
+        : 'This language and form take no options.',
+    )
+  }
+
+  /** @type {Map<string, unknown>} */
+  const options = new Map()
+  const setBy = new Map()
+
+  for (const [flag, raw] of Object.entries(parsed.values)) {
+    const entry = byFlag.get(flag)
+    if (entry === undefined) continue // A built-in; the caller handles those.
+
+    if (setBy.has(entry.key) && setBy.get(entry.key) !== flag) {
+      throw new UsageError(`Contradictory flags: --${setBy.get(entry.key)} and --${flag}`)
+    }
+    setBy.set(entry.key, flag)
+    options.set(entry.key, entry.value ?? raw)
+  }
+
+  for (const spec of /** @type {string[]} */ (parsed.values.option ?? [])) {
+    const separator = spec.indexOf('=')
+    if (separator < 1) {
+      throw new UsageError(`--option expects key=value, got "${spec}"`, 'For example: --option gender=feminine')
+    }
+    const key = spec.slice(0, separator)
+    const raw = spec.slice(separator + 1)
+    const isBoolean = defaults !== undefined && Object.hasOwn(defaults, key) && typeof defaults[key] === 'boolean'
+    options.set(key, isBoolean ? parseBoolean(raw, key) : raw)
+  }
+
+  return {
+    values: parsed.values,
+    positionals: parsed.positionals.map(positional => unshield(positional, shielded)),
+    options,
+  }
+}

--- a/bin/lib/format.js
+++ b/bin/lib/format.js
@@ -1,0 +1,197 @@
+/**
+ * Output rendering for the CLI: help, `--list`, and the effective-options view.
+ *
+ * Everything here is derived from a module's own exports — `<form>Defaults`,
+ * `<form>Values`, `<form>Max` — so help text can't drift from behavior. Those
+ * exports are guaranteed present by the contract gates (see
+ * docs/options-contract.md and docs/range-contract.md).
+ *
+ * @module cli/format
+ */
+
+import { toFlag } from './args.js'
+import { FORMS, describeKind, exportedForms } from './languages.js'
+
+/**
+ * Renders a form's ceiling the way `checkMax` does — `10^N - 1` for an exact
+ * power of ten, the raw maximum otherwise. Duplicated rather than shared
+ * because `src/utils/*` is deliberately unreachable from outside the package.
+ *
+ * @param {bigint | null | undefined} max A form's `<form>Max`
+ * @returns {string | null} The largest supported value, or null when unbounded
+ */
+export function formatMax(max) {
+  if (max === null || max === undefined) return null
+  const exponent = String(max).length - 1
+  return max === 10n ** BigInt(exponent) ? `10^${exponent} - 1` : String(max - 1n)
+}
+
+/**
+ * The options one form of one language declares.
+ *
+ * @param {Record<string, unknown>} mod An imported language module
+ * @param {string} form One of FORMS
+ * @returns {Array<{name: string, flag: string, type: string, default: unknown, values: string[] | null}>}
+ */
+export function formOptions(mod, form) {
+  const defaults = mod[`${form}Defaults`]
+  if (defaults === undefined) return []
+  const values = mod[`${form}Values`] ?? {}
+
+  return Object.entries(defaults).map(([name, value]) => ({
+    name,
+    flag: toFlag(name),
+    type: typeof value,
+    default: value,
+    values: Object.hasOwn(values, name) ? [...values[name]] : null,
+  }))
+}
+
+/**
+ * A language's English display name, when Intl knows one.
+ *
+ * @param {string} code A canonical language code
+ * @returns {string | null} The display name, or null if it's just the code back
+ */
+export function displayName(code) {
+  try {
+    const name = new Intl.DisplayNames(['en'], { type: 'language' }).of(code)
+    return name === code ? null : name
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * Everything `--list` reports about one entry point.
+ *
+ * @param {string} code The language code
+ * @param {Record<string, unknown>} mod Its imported module
+ * @returns {object} A JSON-serializable summary
+ */
+export function summarize(code, mod) {
+  const { kind, target } = describeKind(mod)
+  /** @type {Record<string, object>} */
+  const forms = {}
+
+  for (const form of exportedForms(mod)) {
+    forms[form] = {
+      max: formatMax(/** @type {bigint | null} */ (mod[`${form}Max`])),
+      options: formOptions(mod, form).map(option => ({
+        name: option.name,
+        flag: `--${option.flag}`,
+        type: option.type,
+        default: option.default,
+        values: option.values,
+      })),
+    }
+  }
+
+  return { code, name: displayName(code), kind, target, forms }
+}
+
+/**
+ * The plain-text `--list` table.
+ *
+ * @param {object[]} summaries Output of summarize(), in display order
+ * @returns {string} The rendered table
+ */
+export function renderList(summaries) {
+  const width = Math.max(...summaries.map(summary => summary.code.length))
+
+  return summaries
+    .map((summary) => {
+      const kind = summary.target === null ? summary.kind : `${summary.kind} of ${summary.target}`
+      return `${summary.code.padEnd(width)}  ${kind.padEnd(22)}  ${Object.keys(summary.forms).join(', ')}`
+    })
+    .join('\n')
+}
+
+/**
+ * The general help screen.
+ *
+ * @param {string} version The package version
+ * @returns {string} The rendered help
+ */
+export function renderHelp(version) {
+  return `n2words ${version} — convert numbers to words
+
+Usage:
+  n2words <value>... --lang <code> [options]
+  echo 42 | n2words --lang <code>
+
+Options:
+  -l, --lang <code>     Language entry point, e.g. en, en-GB, zh-Hans-CN (required)
+  -f, --form <form>     Conversion form: ${FORMS.join(', ')} (default: cardinal)
+      --cardinal        Shorthand for --form cardinal
+      --ordinal         Shorthand for --form ordinal
+      --currency <CODE> Convert as currency in an ISO 4217 code, e.g. EUR
+                        (use --form currency for the locale's own default)
+      --option k=value  Set a language option by its declared name
+  -j, --json            Emit one JSON object per input instead of plain text
+      --list            List every language entry point and the forms it exports
+  -h, --help            Show this help; add --lang <code> for that language's options
+  -v, --version         Print the version
+
+Each language declares its own options; run --help --lang <code> to see them.
+Values are read as text, so precision is never lost — 12345678901234567890 works.
+A value starting with "-" is fine as long as no value-taking flag precedes it.
+
+Examples:
+  n2words 42 --lang en
+  n2words 42 -l fr-FR --ordinal
+  n2words 42.50 -l en-US --currency EUR
+  n2words 101 -l es-ES --gender feminine
+  printf '1\\n2\\n' | n2words -l de --json
+
+Exit codes: 0 success, 1 usage error, 2 a value could not be converted.`
+}
+
+/**
+ * The per-language help screen, built from the module's own exports.
+ *
+ * @param {string} code The canonical language code
+ * @param {Record<string, unknown>} mod Its imported module
+ * @returns {string} The rendered help
+ */
+export function renderLanguageHelp(code, mod) {
+  const name = displayName(code)
+  const { kind, target } = describeKind(mod)
+  const lines = [`n2words --lang ${code}${name === null ? '' : ` — ${name}`}`]
+
+  if (target !== null) {
+    lines.push(`${kind === 'alias' ? 'Bare-tag alias for' : 'Locale profile of'} ${target}.`)
+  }
+
+  const forms = exportedForms(mod)
+  lines.push('', 'Forms:')
+  for (const form of forms) {
+    const max = formatMax(/** @type {bigint | null} */ (mod[`${form}Max`]))
+    const range = max === null ? 'no upper limit' : `up to ${max}`
+    lines.push(`  --${form.padEnd(18)}${range}${form === 'cardinal' ? '  (default)' : ''}`)
+  }
+
+  for (const form of forms) {
+    const options = formOptions(mod, form)
+    if (options.length === 0) continue
+
+    const flags = options.map(option => option.type === 'boolean'
+      ? `--${option.flag} / --no-${option.flag}`
+      : `--${option.flag} <value>`)
+    const width = Math.max(...flags.map(flag => flag.length)) + 2
+
+    lines.push('', `Options for --${form}:`)
+    for (const [position, option] of options.entries()) {
+      const allowed = option.values === null ? '' : `  one of: ${option.values.join(', ')}`
+      lines.push(`  ${flags[position].padEnd(width)}default: ${option.default}${allowed}`)
+    }
+  }
+
+  if (forms.includes('currency') && mod.currencyDefaults?.currency === undefined) {
+    lines.push('', `A bare tag names a language, not a country, so ${code} has no default`,
+      'currency: pass --currency <CODE>, or use a region-qualified --lang.')
+  }
+
+  return lines.join('\n')
+}

--- a/bin/lib/languages.js
+++ b/bin/lib/languages.js
@@ -1,0 +1,118 @@
+/**
+ * Language discovery and loading for the CLI.
+ *
+ * Resolves modules relative to this file rather than the cwd, so the same code
+ * works from a git checkout and from an installed `node_modules/n2words`
+ * (`files` ships `src/**\/*.js`). This is deliberately not
+ * `test/helpers/language-helpers.js` — that one reads `./src` relative to the
+ * cwd and lives under `test/`, which isn't published.
+ *
+ * @module cli/languages
+ */
+
+import { readdirSync } from 'node:fs'
+
+const SRC_DIR = new URL('../../src/', import.meta.url)
+
+/** Form key -> the export a language provides when it supports that form. */
+export const FORM_EXPORTS = {
+  cardinal: 'toCardinal',
+  ordinal: 'toOrdinal',
+  currency: 'toCurrency',
+}
+
+/** The three conversion forms, in the order they're presented to the user. */
+export const FORMS = Object.keys(FORM_EXPORTS)
+
+// Every shape in src/: `en`, `pt-BR`, `hbo-IL`, `fil-PH`, `zh-Hans-CN`,
+// `sr-Cyrl-RS`. This is a path-traversal guard, not a nicety — the code ends up
+// in a dynamic import specifier, so nothing outside this pattern may reach it.
+const CODE_PATTERN = /^[a-z]{2,3}(?:-[A-Z][a-z]{3})?(?:-[A-Z]{2})?$/
+
+/**
+ * Canonicalizes user input to BCP 47 casing (`en-us` -> `en-US`,
+ * `ZH-hans-cn` -> `zh-Hans-CN`).
+ *
+ * @param {string} input Language code as typed
+ * @returns {string | null} The canonical code, or null if it isn't shaped like one
+ */
+export function canonicalCode(input) {
+  const code = String(input)
+    .split('-')
+    .map((subtag, index) => {
+      if (index === 0) return subtag.toLowerCase()
+      // A 4-letter subtag is a script (Titlecase); anything else here is a region.
+      if (subtag.length === 4) return subtag[0].toUpperCase() + subtag.slice(1).toLowerCase()
+      return subtag.toUpperCase()
+    })
+    .join('-')
+
+  return CODE_PATTERN.test(code) ? code : null
+}
+
+/**
+ * Every entry point shipped in src/, sorted.
+ *
+ * @returns {string[]} Language codes (e.g. ['ar', 'ar-SA', 'az', ...])
+ */
+export function listCodes() {
+  return readdirSync(SRC_DIR)
+    .filter(file => file.endsWith('.js'))
+    .map(file => file.slice(0, -'.js'.length))
+    .sort((a, b) => a.localeCompare(b))
+}
+
+/**
+ * Imports a language module by canonical code.
+ *
+ * @param {string} code Canonical language code, already through canonicalCode()
+ * @returns {Promise<Record<string, unknown>>} The module namespace
+ * @throws {Error} If the code was never canonicalized, or the module is missing
+ */
+export async function importLanguage(code) {
+  // Re-assert rather than trust the caller: this string builds a URL.
+  if (!CODE_PATTERN.test(code)) throw new Error(`Refusing to import unvalidated code: ${code}`)
+  return import(new URL(`${code}.js`, SRC_DIR).href)
+}
+
+/**
+ * The forms a module actually exports, read from its real exports rather than
+ * from source text — the exports are the behavior.
+ *
+ * @param {Record<string, unknown>} mod An imported language module
+ * @returns {string[]} Supported form keys, in FORMS order
+ */
+export function exportedForms(mod) {
+  return FORMS.filter(form => typeof mod[FORM_EXPORTS[form]] === 'function')
+}
+
+/**
+ * Which of the three file kinds a module is (see docs/language-layers.md and
+ * docs/bare-tag-aliases.md).
+ *
+ * @param {Record<string, unknown>} mod An imported language module
+ * @returns {{kind: 'implementation' | 'alias' | 'profile', target: string | null}}
+ */
+export function describeKind(mod) {
+  if (typeof mod.aliasOf === 'string') return { kind: 'alias', target: mod.aliasOf }
+  if (typeof mod.variantOf === 'string') return { kind: 'profile', target: mod.variantOf }
+  return { kind: 'implementation', target: null }
+}
+
+/**
+ * Codes worth suggesting after an unknown one — same family first, then prefix
+ * matches. Purely a nicety on the error path; never used to pick a language.
+ *
+ * @param {string} input The code the user typed
+ * @param {string[]} codes Every known code
+ * @returns {string[]} At most 8 suggestions
+ */
+export function suggestCodes(input, codes) {
+  const needle = String(input).toLowerCase()
+  const primary = needle.split('-')[0]
+
+  const family = codes.filter(code => code.toLowerCase().split('-')[0] === primary)
+  const prefix = codes.filter(code => code.toLowerCase().startsWith(primary.slice(0, 2)))
+
+  return [...new Set([...family, ...prefix])].slice(0, 8)
+}

--- a/bin/n2words.js
+++ b/bin/n2words.js
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+/**
+ * n2words command-line interface.
+ *
+ * Nothing about a language is hardcoded here. Flags, help text and validation
+ * are derived at runtime from each module's own declarations — `<form>Defaults`,
+ * `<form>Values`, `<form>Max` — so adding a language or an option to src/ gives
+ * the CLI a new flag with no edit in bin/.
+ *
+ * Ships in the published package, so it imports only node: builtins and src/.
+ */
+
+import { createInterface } from 'node:readline'
+import { readFileSync } from 'node:fs'
+import { UsageError, parseGlobals, parseInvocation, resolveForm } from './lib/args.js'
+import { FORM_EXPORTS, canonicalCode, exportedForms, importLanguage, listCodes, suggestCodes } from './lib/languages.js'
+import { renderHelp, renderLanguageHelp, renderList, summarize } from './lib/format.js'
+
+const EXIT_USAGE = 1
+const EXIT_CONVERSION = 2
+
+/**
+ * The package version, read from the manifest rather than duplicated here.
+ *
+ * @returns {string} The version string
+ */
+function version() {
+  return JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')).version
+}
+
+/**
+ * Resolves a user-supplied code to a canonical one and imports it.
+ *
+ * The membership check against the real directory listing is what turns a typo
+ * into a helpful message instead of a raw ERR_MODULE_NOT_FOUND.
+ *
+ * @param {string} input The code as typed
+ * @returns {Promise<{code: string, mod: Record<string, unknown>}>} The canonical code and its module
+ * @throws {UsageError} If no such entry point exists
+ */
+async function loadLanguage(input) {
+  const code = canonicalCode(input)
+  const codes = listCodes()
+
+  if (code === null || !codes.includes(code)) {
+    const suggestions = suggestCodes(input, codes)
+    throw new UsageError(
+      `Unknown language: ${input}`,
+      suggestions.length > 0
+        ? `Did you mean: ${suggestions.join(', ')}`
+        : 'Run n2words --list to see every language code.',
+    )
+  }
+
+  return { code, mod: await importLanguage(code) }
+}
+
+/**
+ * Turns a parseArgs failure into a usage error, so a missing flag value reads
+ * as advice rather than as a stack trace.
+ *
+ * @param {string[]} argv Raw arguments
+ * @returns {Record<string, unknown>} The built-in flag values
+ * @throws {UsageError} On a malformed invocation
+ */
+function readGlobals(argv) {
+  try {
+    return parseGlobals(argv)
+  }
+  catch (error) {
+    if (typeof error.code === 'string' && error.code.startsWith('ERR_PARSE_ARGS')) {
+      throw new UsageError(error.message)
+    }
+    throw error
+  }
+}
+
+/**
+ * Prints every entry point and the forms it exports.
+ *
+ * @param {boolean} json Emit JSON instead of a table
+ * @returns {Promise<void>} Resolves once printed
+ */
+async function printList(json) {
+  const summaries = []
+  for (const code of listCodes()) {
+    summaries.push(summarize(code, await importLanguage(code)))
+  }
+  console.log(json ? JSON.stringify(summaries, null, 2) : renderList(summaries))
+}
+
+/**
+ * Runs the CLI.
+ *
+ * @param {string[]} argv Raw arguments (process.argv.slice(2))
+ * @returns {Promise<number>} The process exit code
+ * @throws {UsageError} On a malformed invocation
+ */
+async function main(argv) {
+  const globals = readGlobals(argv)
+  const json = globals.json === true
+
+  if (globals.version === true) {
+    console.log(version())
+    return 0
+  }
+
+  if (globals.list === true) {
+    await printList(json)
+    return 0
+  }
+
+  if (globals.help === true) {
+    if (globals.lang === undefined) {
+      console.log(renderHelp(version()))
+    }
+    else {
+      const { code, mod } = await loadLanguage(String(globals.lang))
+      console.log(renderLanguageHelp(code, mod))
+    }
+    return 0
+  }
+
+  if (globals.lang === undefined) {
+    throw new UsageError('Missing --lang', 'For example: n2words 42 --lang en. Run n2words --list for every code.')
+  }
+
+  const { code, mod } = await loadLanguage(String(globals.lang))
+  const form = resolveForm(globals)
+  const convert = mod[FORM_EXPORTS[form]]
+
+  if (typeof convert !== 'function') {
+    throw new UsageError(
+      `${code} has no ${form} form`,
+      `It supports: ${exportedForms(mod).map(supported => `--${supported}`).join(', ')}`,
+    )
+  }
+
+  const defaults = /** @type {Record<string, unknown> | undefined} */ (mod[`${form}Defaults`])
+  const { values, positionals, options } = parseInvocation(argv, defaults)
+
+  // `--currency CODE` is both the form shorthand and the option value. Forward
+  // it even when the module's own defaults omit `currency`: the 46 bare-tag
+  // aliases deliberately carry no default currency and require an explicit one
+  // (see src/en.js and docs/bare-tag-aliases.md).
+  if (form === 'currency' && typeof values.currency === 'string') {
+    options.set('currency', values.currency)
+  }
+
+  // Object.fromEntries builds genuine own properties, so a key like `__proto__`
+  // reaches resolveOptions as an unknown option (a clear TypeError) instead of
+  // mutating a prototype or vanishing silently.
+  const resolved = options.size > 0 ? Object.fromEntries(options) : undefined
+  const effective = { ...defaults, ...Object.fromEntries(options) }
+  let failed = false
+
+  /**
+   * Converts one value and prints the result or the failure.
+   *
+   * @param {string} input The value as typed — passed through as text, never
+   *   through Number(), so precision survives
+   */
+  const write = (input) => {
+    let output
+    try {
+      output = convert(input, resolved)
+    }
+    catch (error) {
+      failed = true
+      if (json) {
+        console.log(JSON.stringify({ input, lang: code, form, error: { name: error.name, message: error.message } }))
+      }
+      else {
+        console.error(`n2words: ${input}: ${error.message}`)
+      }
+      return
+    }
+    console.log(json ? JSON.stringify({ input, output, lang: code, form, options: effective }) : output)
+  }
+
+  const fromStdin = positionals.length === 0 || (positionals.length === 1 && positionals[0] === '-')
+
+  if (fromStdin) {
+    if (process.stdin.isTTY) {
+      throw new UsageError('No values to convert', 'Pass a value, or pipe them in: echo 42 | n2words -l en')
+    }
+    // Streaming keeps a long pipe responsive and bounded in memory.
+    for await (const line of createInterface({ input: process.stdin, crlfDelay: Infinity })) {
+      const value = line.trim()
+      if (value === '') {
+        // Keep output lined up with input in text mode; a blank line has no
+        // JSON representation, so JSONL simply skips it.
+        if (!json) console.log('')
+        continue
+      }
+      write(value)
+    }
+  }
+  else {
+    for (const positional of positionals) write(positional)
+  }
+
+  return failed ? EXIT_CONVERSION : 0
+}
+
+// A CLI that feeds `head` or `grep -q` gets its stdout closed mid-write; that's
+// a normal end, not a crash.
+process.stdout.on('error', (error) => {
+  // eslint-disable-next-line n/no-process-exit -- a closed stdout is a normal end for a pipe consumer (`| head`), and there is nothing left to unwind
+  if (error.code === 'EPIPE') process.exit(0)
+  throw error
+})
+
+try {
+  process.exitCode = await main(process.argv.slice(2))
+}
+catch (error) {
+  if (!(error instanceof UsageError)) throw error
+  console.error(`n2words: ${error.message}`)
+  if (error.hint !== undefined) console.error(error.hint)
+  process.exitCode = EXIT_USAGE
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,6 +67,17 @@ export default defineConfig([
     extends: [n.configs['flat/recommended-module']],
   },
 
+  // The shipped CLI runs wherever the package is installed, so it's held to
+  // engines.node (>=22) — n reads that from package.json, hence no version
+  // override here, unlike the dev-cli block below. n/hashbang additionally
+  // checks the shebang and the bin wiring.
+  {
+    name: 'n2words/bin',
+    files: ['bin/**/*.js'],
+    languageOptions: { globals: globals.node },
+    extends: [n.configs['flat/recommended-module']],
+  },
+
   // Dev CLIs (scripts, bench, root configs) run on the .nvmrc Node (24), not
   // the published library's floor — so n targets 24 there.
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "n2words",
       "version": "6.0.1",
       "license": "MIT",
+      "bin": {
+        "n2words": "bin/n2words.js"
+      },
       "devDependencies": {
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,11 @@
       ]
     }
   },
+  "bin": {
+    "n2words": "./bin/n2words.js"
+  },
   "files": [
+    "bin/**/*.js",
     "src/**/*.js",
     "src/**/*.d.ts",
     "dist/**/*.js",

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -1,0 +1,265 @@
+/**
+ * CLI tests.
+ *
+ * These spawn the real executable rather than importing its internals: the
+ * things worth pinning down here — exit codes, stdin streaming, how argv
+ * survives parsing — only exist at the process boundary.
+ */
+
+import { execFile } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import test from 'ava'
+import { toCardinal } from '../src/en-US.js'
+import { getLanguageCodes } from './helpers/language-helpers.js'
+
+const CLI = fileURLToPath(new URL('../bin/n2words.js', import.meta.url))
+
+/**
+ * Runs the CLI in a child process.
+ *
+ * @param {string[]} args Arguments after the executable
+ * @param {string} [input] Text to write to stdin (always closed, so the CLI
+ *   never sees a TTY)
+ * @returns {Promise<{stdout: string, stderr: string, code: number}>} The result
+ */
+function run(args, input) {
+  return new Promise((resolve) => {
+    const child = execFile(process.execPath, [CLI, ...args], (error, stdout, stderr) => {
+      resolve({ stdout, stderr, code: typeof error?.code === 'number' ? error.code : 0 })
+    })
+    child.stdin.end(input ?? '')
+  })
+}
+
+/**
+ * Runs the CLI and returns its trimmed stdout, asserting it succeeded.
+ *
+ * @param {import('ava').ExecutionContext} t The AVA context
+ * @param {string[]} args Arguments after the executable
+ * @param {string} [input] Text to write to stdin
+ * @returns {Promise<string>} Trimmed stdout
+ */
+async function output(t, args, input) {
+  const result = await run(args, input)
+  t.is(result.code, 0, result.stderr)
+  return result.stdout.trim()
+}
+
+// ============================================================================
+// Forms
+// ============================================================================
+
+test('converts cardinals by default', async (t) => {
+  t.is(await output(t, ['42', '--lang', 'en']), 'forty-two')
+})
+
+test('converts ordinals with --ordinal', async (t) => {
+  t.is(await output(t, ['42', '-l', 'fr-FR', '--ordinal']), 'quarante-deuxième')
+})
+
+test('--currency selects the form and the currency at once', async (t) => {
+  t.is(await output(t, ['42.50', '-l', 'en-US', '--currency', 'EUR']), 'forty-two euro and fifty cents')
+})
+
+test('--form currency uses the locale default currency', async (t) => {
+  t.is(await output(t, ['42.50', '-l', 'en-US', '--form', 'currency']), 'forty-two dollars and fifty cents')
+})
+
+test('rejects contradictory form selectors', async (t) => {
+  const result = await run(['42', '-l', 'en', '--cardinal', '--ordinal'])
+  t.is(result.code, 1)
+  t.regex(result.stderr, /Conflicting forms/)
+})
+
+// ============================================================================
+// Options derived from the language's own declarations
+// ============================================================================
+
+test('accepts an enum option as a flag', async (t) => {
+  t.is(await output(t, ['1', '-l', 'es-ES', '--gender', 'feminine']), 'una')
+})
+
+test('negates a boolean option with --no-', async (t) => {
+  t.is(await output(t, ['105', '-l', 'en-CA', '--no-and']), 'one hundred five')
+})
+
+test('accepts --flag=false for a boolean option', async (t) => {
+  t.is(await output(t, ['105', '-l', 'en-CA', '--and=false']), 'one hundred five')
+})
+
+test('accepts a free-string option', async (t) => {
+  const custom = await output(t, ['21', '-l', 'he-IL', '--and-word', 'X'])
+  const standard = await output(t, ['21', '-l', 'he-IL'])
+  t.not(custom, standard)
+})
+
+test('--option reaches an option by its declared name', async (t) => {
+  t.is(await output(t, ['1', '-l', 'es-ES', '--option', 'gender=feminine']), 'una')
+})
+
+test('rejects an option flag the language does not declare', async (t) => {
+  const result = await run(['42', '-l', 'en', '--gender', 'feminine'])
+  t.is(result.code, 1)
+  t.regex(result.stderr, /Options for this language and form/)
+})
+
+test('rejects contradictory boolean flags', async (t) => {
+  const result = await run(['42', '-l', 'en-CA', '--and', '--no-and'])
+  t.is(result.code, 1)
+  t.regex(result.stderr, /Contradictory flags/)
+})
+
+// ============================================================================
+// Value parsing
+// ============================================================================
+
+test('reads a negative value as a value, not as short flags', async (t) => {
+  t.is(await output(t, ['-42', '-l', 'en']), 'minus forty-two')
+})
+
+test('reads a negative value after the -- escape', async (t) => {
+  t.is(await output(t, ['-l', 'en', '--', '-42']), 'minus forty-two')
+})
+
+test('does not mistake a flag value for a negative number', async (t) => {
+  const result = await run(['42', '-l', '-9'])
+  t.is(result.code, 1)
+  t.regex(result.stderr, /Unknown language: -9/)
+})
+
+test('expands scientific notation', async (t) => {
+  t.is(await output(t, ['1e6', '-l', 'en']), 'one million')
+})
+
+test('keeps full precision on values beyond Number.MAX_SAFE_INTEGER', async (t) => {
+  const value = '12345678901234567890'
+  t.is(await output(t, [value, '-l', 'en']), toCardinal(value))
+})
+
+test('converts several values, one line each', async (t) => {
+  t.is(await output(t, ['1', '2', '3', '-l', 'en']), 'one\ntwo\nthree')
+})
+
+// ============================================================================
+// stdin
+// ============================================================================
+
+test('reads values from stdin', async (t) => {
+  t.is(await output(t, ['-l', 'en'], '1\n2\n'), 'one\ntwo')
+})
+
+test('reads stdin for an explicit - positional', async (t) => {
+  t.is(await output(t, ['-l', 'en', '-'], '7\n'), 'seven')
+})
+
+test('keeps blank stdin lines aligned with their output', async (t) => {
+  const result = await run(['-l', 'en'], '1\n\n3\n')
+  t.is(result.code, 0)
+  t.is(result.stdout, 'one\n\nthree\n')
+})
+
+test('converts the remaining lines when one fails, and exits 2', async (t) => {
+  const result = await run(['-l', 'en'], '1\nzzz\n3\n')
+  t.is(result.code, 2)
+  t.is(result.stdout, 'one\nthree\n')
+  t.regex(result.stderr, /Invalid number format/)
+})
+
+// ============================================================================
+// Errors
+// ============================================================================
+
+test('exits 1 on an unknown language, suggesting near matches', async (t) => {
+  const result = await run(['42', '-l', 'enn'])
+  t.is(result.code, 1)
+  t.regex(result.stderr, /Unknown language: enn/)
+  t.regex(result.stderr, /Did you mean: .*\ben-GB\b/)
+})
+
+test('exits 1 when --lang is missing', async (t) => {
+  const result = await run(['42'])
+  t.is(result.code, 1)
+  t.regex(result.stderr, /Missing --lang/)
+})
+
+test('exits 2 with the library message when a value is out of range', async (t) => {
+  const result = await run(['1e400', '-l', 'en'])
+  t.is(result.code, 2)
+  t.regex(result.stderr, /largest supported value is 10\^66 - 1/)
+})
+
+test('exits 2 listing the allowed set for an out-of-set enum value', async (t) => {
+  const result = await run(['1', '-l', 'es-ES', '--gender', 'nonsense'])
+  t.is(result.code, 2)
+  t.regex(result.stderr, /must be one of: masculine, feminine/)
+})
+
+test('exits 2 with the bare-tag hint when a currency is required', async (t) => {
+  const result = await run(['42.50', '-l', 'en', '--form', 'currency'])
+  t.is(result.code, 2)
+  t.regex(result.stderr, /names a language, not a locale/)
+})
+
+test('a bare tag converts currency once given an explicit code', async (t) => {
+  t.is(await output(t, ['42.50', '-l', 'en', '--currency', 'USD']), 'forty-two dollars and fifty cents')
+})
+
+// ============================================================================
+// Introspection
+// ============================================================================
+
+test('--list covers exactly the shipped entry points', async (t) => {
+  const listed = JSON.parse(await output(t, ['--list', '--json']))
+  t.deepEqual(listed.map(entry => entry.code).sort(), getLanguageCodes().sort())
+})
+
+test('--list reports each entry point kind', async (t) => {
+  const listed = JSON.parse(await output(t, ['--list', '--json']))
+  t.is(listed.find(entry => entry.code === 'en').kind, 'alias')
+  t.is(listed.find(entry => entry.code === 'en-AU').kind, 'profile')
+  t.is(listed.find(entry => entry.code === 'en-US').kind, 'implementation')
+})
+
+test('--help --lang shows that language options and ceilings', async (t) => {
+  const help = await output(t, ['--help', '--lang', 'es-ES'])
+  t.regex(help, /--gender/)
+  t.regex(help, /masculine, feminine/)
+  t.regex(help, /10\^9 - 1/)
+})
+
+test('--help alone shows usage', async (t) => {
+  t.regex(await output(t, ['--help']), /Usage:/)
+})
+
+test('--version prints the package version', async (t) => {
+  t.regex(await output(t, ['--version']), /^\d+\.\d+\.\d+/)
+})
+
+test('--json reports the input, output and effective options', async (t) => {
+  const record = JSON.parse(await output(t, ['1234', '-l', 'en', '--json']))
+  t.is(record.input, '1234')
+  t.is(record.output, 'one thousand two hundred thirty-four')
+  t.is(record.lang, 'en')
+  t.is(record.form, 'cardinal')
+  t.deepEqual(record.options, { hundredPairing: false, and: false })
+})
+
+test('--json reports a failure as a record rather than plain text', async (t) => {
+  const result = await run(['zzz', '-l', 'en', '--json'])
+  t.is(result.code, 2)
+  t.is(JSON.parse(result.stdout).error.name, 'RangeError')
+})
+
+// ============================================================================
+// Language codes
+// ============================================================================
+
+test('accepts a language code in any casing', async (t) => {
+  t.is(await output(t, ['1', '-l', 'EN-us']), 'one')
+})
+
+test('refuses a code that could escape the source directory', async (t) => {
+  const result = await run(['1', '-l', '../../etc/passwd'])
+  t.is(result.code, 1)
+  t.regex(result.stderr, /Unknown language/)
+})

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,5 +10,5 @@
     "rootDir": "."
   },
   "include": ["src/**/*.js"],
-  "exclude": ["node_modules", "dist", "test", "bench", "scripts"]
+  "exclude": ["node_modules", "dist", "test", "bench", "scripts", "bin"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,6 +21,7 @@
   // config covers the rest for editor IntelliSense without checkJs (CI does not
   // type-check test/scripts/bench, so flagging them in-editor would be phantom).
   "include": [
+    "bin/**/*.js",
     "test/**/*.js",
     "scripts/**/*.js",
     "bench/**/*.js"


### PR DESCRIPTION
Adds a `bin` entry point so the library is usable from a shell without writing code.

```bash
npx n2words 42 --lang en                   # forty-two
npx n2words 42 -l fr-FR --ordinal          # quarante-deuxième
npx n2words 42.50 -l en-US --currency EUR  # forty-two euro and fifty cents
npx n2words 101 -l es-ES --gender feminine # ciento una
```

## Nothing about a language is hardcoded

Flags, help text and validation are derived at runtime from each module's own
declarations — `<form>Defaults` for the flag set and types, `<form>Values` for enum sets,
`<form>Max` for the ceilings shown in help. These are the same contracts the gates in
`test/` already enforce, so adding a language or an option to `src/` gives the CLI a new
flag with no edit in `bin/`. Option *value* validation stays in `resolveOptions`, whose
errors already name the key and the allowed set; the CLI prints them rather than
re-checking.

```console
$ npx n2words --help --lang es-ES
n2words --lang es-ES — European Spanish

Forms:
  --cardinal          up to 10^30 - 1  (default)
  --ordinal           up to 10^9 - 1
  --currency          up to 10^30 - 1

Options for --cardinal:
  --gender <value>  default: masculine  one of: masculine, feminine
...
```

`--list` does the same across all 118 entry points, reporting each one's kind
(implementation / alias / profile) and the forms it exports.

## What it supports

- All three forms; `--currency <CODE>` names the currency and selects the form in one flag,
  `--form currency` keeps the locale's own default.
- Per-language options as flags, with `--no-` negation and `--flag=false` — neither of which
  `parseArgs` offers, so both are handled explicitly. `--option key=value` is an escape
  hatch for any future name that collides with a built-in.
- Several values at once, or stdin streamed line by line; `--json` emits one record per line.
- Exit codes separate a usage error (`1`) from a value the library refused (`2`). A bad line
  in a pipe doesn't stop the rest.

## Details worth a look in review

- **Precision.** Values reach the library as raw strings — never through `Number()` — so
  `n2words 12345678901234567890 -l en` is exact.
- **Negative numbers.** `-42` would parse as the short-option group `-4 -2`. Tokens matching
  `/^-\d/` are reclassified as positionals unless a value-taking flag precedes them, which
  is decidable rather than a guess because the full option config is known by then.
- **`currency` is both a form name and an option key.** The built-in wins, and its value is
  forwarded even when a module's `currencyDefaults` omits `currency` — the 46 bare-tag
  aliases deliberately require an explicit one.
- **Path traversal.** The language code goes into a dynamic import specifier, so it is
  canonicalized, pattern-checked, and confirmed against the real directory listing first.
- **Zero dependencies preserved.** `bin/` imports only `node:` builtins and `src/`; no
  `chalk`. Modules resolve relative to `import.meta.url`, so the CLI works from a checkout
  and from an installed `node_modules` at any cwd.

## Testing

`test/cli.test.js` — 37 tests spawning the real binary, covering forms, derived options,
error paths and exit codes, argv edge cases, stdin streaming, and the introspection output
(`--list --json` is asserted to cover exactly `getLanguageCodes()`).

Also verified by packing the tarball and running the extracted `bin/n2words.js` from an
unrelated cwd.

`.commitlintrc.mjs` gains a `cli` scope, alongside the existing `bench` / `scripts` / `site`
project areas.
