### PR TITLE
fix(site): act on the #441 review, and document the CLI on the site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,16 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+      # The demo site's manifest is generated from src/ at deploy time, and
+      # pages.yml only runs on main — so a language whose shape the generator
+      # can't read used to pass every PR gate and surface after merge, as a red
+      # deploy with the site still serving the previous commit's bundles. The
+      # generator imports every language and reads its declarations, which is
+      # the part that can break; dist/ is not needed (bundle sizes come back
+      # null), so this costs seconds rather than a full build.
+      - name: Generate site data
+        run: node scripts/generate-site-data.js "$RUNNER_TEMP/languages.json"
+
   test:
     name: Test (Node ${{ matrix.node }}${{ matrix.coverage && ' + Coverage' || '' }})
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -13,10 +13,20 @@ env:
 # commit — there is no snapshot to refresh by hand.
 #
 # Requires repository Settings -> Pages -> Source = "GitHub Actions".
+#
+# `release: published` is what redeploys after a release. release.yml commits
+# `chore(release): vX.Y.Z [skip ci]` and pushes it, and GitHub skips
+# push-triggered runs for a `[skip ci]` commit — so without this trigger the
+# site would keep serving the previous version's footer and bundles until some
+# unrelated push landed. The release is created with the release-bot App token,
+# not GITHUB_TOKEN, so the event does start a run; a release event checks out
+# the tag, which is that same chore(release) commit.
 on:
   push:
     branches:
       - main
+  release:
+    types: [published]
   workflow_dispatch:
 
 # Never cancel a deploy in progress; queue behind it instead.
@@ -32,6 +42,15 @@ jobs:
     name: Build site
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    # `actions/configure-pages` calls the Pages API (`GET /repos/{o}/{r}/pages`)
+    # to resolve the site's base URL, and a workflow-level `permissions:` block
+    # sets every scope it doesn't list to `none`. It works today only because
+    # this repo is public and that endpoint is readable anonymously; the read
+    # scope is what actually entitles it. Deploy keeps its own write scopes.
+    permissions:
+      contents: read
+      pages: read
 
     steps:
       - uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,7 +305,7 @@ refused. `test/cli.test.js` spawns the real binary and pins all three.
 
 ## Commits
 
-Conventional Commits required. Scopes: BCP 47 codes — one (`en-US`), comma-separated (`az-AZ,tr-TR`), or a bare primary subtag for a variant family (`en`, `es`) — or project areas (`core`, `esm`, `umd`, `types`, `deps`). Family names like `slavic`/`turkic` are **not** valid scopes.
+Conventional Commits required. Scopes: BCP 47 codes — one (`en-US`), comma-separated (`az-AZ,tr-TR`), or a bare primary subtag for a variant family (`en`, `es`) — or project areas (`core`, `cli`, `site`, `scripts`, `esm`, `umd`, `types`, `bench`, `release`, `deps`, `deps-dev`). Family names like `slavic`/`turkic` are **not** valid scopes.
 
 ```bash
 feat(pt-BR): add Brazilian Portuguese

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ npm test
 - `refactor(core): simplify exports` — code refactoring
 - `docs: update README` — documentation
 
-Scopes use BCP 47 language codes — one (`en-US`), comma-separated (`az-AZ,tr-TR`), or a bare primary subtag for a variant family (`en`, `es`) — or project areas (`core`, `types`, `umd`). See [.commitlintrc.mjs](.commitlintrc.mjs) for details.
+Scopes use BCP 47 language codes — one (`en-US`), comma-separated (`az-AZ,tr-TR`), or a bare primary subtag for a variant family (`en`, `es`) — or project areas (`core`, `cli`, `site`, `scripts`, `types`, `umd`, ...). See [.commitlintrc.mjs](.commitlintrc.mjs) for details.
 
 ## Adding a New Language
 
@@ -56,6 +56,17 @@ Then:
 2. Add test cases to `test/fixtures/<code>.js`
 3. Run `npm test` — the suite's gates verify everything automatically and tell
    you exactly what's missing; green means done
+
+Nothing else needs editing. The shipped `n2words` CLI (`bin/`) and the demo site
+(`site/`) both derive their language lists, flags and options panels at runtime
+from the declarations your file exports, so a new language gets a CLI flag set
+and a site entry with no change in either place:
+
+```bash
+node bin/n2words.js 42 -l <code>       # the CLI, before publishing
+node bin/n2words.js --help -l <code>   # the flags your declarations produced
+npm run build && npm run site:build && npm run site:serve  # preview the site
+```
 
 ## Code Style
 

--- a/scripts/build-site.js
+++ b/scripts/build-site.js
@@ -4,7 +4,7 @@
  * Assembles the deployable site into `_site/`:
  *
  *   site/**            -> _site/**          (hand-written pages, styles, script)
- *   dist/**            -> _site/dist/**     (the real built bundles)
+ *   dist/**            -> _site/dist/**     (the real built bundles, minus UMD)
  *   generate-site-data -> _site/languages.json
  *
  * The demo imports `./dist/{code}/{form}.js` at runtime, so the page runs the
@@ -12,26 +12,45 @@
  * can't drift from the library it advertises, and there is nothing to keep in
  * sync by hand.
  *
+ * Assembly happens in a staging directory that replaces `_site/` only once
+ * every step has succeeded. A half-built tree is indistinguishable from a
+ * complete one once it is being served — pages load, `languages.json` 404s,
+ * and every table is empty — so a failed build must leave no new tree at all.
+ *
  * Usage:
  *   node --run build        # produces dist/ (prerequisite)
  *   node --run site:build
  */
 
-import { cpSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import { cpSync, existsSync, mkdirSync, renameSync, rmSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
 
 const OUT = '_site'
+const STAGE = '_site.tmp'
 
 if (!existsSync('dist')) {
   throw new Error('dist/ not found — run `node --run build` first (the demo loads the real bundles).')
 }
 
-rmSync(OUT, { recursive: true, force: true })
-mkdirSync(OUT, { recursive: true })
+rmSync(STAGE, { recursive: true, force: true })
+mkdirSync(STAGE, { recursive: true })
 
-cpSync('site', OUT, { recursive: true })
-cpSync('dist', `${OUT}/dist`, { recursive: true })
+try {
+  cpSync('site', STAGE, { recursive: true })
+  // UMD builds are excluded: nothing on the site loads one. The demo imports
+  // `dist/{code}/{form}.js`, and the single UMD mention in site/ is a jsDelivr
+  // snippet in docs.html — a code sample pointing at the CDN, not a fetch.
+  // Copying all 118 would add ~1.3 MB to the Pages artifact for no request.
+  cpSync('dist', `${STAGE}/dist`, { recursive: true, filter: source => !source.endsWith('.umd.js') })
 
-execFileSync(process.execPath, ['scripts/generate-site-data.js', `${OUT}/languages.json`], { stdio: 'inherit' })
+  execFileSync(process.execPath, ['scripts/generate-site-data.js', `${STAGE}/languages.json`], { stdio: 'inherit' })
+
+  rmSync(OUT, { recursive: true, force: true })
+  renameSync(STAGE, OUT)
+}
+catch (error) {
+  rmSync(STAGE, { recursive: true, force: true })
+  throw error
+}
 
 console.log(`✓ Built ${OUT}/ — serve it with \`node --run site:serve\``)

--- a/scripts/generate-site-data.js
+++ b/scripts/generate-site-data.js
@@ -62,8 +62,12 @@ function endonym(code, fallback) {
     // ICU echoes the subtag back when it has no data for a language — either
     // alone ("hbo") or inside an otherwise-translated name ("hbo (Israel)").
     // A word-boundary match catches both without touching a real endonym,
-    // since no endonym contains its own subtag as a standalone word.
-    const echoesCode = name && new RegExp(`\\b${code.split('-')[0]}\\b`).test(name)
+    // since no endonym contains its own subtag as a standalone word. The
+    // boundary has to be Unicode-aware: `\b` is defined against `\w`, which is
+    // ASCII, so it fires between "az" and "ə" and discards Azerbaijani's real
+    // endonym ("azərbaycan"). Letter lookarounds test the actual condition.
+    const subtag = code.split('-')[0]
+    const echoesCode = name && new RegExp(`(?<!\\p{L})${subtag}(?!\\p{L})`, 'u').test(name)
     return name && !echoesCode ? name : fallback
   }
   catch {

--- a/scripts/serve-site.js
+++ b/scripts/serve-site.js
@@ -28,8 +28,18 @@ const TYPES = {
 }
 
 createServer((request, response) => {
-  // Resolve within ROOT: normalize collapses any `..` before it can escape.
-  const path = normalize(decodeURIComponent(new URL(request.url, 'http://localhost').pathname))
+  let path
+  try {
+    // Resolve within ROOT: normalize collapses any `..` before it can escape.
+    // `decodeURIComponent` throws on a malformed escape (`GET /%`), and an
+    // uncaught throw in this handler takes the whole preview server down.
+    path = normalize(decodeURIComponent(new URL(request.url, 'http://localhost').pathname))
+  }
+  catch {
+    response.writeHead(400, { 'content-type': 'text/plain' }).end('400')
+    return
+  }
+
   let file = join(ROOT, path)
 
   try {

--- a/site/app.js
+++ b/site/app.js
@@ -26,6 +26,13 @@ export function loadManifest() {
       if (!response.ok) throw new Error(`languages.json: HTTP ${response.status}`)
       return response.json()
     })
+    // Memoize the success, not the failure. A dropped request would otherwise
+    // be replayed to every later caller for the rest of the session, so one
+    // transient network blip would leave all three pages permanently broken.
+    .catch((error) => {
+      manifestPromise = undefined
+      throw error
+    })
   return manifestPromise
 }
 
@@ -42,7 +49,12 @@ const bundles = new Map()
 export function loadBundle(code, form) {
   const key = `${code}/${form}`
   if (!bundles.has(key)) {
-    bundles.set(key, import(new URL(`dist/${key}.js`, import.meta.url).href))
+    // Cached on success only — a failed import is dropped so the next
+    // keystroke retries it rather than replaying the same error forever.
+    bundles.set(key, import(new URL(`dist/${key}.js`, import.meta.url).href).catch((error) => {
+      bundles.delete(key)
+      throw error
+    }))
   }
   return bundles.get(key)
 }

--- a/site/demo.js
+++ b/site/demo.js
@@ -84,6 +84,21 @@ const variant = () => state.variants.get(state.region ?? family().landing)
 const value = () => elements.value.value.trim()
 
 /**
+ * Whether this call takes its currency from a region's default rather than
+ * naming one — the single question behind the import specifier, the currency
+ * note and the snippet footnote, which must agree in every state.
+ *
+ * `state.currency` is null exactly when nothing was named: `normalizeCurrency`
+ * collapses a pick that merely restates the resolved variant's own default, so
+ * "picked USD on en-US" and "picked nothing" cannot disagree here.
+ *
+ * @returns {boolean} True when the currency is borrowed from a country
+ */
+function borrowsRegionDefault() {
+  return state.form === 'currency' && state.currency === null
+}
+
+/**
  * The import specifier for the current selection.
  *
  * A bare tag names a language and carries no default currency, so a currency
@@ -95,8 +110,26 @@ const value = () => elements.value.value.trim()
  */
 function specifier() {
   if (state.region !== null) return `n2words/${state.region}`
-  const borrowsRegionDefault = state.form === 'currency' && state.currency === null
-  return `n2words/${borrowsRegionDefault ? variant().code : family().entry ?? family().landing}`
+  return `n2words/${borrowsRegionDefault() ? variant().code : family().entry ?? family().landing}`
+}
+
+/**
+ * Drop an explicit currency that the current selection can't or needn't name.
+ *
+ * Two cases collapse to "nothing named": a currency this language has no words
+ * for (carried over from a previous language), and one that merely restates
+ * the resolved variant's own default. The second matters because the snippet
+ * shows the shortest call producing this output — the same rule the options
+ * panel already follows by reporting only what differs from a declared default.
+ * Without it, picking GBP and then picking USD back on en-US leaves an explicit
+ * "USD" that reads as a borrowed default in one place and an explicit choice in
+ * another.
+ */
+function normalizeCurrency() {
+  if (state.currency === null) return
+  if (!family().currencies.includes(state.currency) || state.currency === variant().defaultCurrency) {
+    state.currency = null
+  }
 }
 
 /** The options object the current call actually passes. */
@@ -186,7 +219,7 @@ function renderCurrency() {
       + `${escapeHtml(code)} — ${escapeHtml(name ?? code)}${isDefault ? ` (default of ${escapeHtml(item.code)})` : ''}</option>`
   }).join('')
 
-  const usingDefault = state.currency === null || state.currency === fallback
+  const usingDefault = borrowsRegionDefault()
   refineSummary(
     elements.currencySummary,
     `Naming <code>${escapeHtml(selected)}</code> — ${escapeHtml(state.manifest.currencies[selected] ?? selected)}`
@@ -368,8 +401,17 @@ function renderLocale() {
 
 // --------------------------------------------------------------- the output
 
+// Each panel below reads the selection, awaits a bundle, then paints. A cold
+// bundle can take long enough for a second selection to overtake the first —
+// switch language while one is downloading and the slower reply lands last,
+// leaving output that belongs to a language the picker no longer shows. Each
+// paint claims a ticket first and drops its result if a newer one exists.
+let outputRun = 0
+let compareRun = 0
+
 /** Convert and paint the output panel and the snippet. */
 async function run() {
+  const ticket = ++outputRun
   const item = variant()
   const input = value()
 
@@ -383,6 +425,7 @@ async function run() {
 
   try {
     const words = await convert(item.code, state.form, input, callOptions())
+    if (ticket !== outputRun) return
     elements.output.dataset.state = 'ok'
     elements.outputText.textContent = words
     elements.outputText.lang = item.code
@@ -394,6 +437,7 @@ async function run() {
     renderSnippet(words)
   }
   catch (error) {
+    if (ticket !== outputRun) return
     elements.output.dataset.state = 'error'
     elements.outputText.removeAttribute('dir')
     elements.outputText.textContent = describeError(error)
@@ -412,14 +456,18 @@ function renderSnippet(words) {
   const fn = FORM_FUNCTION[state.form]
   const call = `${fn}('${value()}'${formatOptions(callOptions())})`
 
-  elements.snippet.innerHTML = [
+  // The blank line separates the import from the call and is part of the
+  // snippet — only the result comment is conditional, so build the lines
+  // rather than filtering empties, which would drop the separator too.
+  const lines = [
     `<span class="kw">import</span> { ${fn} } <span class="kw">from</span> '${escapeHtml(specifier())}'`,
     '',
     escapeHtml(call),
-    words === null ? '' : `<span class="cm">// → '${escapeHtml(words)}'</span>`,
-  ].filter(line => line !== '').join('\n')
+  ]
+  if (words !== null) lines.push(`<span class="cm">// → '${escapeHtml(words)}'</span>`)
+  elements.snippet.innerHTML = lines.join('\n')
 
-  const borrowed = state.region === null && state.form === 'currency' && state.currency === null && family().entry
+  const borrowed = state.region === null && borrowsRegionDefault() && family().entry
   elements.snippetNote.hidden = !borrowed
   if (borrowed) {
     elements.snippetNote.innerHTML = `<code>${escapeHtml(variant().code)}</code>, not <code>${escapeHtml(family().entry)}</code>: `
@@ -431,6 +479,7 @@ function renderSnippet(words) {
 
 /** Convert the current value in one language after another. */
 async function renderCompare() {
+  const ticket = ++compareRun
   const families = state.showAll
     ? state.manifest.families
     : COMPARE_SAMPLE.map(primary => state.families.get(primary)).filter(Boolean)
@@ -453,6 +502,8 @@ async function renderCompare() {
       return { item, member, shown, text: describeError(error), empty: true }
     }
   }))
+
+  if (ticket !== compareRun) return
 
   elements.compare.innerHTML = results.map(({ item, member, shown, text, empty }) => `
     <article class="compare-item">
@@ -497,6 +548,19 @@ function readHash() {
   const raw = location.hash.slice(1)
   if (!raw) return
 
+  // A hand-edited or truncated fragment can hold a malformed escape ("100%"),
+  // and `decodeURIComponent` throws on one. That throw would reach `init`'s
+  // catch and replace the whole page with an error, so a bad escape falls back
+  // to the raw text: the value is the reader's to fix in the field.
+  const decode = (text) => {
+    try {
+      return decodeURIComponent(text)
+    }
+    catch {
+      return text
+    }
+  }
+
   const [path, query] = raw.split('?')
   const [target, form, encoded] = path.split('/')
 
@@ -510,7 +574,7 @@ function readHash() {
   }
 
   if (FORMS.includes(form) && variant().forms[form]) state.form = form
-  if (encoded !== undefined) elements.value.value = decodeURIComponent(encoded)
+  if (encoded !== undefined) elements.value.value = decode(encoded)
 
   const params = query ? Object.fromEntries(new URLSearchParams(query)) : {}
   // Assign rather than test: a hash typed over the current one must replace
@@ -536,8 +600,7 @@ function applyPendingOptions() {
 /** Re-render everything that depends on the language, region or form. */
 function refresh() {
   syncForms()
-  // A currency the new language has no words for is dropped, not carried.
-  if (state.currency !== null && !family().currencies.includes(state.currency)) state.currency = null
+  normalizeCurrency()
   renderCurrency()
   renderOptions()
   applyPendingOptions()
@@ -600,6 +663,7 @@ async function init() {
 
   elements.currency.addEventListener('change', () => {
     state.currency = elements.currency.value
+    normalizeCurrency()
     renderCurrency()
     run()
     writeHash()

--- a/site/docs.html
+++ b/site/docs.html
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Docs — n2words</title>
-<meta name="description" content="Getting started with n2words: install, the three forms, entry points, options, currency, error behaviour, browser and CDN usage, TypeScript.">
+<meta name="description" content="Getting started with n2words: install, the CLI, the three forms, entry points, options, currency, error behaviour, browser and CDN usage, TypeScript.">
 <link rel="icon" href="favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="styles.css">
 <script>
@@ -54,6 +54,51 @@ catch { /* private mode, blocked storage: fall back to the system theme */ }
     <h2>Install</h2>
     <pre><code>npm install n2words</code></pre>
     <p>Zero dependencies. Node.js 22+, or any browser with BigInt support.</p>
+
+    <h2 id="cli">Command line</h2>
+    <p>
+      The package ships an <code>n2words</code> command, so a number can be
+      spelled without writing any code. <code>npx</code> runs it without
+      installing anything first.
+    </p>
+    <pre><code>npx n2words 42 --lang en                   <span class="cm"># forty-two</span>
+npx n2words 42 -l fr-FR --ordinal          <span class="cm"># quarante-deuxième</span>
+npx n2words 42.50 -l en-US --currency EUR  <span class="cm"># forty-two euro and fifty cents</span></code></pre>
+    <p>
+      <code>--lang</code> takes any entry point this site lists — a bare tag
+      (<code>en</code>, <code>de</code>) or a region/script-qualified code
+      (<code>en-GB</code>, <code>zh-Hans-CN</code>), in any casing.
+      <code>--cardinal</code> (the default), <code>--ordinal</code> and
+      <code>--currency</code> pick the form; <code>--currency &lt;CODE&gt;</code>
+      names the currency and selects the form in one flag, while
+      <code>--form currency</code> keeps the locale's own default.
+    </p>
+    <p>
+      <strong>The options are the language's own.</strong> Every flag past the
+      built-ins is derived at runtime from the module you selected — from the
+      same <code>&lt;form&gt;Defaults</code> and <code>&lt;form&gt;Values</code>
+      declarations the demo builds its options panel from — so the CLI offers
+      exactly what that language and form accept, and nothing else:
+    </p>
+    <pre><code>npx n2words --list                <span class="cm"># every entry point and the forms it exports</span>
+npx n2words --help -l es-ES       <span class="cm"># es-ES's forms, their ceilings, and its options</span>
+npx n2words 101 -l es-ES --gender feminine
+npx n2words 1500 -l en --hundred-pairing</code></pre>
+    <p>
+      With no values it reads stdin, one per line, streaming — so it composes in
+      a pipeline. Values are read as text and passed through untouched, so
+      precision is never lost.
+    </p>
+    <pre><code>printf '1\n2\n3\n' | npx n2words -l de
+seq 1 100 | npx n2words -l fr --json &gt; numbers.jsonl</code></pre>
+    <p>
+      <code>--json</code> emits one record per line
+      (<code>{input, output, lang, form, options}</code>), with failures
+      reported as <code>{input, error}</code> rather than on stderr. Exit codes
+      are part of the contract: <code>0</code> success, <code>1</code> a usage
+      error, <code>2</code> at least one value the library refused. A bad line
+      in a pipe doesn't stop the rest.
+    </p>
 
     <h2>The three forms</h2>
     <p>

--- a/site/index.html
+++ b/site/index.html
@@ -148,7 +148,15 @@ catch { /* private mode, blocked storage: fall back to the system theme */ }
   <section aria-labelledby="install-heading">
     <h2 id="install-heading">Install</h2>
     <pre><code><span class="cm"># Node, bundlers, Deno, Bun</span>
-npm install n2words</code></pre>
+npm install n2words
+
+<span class="cm"># or spell a number without writing any code</span>
+npx n2words 42 --lang en  <span class="cm"># forty-two</span></code></pre>
+    <p>
+      The shipped <code>n2words</code> command derives its flags from whichever
+      language you name, so the options above are flags too —
+      <a href="docs.html#cli">the CLI section</a> has the details.
+    </p>
     <p>
       No build step? Load a single bundle straight from a CDN — the same file this
       page just used. See <a href="docs.html">the docs</a> for browser, UMD and

--- a/site/languages.js
+++ b/site/languages.js
@@ -146,7 +146,12 @@ function apply() {
     if (kind === 'no-alias') return family.entry === null
     if (kind === 'options') {
       const landing = variantsByCode.get(family.landing)
-      return Object.values(landing.forms).some(form => form.options.length > 0)
+      // `currency` is declared by every currency form, so counting it would
+      // match all 50 languages and filter nothing. What the reader means by
+      // "has options" is a knob this language has and others don't — the same
+      // set the demo's options panel shows, which excludes currency because it
+      // has its own control there.
+      return Object.values(landing.forms).some(form => form.options.some(option => option.name !== 'currency'))
     }
     return true
   })
@@ -192,10 +197,13 @@ async function init() {
   })
 
   // languages.html#en-KE opens English and scrolls to it, so deep links from
-  // LANGUAGES.md and from the demo keep landing.
+  // LANGUAGES.md and from the demo keep landing. A row's own id is its
+  // language (`#en`) — the browser's native fragment jump ran against an empty
+  // tbody long before `apply()` filled it — so both spellings resolve here.
   const target = location.hash.slice(1)
-  if (target && variantsByCode.has(target)) {
-    const primary = variantsByCode.get(target).primary
+  const primary = variantsByCode.get(target)?.primary
+    ?? (families.some(family => family.primary === target) ? target : null)
+  if (primary) {
     const button = rows.querySelector(`#${CSS.escape(primary)} .expand`)
     if (button) toggle(button, true)
     document.querySelector(`#${CSS.escape(primary)}`)?.scrollIntoView({ block: 'center' })


### PR DESCRIPTION
Acts on the [review of #441](https://github.com/forzagreen/n2words/pull/441#issuecomment-5532801603), and adds the CLI to the site, which never mentioned it.

## The CLI on the site

`n2words` has shipped since v6.1.0 and appeared nowhere on the Pages site. `docs.html` gets a **Command line** section (`--lang`, form flags, `--list`, `--help --lang`, stdin, `--json`, exit codes) and the landing page's Install block gets the `npx` one-liner plus a link to it. Every example was run against `bin/n2words.js` before being written down.

Both make the point the CLI shares with the demo: its flags come from the same `<form>Defaults` / `<form>Values` declarations the options panel is rendered from — neither hardcodes anything about a language. `CONTRIBUTING.md` now says so too, since it mentioned neither surface.

## Review findings addressed

| Finding | Fix |
| --- | --- |
| Snippet's blank separator stripped with the absent comment | Build the lines; only the result comment is conditional |
| Three predicates for "is this currency borrowed?" | One `borrowsRegionDefault()`; `normalizeCurrency()` collapses a pick that restates the default |
| `run`/`renderCompare` read-await-write with no guard | Each paint claims a ticket and drops a stale result |
| `readHash` crashes the page on `#en/cardinal/100%` | Malformed escapes fall back to the raw text |
| "Has options" filter matched all 50 languages | Excludes `currency`, matching the demo's own count of 20 |
| `languages.html#en` never resolved | Family primaries resolve alongside variant codes |
| Memoized rejection is permanent | Success is cached, failure is dropped and retried |
| `GET /%` kills the preview server | Decode inside the try; 400 instead of a dead process |
| Non-Unicode `\b` discards real endonyms | Letter lookarounds — `az` now shows "azərbaycan" |
| A failed build leaves a servable, broken tree | Staged in `_site.tmp`, swapped in only on success |
| UMD is copied but never fetched | Excluded from `_site/` — ~1.3 MB off the artifact |
| Nothing exercises the generators on a PR | `lint` runs the manifest generator (no `dist/` needed) |
| Site won't redeploy on a release | `release: published` trigger |
| `configure-pages` runs without a Pages scope | `pages: read` on the build job |

## Verified

- `npm test` 845 passing, `npm run lint` clean, `actionlint` clean.
- Failed generator → `site:build` exits 1, previous `_site/` intact, no `_site.tmp` left behind.
- `GET /` → 200, `GET /%` → 400, `GET /` → 200, server alive.
- Currency truth table replayed over the real manifest across all six reachable states: the contradiction row is gone.
- "Has options" 50 → 20; deep links resolve `#en`, `#en-KE`, `#zh`, `#zh-Hans-CN`, and reject unknown fragments.

## Not done, deliberately

**`dist/` built twice per push to main.** Real, but the two runs verify different things (published package contents vs. a deployable site) and folding them together entangles ci.yml's `cancel-in-progress: true` with the deploy's deliberate `false`. Left as a cost observation.

**Rollup target selector.** The UMD bundles are still *built* — the published package needs them. Only the copy into `_site/` was wasteful, and that's fixed.

---

Separately, verifying the docs turned up a Spanish bug, filed on its own: `toCardinal(101, { gender: 'feminine' })` returns `cienta una`, and "cienta" is not a Spanish word. It makes the `--gender` example in README and in `n2words --help` wrong.
