### PR TITLE
ci: redeploy Pages via workflow_run, since a release event can't deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -14,19 +14,26 @@ env:
 #
 # Requires repository Settings -> Pages -> Source = "GitHub Actions".
 #
-# `release: published` is what redeploys after a release. release.yml commits
-# `chore(release): vX.Y.Z [skip ci]` and pushes it, and GitHub skips
+# `workflow_run` on Release is what redeploys after a release. release.yml
+# commits `chore(release): vX.Y.Z [skip ci]` and pushes it, and GitHub skips
 # push-triggered runs for a `[skip ci]` commit — so without this trigger the
 # site would keep serving the previous version's footer and bundles until some
-# unrelated push landed. The release is created with the release-bot App token,
-# not GITHUB_TOKEN, so the event does start a run; a release event checks out
-# the tag, which is that same chore(release) commit.
+# unrelated push landed.
+#
+# It has to be `workflow_run` and not `release: published`, which was tried
+# first and fails at the last step: the `github-pages` environment allows
+# deployments from `main` alone, and a release event runs against the tag, so
+# the site built for two minutes and was then rejected with "Tag v6.1.1 is not
+# allowed to deploy to github-pages". A `workflow_run` runs against the default
+# branch, which by then already carries the chore(release) commit the tag
+# points at — same tree, allowed ref.
 on:
   push:
     branches:
       - main
-  release:
-    types: [published]
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
   workflow_dispatch:
 
 # Never cancel a deploy in progress; queue behind it instead.
@@ -42,6 +49,11 @@ jobs:
     name: Build site
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    # A `workflow_run` fires on every Release outcome, including a failed one
+    # and the no-op "already at this version" skip. Only a successful release
+    # has anything new to publish; every other trigger runs unconditionally.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
 
     # `actions/configure-pages` calls the Pages API (`GET /repos/{o}/{r}/pages`)
     # to resolve the site's base URL, and a workflow-level `permissions:` block


### PR DESCRIPTION
Follow-up to the `release: published` trigger merged in #443 — it doesn't work, and the v6.1.1 release proved it.

The build succeeded and the deploy was rejected:

```
✓ Build site        2m38s
X Deploy to GitHub Pages  1s
  Tag "v6.1.1" is not allowed to deploy to github-pages due to
  environment protection rules.
```

The `github-pages` environment's deployment branch policy permits exactly one ref:

```
$ gh api repos/forzagreen/n2words/environments/github-pages/deployment-branch-policies
branch: main
```

A `release` event runs against the tag, so it can never satisfy that. A `workflow_run` on Release runs against the **default branch**, which by then already carries the `chore(release)` commit the tag points at — same tree, allowed ref — and needs no extra token scope, unlike dispatching pages.yml from release.yml.

`workflow_run` fires on every Release outcome, so the build job now skips failed runs and the no-op "already at this version" skip.

## Effect on v6.1.1

None on the published package — npm has 6.1.1, the tag and GitHub Release are correct. Only the site's redeploy was missed, so its footer still reads v6.1.0. Merging this triggers a push deploy that corrects it; the `workflow_run` path itself gets exercised at the next release.