### PR TITLE
fix(es-ES,es-US): "ciento" is invariable, so 101 feminine is "ciento una"

### DIFF
--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -12,7 +12,7 @@
  * - Gender agreement: uno/una, veintiuno/veintiuna, hundreds
  * - Special twenties: veinte, veintiuno, veintidós, ... veintinueve
  * - "y" conjunction: treinta y uno (only 30-99 with ones)
- * - "cien" for exact 100, "ciento/cienta" otherwise
+ * - "cien" for exact 100, "ciento" otherwise ("ciento" is invariable; only 200-900 agree)
  * - Irregular hundreds: quinientos, setecientos, novecientos
  * - "un" before millón (not "uno"), omit before mil
  */
@@ -42,7 +42,7 @@ const TENS = ['', '', '', 'treinta', 'cuarenta', 'cincuenta', 'sesenta', 'setent
 
 // Irregular hundreds
 const HUNDREDS_MASC = ['', 'ciento', 'doscientos', 'trescientos', 'cuatrocientos', 'quinientos', 'seiscientos', 'setecientos', 'ochocientos', 'novecientos']
-const HUNDREDS_FEM = ['', 'cienta', 'doscientas', 'trescientas', 'cuatrocientas', 'quinientas', 'seiscientas', 'setecientas', 'ochocientas', 'novecientas']
+const HUNDREDS_FEM = ['', 'ciento', 'doscientas', 'trescientas', 'cuatrocientas', 'quinientas', 'seiscientas', 'setecientas', 'ochocientas', 'novecientas']
 
 // Scale words (compound long scale)
 const SCALES = ['millón', 'billón', 'trillón', 'cuatrillón']

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -12,7 +12,7 @@
  * - Gender agreement: uno/una, veintiuno/veintiuna, hundreds
  * - Special twenties: veinte, veintiuno, veintidós, ... veintinueve
  * - "y" conjunction: treinta y uno (only 30-99 with ones)
- * - "cien" for exact 100, "ciento/cienta" otherwise
+ * - "cien" for exact 100, "ciento" otherwise ("ciento" is invariable; only 200-900 agree)
  * - Irregular hundreds: quinientos, setecientos, novecientos
  * - "un" before millón (not "uno"), omit before mil
  */
@@ -42,7 +42,7 @@ const TENS = ['', '', '', 'treinta', 'cuarenta', 'cincuenta', 'sesenta', 'setent
 
 // Irregular hundreds
 const HUNDREDS_MASC = ['', 'ciento', 'doscientos', 'trescientos', 'cuatrocientos', 'quinientos', 'seiscientos', 'setecientos', 'ochocientos', 'novecientos']
-const HUNDREDS_FEM = ['', 'cienta', 'doscientas', 'trescientas', 'cuatrocientas', 'quinientas', 'seiscientas', 'setecientas', 'ochocientas', 'novecientas']
+const HUNDREDS_FEM = ['', 'ciento', 'doscientas', 'trescientas', 'cuatrocientas', 'quinientas', 'seiscientas', 'setecientas', 'ochocientas', 'novecientas']
 
 // Scale words (short scale - each scale is 10^3 apart)
 const SCALES = ['mil', 'millón', 'billón', 'trillón', 'cuatrillón', 'quintillón']

--- a/test/fixtures/es-ES.js
+++ b/test/fixtures/es-ES.js
@@ -91,8 +91,8 @@ export const cardinal = [
   [1, 'una', { gender: 'feminine' }],
   [21, 'veintiuna', { gender: 'feminine' }],
   [31, 'treinta y una', { gender: 'feminine' }],
-  [101, 'cienta una', { gender: 'feminine' }],
-  [121, 'cienta veintiuna', { gender: 'feminine' }],
+  [101, 'ciento una', { gender: 'feminine' }],
+  [121, 'ciento veintiuna', { gender: 'feminine' }],
   [201, 'doscientas una', { gender: 'feminine' }],
   [221, 'doscientas veintiuna', { gender: 'feminine' }],
   [300, 'trescientas', { gender: 'feminine' }],
@@ -106,7 +106,7 @@ export const cardinal = [
   [900, 'novecientas', { gender: 'feminine' }],
   [1001, 'mil una', { gender: 'feminine' }],
   [2001, 'dos mil una', { gender: 'feminine' }],
-  [2121, 'dos mil cienta veintiuna', { gender: 'feminine' }],
+  [2121, 'dos mil ciento veintiuna', { gender: 'feminine' }],
 ]
 
 /**

--- a/test/fixtures/es-MX.js
+++ b/test/fixtures/es-MX.js
@@ -106,8 +106,8 @@ export const cardinal = [
   [1, 'una', { gender: 'feminine' }],
   [21, 'veintiuna', { gender: 'feminine' }],
   [31, 'treinta y una', { gender: 'feminine' }],
-  [101, 'cienta una', { gender: 'feminine' }],
-  [121, 'cienta veintiuna', { gender: 'feminine' }],
+  [101, 'ciento una', { gender: 'feminine' }],
+  [121, 'ciento veintiuna', { gender: 'feminine' }],
   [201, 'doscientas una', { gender: 'feminine' }],
   [221, 'doscientas veintiuna', { gender: 'feminine' }],
   [300, 'trescientas', { gender: 'feminine' }],
@@ -121,7 +121,7 @@ export const cardinal = [
   [900, 'novecientas', { gender: 'feminine' }],
   [1001, 'mil una', { gender: 'feminine' }],
   [2001, 'dos mil una', { gender: 'feminine' }],
-  [2121, 'dos mil cienta veintiuna', { gender: 'feminine' }],
+  [2121, 'dos mil ciento veintiuna', { gender: 'feminine' }],
 ]
 
 /**

--- a/test/fixtures/es-US.js
+++ b/test/fixtures/es-US.js
@@ -50,7 +50,7 @@ export const cardinal = [
   [1, 'una', { gender: 'feminine' }],
   [21, 'veintiuna', { gender: 'feminine' }],
   [31, 'treinta y una', { gender: 'feminine' }],
-  [101, 'cienta una', { gender: 'feminine' }],
+  [101, 'ciento una', { gender: 'feminine' }],
   [201, 'doscientas una', { gender: 'feminine' }],
 ]
 


### PR DESCRIPTION
Found while verifying that the docs match what the library actually does.

```
$ npx n2words 101 -l es-ES --gender feminine
cienta una
```

"Cienta" is not a Spanish word. Only the hundreds from 200 to 900 agree in gender — *doscientas*, *trescientas*, *quinientas* — while **ciento is invariable**: "ciento una mujeres", never "cienta una". The feminine word-form array had position 1 inflected anyway.

Every feminine value from 101 to 199 was affected, at any scale:

| call | before | after |
| --- | --- | --- |
| `toCardinal(101, { gender: 'feminine' })` | cienta una | ciento una |
| `toCardinal(121, { gender: 'feminine' })` | cienta veintiuna | ciento veintiuna |
| `toCardinal(2121, { gender: 'feminine' })` | dos mil cienta veintiuna | dos mil ciento veintiuna |

Unaffected and unchanged: `cien` (exact 100, already correct), `doscientas una`, and every masculine form.

## Why this is also a docs fix

README's CLI section and the `n2words --help` output both use this exact call as their `--gender` example, and both advertise `ciento una`. They were describing correct Spanish that the library didn't produce — so this makes them true rather than requiring them to document the bug.

## Scope

`es-MX` is a locale profile of `es-ES` and inherits the fix; `es-US` is a full implementation with its own copy of the table and is fixed alongside. The fixtures asserted the wrong spelling and are corrected with it. 845 tests pass.

## Related, not fixed here

`toCardinal` doesn't apocopate *uno* before a scale word: `21000` returns "veintiuno mil" where standard Spanish is "veintiún mil", and `21000000` returns "veintiuno millones" for "veintiún millones". Same family of agreement bug, but a distinct rule touching the scale-word joining logic — worth its own change.
