### PR TITLE
fix(es-ES,es-US): apocopate "uno" before a noun — 21000 is "veintiún mil"

### DIFF
--- a/src/es-ES.js
+++ b/src/es-ES.js
@@ -14,7 +14,10 @@
  * - "y" conjunction: treinta y uno (only 30-99 with ones)
  * - "cien" for exact 100, "ciento" otherwise ("ciento" is invariable; only 200-900 agree)
  * - Irregular hundreds: quinientos, setecientos, novecientos
- * - "un" before millón (not "uno"), omit before mil
+ * - Apocopation: "uno" shortens to "un" before a masculine noun, and a scale
+ *   word or currency noun is exactly that — "veintiún mil", "treinta y un
+ *   millones", "veintiún euros". A multiplier of exactly 1 is dropped before
+ *   "mil" ("mil", not "un mil") but kept before "millón" ("un millón").
  */
 
 import { parseCardinalValue } from './utils/parse-cardinal.js'
@@ -31,12 +34,16 @@ import { es as CURRENCY_VOCAB, assertCurrencyExponent } from './utils/currency-v
 
 const ONES_MASC = ['', 'uno', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve']
 const ONES_FEM = ['', 'una', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve']
+// Apocopated masculine: only the ones digit changes, and only before a noun.
+// The feminine forms never apocopate ("veintiuna casas", "treinta y una casas").
+const ONES_MASC_APOC = ['', 'un', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve']
 
 const TEENS = ['diez', 'once', 'doce', 'trece', 'catorce', 'quince', 'dieciseis', 'diecisiete', 'dieciocho', 'diecinueve']
 
 // 20-29 have special compound forms
 const TWENTIES_MASC = ['veinte', 'veintiuno', 'veintidós', 'veintitrés', 'veinticuatro', 'veinticinco', 'veintiséis', 'veintisiete', 'veintiocho', 'veintinueve']
 const TWENTIES_FEM = ['veinte', 'veintiuna', 'veintidós', 'veintitrés', 'veinticuatro', 'veinticinco', 'veintiséis', 'veintisiete', 'veintiocho', 'veintinueve']
+const TWENTIES_MASC_APOC = ['veinte', 'veintiún', 'veintidós', 'veintitrés', 'veinticuatro', 'veinticinco', 'veintiséis', 'veintisiete', 'veintiocho', 'veintinueve']
 
 const TENS = ['', '', '', 'treinta', 'cuarenta', 'cincuenta', 'sesenta', 'setenta', 'ochenta', 'noventa']
 
@@ -85,9 +92,12 @@ const CURRENCY_CONNECTOR = 'con'
  * Builds segment word for 0-999.
  * @param {number} n - Segment value
  * @param {boolean} feminine - Use feminine forms
+ * @param {boolean} [apocopate] - The segment is immediately followed by a
+ *   masculine noun (a scale word, a currency name), so a trailing "uno"
+ *   shortens to "un" and "veintiuno" to "veintiún". Ignored when feminine.
  * @returns {string} Spanish word
  */
-function buildSegment(n, feminine) {
+function buildSegment(n, feminine, apocopate = false) {
   if (n === 0) return ''
 
   // Special case: exact 100 is "cien" (no gender)
@@ -97,6 +107,9 @@ function buildSegment(n, feminine) {
   const tens = Math.trunc(n / 10) % 10
   const hundreds = Math.trunc(n / 100)
   const tensOnes = n % 100
+
+  const masculineOnes = apocopate ? ONES_MASC_APOC : ONES_MASC
+  const masculineTwenties = apocopate ? TWENTIES_MASC_APOC : TWENTIES_MASC
 
   const parts = []
 
@@ -112,7 +125,7 @@ function buildSegment(n, feminine) {
   }
   else if (tensOnes < 10) {
     // Single digit
-    const onesArr = feminine ? ONES_FEM : ONES_MASC
+    const onesArr = feminine ? ONES_FEM : masculineOnes
     parts.push(onesArr[tensOnes])
   }
   else if (tensOnes < 20) {
@@ -121,7 +134,7 @@ function buildSegment(n, feminine) {
   }
   else if (tensOnes < 30) {
     // 20-29: special twenties
-    const twentiesArr = feminine ? TWENTIES_FEM : TWENTIES_MASC
+    const twentiesArr = feminine ? TWENTIES_FEM : masculineTwenties
     parts.push(twentiesArr[ones])
   }
   else {
@@ -130,7 +143,7 @@ function buildSegment(n, feminine) {
       parts.push(TENS[tens])
     }
     else {
-      const onesArr = feminine ? ONES_FEM : ONES_MASC
+      const onesArr = feminine ? ONES_FEM : masculineOnes
       parts.push(TENS[tens] + ' y ' + onesArr[ones])
     }
   }
@@ -176,14 +189,17 @@ function getScaleWord(scaleIndex, segment) {
  * Converts a non-negative integer to Spanish words.
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} feminine - Use feminine forms
+ * @param {boolean} [beforeNoun] - The whole number is followed by a noun (a
+ *   currency name), so its trailing segment apocopates: "veintiún euros".
+ *   A standalone numeral doesn't: toCardinal(21) is "veintiuno".
  * @returns {string} Spanish words
  */
-function integerToWords(n, feminine) {
+function integerToWords(n, feminine, beforeNoun = false) {
   if (n === 0n) return ZERO
 
   // Fast path: numbers < 1000
   if (n < 1000n) {
-    return buildSegment(Number(n), feminine)
+    return buildSegment(Number(n), feminine, beforeNoun)
   }
 
   // Fast path: numbers < 1,000,000 (thousands)
@@ -193,30 +209,25 @@ function integerToWords(n, feminine) {
 
     let result
     if (thousands === 1) {
-      // "mil" not "uno mil"
+      // "mil" not "un mil"
       result = THOUSAND
     }
     else {
-      // Use masculine for thousands segment, but check for "uno" → omit before mil
-      const thousandsWord = buildSegment(thousands, false)
-      // "uno mil" → "mil" (handled in joinSegments equivalent)
-      if (thousandsWord === 'uno' || thousandsWord === 'una') {
-        result = THOUSAND
-      }
-      else {
-        result = thousandsWord + ' ' + THOUSAND
-      }
+      // "mil" is a masculine noun to the multiplier in front of it: masculine
+      // forms regardless of the requested gender, and apocopated —
+      // "veintiún mil", "treinta y un mil".
+      result = buildSegment(thousands, false, true) + ' ' + THOUSAND
     }
 
     if (remainder > 0) {
-      result += ' ' + buildSegment(remainder, feminine)
+      result += ' ' + buildSegment(remainder, feminine, beforeNoun)
     }
 
     return result
   }
 
   // For numbers >= 1,000,000, use scale decomposition
-  return buildLargeNumberWords(n, feminine)
+  return buildLargeNumberWords(n, feminine, beforeNoun)
 }
 
 /**
@@ -224,9 +235,10 @@ function integerToWords(n, feminine) {
  * Uses BigInt division for faster segment extraction.
  * @param {bigint} n - Number >= 1,000,000
  * @param {boolean} feminine - Use feminine forms
+ * @param {boolean} [beforeNoun] - A noun follows the units segment
  * @returns {string} Spanish words
  */
-function buildLargeNumberWords(n, feminine) {
+function buildLargeNumberWords(n, feminine, beforeNoun = false) {
   // Extract segments using BigInt division (faster than string slicing)
   // Segments stored least-significant first (index 0 = ones, 1 = thousands, etc.)
   // Callers guard the magnitude (cardinalMax) before reaching here.
@@ -250,37 +262,24 @@ function buildLargeNumberWords(n, feminine) {
 
     if (i === 0) {
       // Units segment
-      result += buildSegment(Number(segment), feminine)
+      result += buildSegment(Number(segment), feminine, beforeNoun)
     }
-    else if (i === 1) {
-      // Thousands: omit "uno" before mil
-      if (segment === 1n) {
-        result += THOUSAND
-      }
-      else {
-        result += buildSegment(Number(segment), false) + ' ' + scaleWord
-      }
-    }
-    else if (i % 2 === 1) {
-      // Odd scale indices (3, 5, 7): "mil millones", "mil billones", etc.
-      // Omit "uno" before these compound scales
+    else if (i === 1 || i % 2 === 1) {
+      // Scales that start with "mil": THOUSAND itself, and the compound
+      // "mil millones" / "mil billones" tiers. A multiplier of exactly 1 is
+      // dropped ("mil", "mil millones" — never "un mil").
       if (segment === 1n) {
         result += scaleWord
       }
       else {
-        result += buildSegment(Number(segment), false) + ' ' + scaleWord
+        result += buildSegment(Number(segment), false, true) + ' ' + scaleWord
       }
     }
     else {
-      // Even scale indices (2, 4, 6): millón, billón, trillón
-      if (segment === 1n) {
-        // "un millón" not "uno millón"
-        result += 'un ' + scaleWord
-      }
-      else {
-        // Use masculine for scale segment
-        result += buildSegment(Number(segment), false) + ' ' + scaleWord
-      }
+      // Even scale indices (2, 4, 6): millón, billón, trillón. Here the
+      // multiplier is kept and apocopated — "un millón", "veintiún millones",
+      // "ciento un millones". getScaleWord already picked singular vs plural.
+      result += buildSegment(Number(segment), false, true) + ' ' + scaleWord
     }
   }
 
@@ -576,7 +575,7 @@ function toCurrency(value, options) {
       result += (majorFeminine ? 'una ' : 'un ') + major[0]
     }
     else {
-      result += integerToWords(euros, majorFeminine) + ' ' + major[1]
+      result += integerToWords(euros, majorFeminine, true) + ' ' + major[1]
     }
   }
 
@@ -589,7 +588,7 @@ function toCurrency(value, options) {
       result += (minorFeminine ? 'una ' : 'un ') + (/** @type {string[]} */ (minor))[0]
     }
     else {
-      result += integerToWords(centimos, minorFeminine) + ' ' + (/** @type {string[]} */ (minor))[1]
+      result += integerToWords(centimos, minorFeminine, true) + ' ' + (/** @type {string[]} */ (minor))[1]
     }
   }
 

--- a/src/es-US.js
+++ b/src/es-US.js
@@ -14,7 +14,10 @@
  * - "y" conjunction: treinta y uno (only 30-99 with ones)
  * - "cien" for exact 100, "ciento" otherwise ("ciento" is invariable; only 200-900 agree)
  * - Irregular hundreds: quinientos, setecientos, novecientos
- * - "un" before millón (not "uno"), omit before mil
+ * - Apocopation: "uno" shortens to "un" before a masculine noun, and a scale
+ *   word or currency noun is exactly that — "veintiún mil", "treinta y un
+ *   millones", "veintiún dólares". A multiplier of exactly 1 is dropped before
+ *   "mil" ("mil", not "un mil") but kept before "millón" ("un millón").
  */
 
 import { parseCardinalValue } from './utils/parse-cardinal.js'
@@ -31,12 +34,16 @@ import { es as CURRENCY_VOCAB, assertCurrencyExponent } from './utils/currency-v
 
 const ONES_MASC = ['', 'uno', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve']
 const ONES_FEM = ['', 'una', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve']
+// Apocopated masculine: only the ones digit changes, and only before a noun.
+// The feminine forms never apocopate ("veintiuna casas", "treinta y una casas").
+const ONES_MASC_APOC = ['', 'un', 'dos', 'tres', 'cuatro', 'cinco', 'seis', 'siete', 'ocho', 'nueve']
 
 const TEENS = ['diez', 'once', 'doce', 'trece', 'catorce', 'quince', 'dieciseis', 'diecisiete', 'dieciocho', 'diecinueve']
 
 // 20-29 have special compound forms
 const TWENTIES_MASC = ['veinte', 'veintiuno', 'veintidós', 'veintitrés', 'veinticuatro', 'veinticinco', 'veintiséis', 'veintisiete', 'veintiocho', 'veintinueve']
 const TWENTIES_FEM = ['veinte', 'veintiuna', 'veintidós', 'veintitrés', 'veinticuatro', 'veinticinco', 'veintiséis', 'veintisiete', 'veintiocho', 'veintinueve']
+const TWENTIES_MASC_APOC = ['veinte', 'veintiún', 'veintidós', 'veintitrés', 'veinticuatro', 'veinticinco', 'veintiséis', 'veintisiete', 'veintiocho', 'veintinueve']
 
 const TENS = ['', '', '', 'treinta', 'cuarenta', 'cincuenta', 'sesenta', 'setenta', 'ochenta', 'noventa']
 
@@ -82,9 +89,12 @@ const CURRENCY_CONNECTOR = 'con'
  * Builds segment word for 0-999.
  * @param {number} n - Segment value
  * @param {boolean} feminine - Use feminine forms
+ * @param {boolean} [apocopate] - The segment is immediately followed by a
+ *   masculine noun (a scale word, a currency name), so a trailing "uno"
+ *   shortens to "un" and "veintiuno" to "veintiún". Ignored when feminine.
  * @returns {string} Spanish word
  */
-function buildSegment(n, feminine) {
+function buildSegment(n, feminine, apocopate = false) {
   if (n === 0) return ''
 
   // Special case: exact 100 is "cien" (no gender)
@@ -94,6 +104,9 @@ function buildSegment(n, feminine) {
   const tens = Math.trunc(n / 10) % 10
   const hundreds = Math.trunc(n / 100)
   const tensOnes = n % 100
+
+  const masculineOnes = apocopate ? ONES_MASC_APOC : ONES_MASC
+  const masculineTwenties = apocopate ? TWENTIES_MASC_APOC : TWENTIES_MASC
 
   const parts = []
 
@@ -109,7 +122,7 @@ function buildSegment(n, feminine) {
   }
   else if (tensOnes < 10) {
     // Single digit
-    const onesArr = feminine ? ONES_FEM : ONES_MASC
+    const onesArr = feminine ? ONES_FEM : masculineOnes
     parts.push(onesArr[tensOnes])
   }
   else if (tensOnes < 20) {
@@ -118,7 +131,7 @@ function buildSegment(n, feminine) {
   }
   else if (tensOnes < 30) {
     // 20-29: special twenties
-    const twentiesArr = feminine ? TWENTIES_FEM : TWENTIES_MASC
+    const twentiesArr = feminine ? TWENTIES_FEM : masculineTwenties
     parts.push(twentiesArr[ones])
   }
   else {
@@ -127,7 +140,7 @@ function buildSegment(n, feminine) {
       parts.push(TENS[tens])
     }
     else {
-      const onesArr = feminine ? ONES_FEM : ONES_MASC
+      const onesArr = feminine ? ONES_FEM : masculineOnes
       parts.push(TENS[tens] + ' y ' + onesArr[ones])
     }
   }
@@ -143,14 +156,17 @@ function buildSegment(n, feminine) {
  * Converts a non-negative integer to Spanish words (short scale).
  * @param {bigint} n - Non-negative integer to convert
  * @param {boolean} feminine - Use feminine forms
+ * @param {boolean} [beforeNoun] - The whole number is followed by a noun (a
+ *   currency name), so its trailing segment apocopates: "veintiún dólares".
+ *   A standalone numeral doesn't: toCardinal(21) is "veintiuno".
  * @returns {string} Spanish words
  */
-function integerToWords(n, feminine) {
+function integerToWords(n, feminine, beforeNoun = false) {
   if (n === 0n) return ZERO
 
   // Fast path: numbers < 1000
   if (n < 1000n) {
-    return buildSegment(Number(n), feminine)
+    return buildSegment(Number(n), feminine, beforeNoun)
   }
 
   // Extract segments using BigInt division
@@ -173,27 +189,30 @@ function integerToWords(n, feminine) {
 
     if (i === 0) {
       // Units segment - use requested gender
-      result += buildSegment(Number(segment), feminine)
+      result += buildSegment(Number(segment), feminine, beforeNoun)
     }
     else if (i === 1) {
-      // Thousands: "mil" not "uno mil"
+      // Thousands: "mil" not "un mil". Otherwise the multiplier treats "mil"
+      // as the masculine noun it is — masculine forms whatever gender was
+      // requested, and apocopated: "veintiún mil", "treinta y un mil".
       if (segment === 1n) {
         result += SCALES[0]
       }
       else {
-        result += buildSegment(Number(segment), false) + ' ' + SCALES[0]
+        result += buildSegment(Number(segment), false, true) + ' ' + SCALES[0]
       }
     }
     else {
-      // Millions and above: "un millón", "dos millones", etc.
+      // Millions and above: "un millón", "veintiún millones", "ciento un
+      // millones" — the multiplier is kept and apocopated.
       // Callers guard the magnitude (cardinalMax) so scaleIndex stays in range.
       const scaleIndex = i - 1 // SCALES[1] = millón, SCALES[2] = billón, etc.
+      const multiplier = buildSegment(Number(segment), false, true)
       if (segment === 1n) {
-        // "un millón" not "uno millón"
-        result += 'un ' + SCALES[scaleIndex]
+        result += multiplier + ' ' + SCALES[scaleIndex]
       }
       else {
-        result += buildSegment(Number(segment), false) + ' ' + SCALES_PLURAL[scaleIndex]
+        result += multiplier + ' ' + SCALES_PLURAL[scaleIndex]
       }
     }
   }
@@ -474,7 +493,7 @@ function toCurrency(value, options) {
       result += (majorFeminine ? 'una ' : 'un ') + major[0]
     }
     else {
-      result += integerToWords(dollars, majorFeminine) + ' ' + major[1]
+      result += integerToWords(dollars, majorFeminine, true) + ' ' + major[1]
     }
   }
 
@@ -487,7 +506,7 @@ function toCurrency(value, options) {
       result += (minorFeminine ? 'una ' : 'un ') + (/** @type {string[]} */ (minor))[0]
     }
     else {
-      result += integerToWords(centavos, minorFeminine) + ' ' + (/** @type {string[]} */ (minor))[1]
+      result += integerToWords(centavos, minorFeminine, true) + ' ' + (/** @type {string[]} */ (minor))[1]
     }
   }
 

--- a/test/fixtures/es-ES.js
+++ b/test/fixtures/es-ES.js
@@ -87,6 +87,26 @@ export const cardinal = [
   [2_000_000_000_000_000_000_000_000n, 'dos cuatrillones'],
   [5_000_000_000_000_000_000_000_000n, 'cinco cuatrillones'],
 
+  // Apocopation: a segment ending in 1 that multiplies a scale word drops to
+  // "un"/"veintiún" — the scale word is the masculine noun it modifies.
+  [21_000, 'veintiún mil'],
+  [31_000, 'treinta y un mil'],
+  [101_000, 'ciento un mil'],
+  [121_000, 'ciento veintiún mil'],
+  [1_021_000, 'un millón veintiún mil'],
+  [21_000_001, 'veintiún millones uno'],
+  [21_000_000, 'veintiún millones'],
+  [101_000_000, 'ciento un millones'],
+  [21_000_000_000n, 'veintiún mil millones'],
+  [41_000_000_000n, 'cuarenta y un mil millones'],
+  [21_000_000_000_000n, 'veintiún billones'],
+  // ...but a numeral before "punto" is standalone and keeps the full form
+  // (as does a bare [21, 'veintiuno'], asserted above)
+  [21.21, 'veintiuno punto veintiuno'],
+  // Feminine never apocopates; the multiplier of "mil" is masculine either way
+  [21_000, 'veintiún mil', { gender: 'feminine' }],
+  [21_021, 'veintiún mil veintiuna', { gender: 'feminine' }],
+
   // Feminine gender tests
   [1, 'una', { gender: 'feminine' }],
   [21, 'veintiuna', { gender: 'feminine' }],
@@ -212,7 +232,9 @@ export const currency = [
   [1, 'un euro'],
   [2, 'dos euros'],
   [10, 'diez euros'],
-  [21, 'veintiuno euros'],
+  [21, 'veintiún euros'],
+  [31, 'treinta y un euros'],
+  [101, 'ciento un euros'],
   [100, 'cien euros'],
   [1000, 'mil euros'],
   [1000000, 'un millón euros'],
@@ -221,7 +243,7 @@ export const currency = [
   [0.01, 'un céntimo'],
   [0.02, 'dos céntimos'],
   [0.10, 'diez céntimos'],
-  [0.21, 'veintiuno céntimos'],
+  [0.21, 'veintiún céntimos'],
   [0.99, 'noventa y nueve céntimos'],
 
   // Euros and cents
@@ -231,6 +253,7 @@ export const currency = [
   [42.50, 'cuarenta y dos euros con cincuenta céntimos'],
   [100.99, 'cien euros con noventa y nueve céntimos'],
   [1234.56, 'mil doscientos treinta y cuatro euros con cincuenta y seis céntimos'],
+  [21.21, 'veintiún euros con veintiún céntimos'],
 
   // Without connector
   [42.50, 'cuarenta y dos euros cincuenta céntimos', { and: false }],

--- a/test/fixtures/es-MX.js
+++ b/test/fixtures/es-MX.js
@@ -189,7 +189,9 @@ export const currency = [
   [1, 'un peso'],
   [2, 'dos pesos'],
   [10, 'diez pesos'],
-  [21, 'veintiuno pesos'],
+  [21, 'veintiún pesos'],
+  [31, 'treinta y un pesos'],
+  [101, 'ciento un pesos'],
   [100, 'cien pesos'],
   [1000, 'mil pesos'],
   [1000000, 'un millón pesos'],
@@ -198,7 +200,7 @@ export const currency = [
   [0.01, 'un centavo'],
   [0.02, 'dos centavos'],
   [0.10, 'diez centavos'],
-  [0.21, 'veintiuno centavos'],
+  [0.21, 'veintiún centavos'],
   [0.99, 'noventa y nueve centavos'],
 
   // Pesos and centavos

--- a/test/fixtures/es-US.js
+++ b/test/fixtures/es-US.js
@@ -46,6 +46,23 @@ export const cardinal = [
   [1_000_000_000_000, 'un trillón'],
   [2_000_000_000_000, 'dos trillones'],
 
+  // Apocopation: a segment ending in 1 that multiplies a scale word drops to
+  // "un"/"veintiún" — the scale word is the masculine noun it modifies.
+  [21_000, 'veintiún mil'],
+  [31_000, 'treinta y un mil'],
+  [101_000, 'ciento un mil'],
+  [1_021_000, 'un millón veintiún mil'],
+  [21_000_000, 'veintiún millones'],
+  [101_000_000, 'ciento un millones'],
+  [21_000_000_000, 'veintiún billones'],
+  [41_000_000_000, 'cuarenta y un billones'],
+  // ...but a numeral before "punto" is standalone and keeps the full form
+  // (as does a bare [21, 'veintiuno'], asserted above)
+  [21.21, 'veintiuno punto veintiuno'],
+  // Feminine never apocopates; the multiplier of "mil" is masculine either way
+  [21_000, 'veintiún mil', { gender: 'feminine' }],
+  [21_021, 'veintiún mil veintiuna', { gender: 'feminine' }],
+
   // Feminine gender tests
   [1, 'una', { gender: 'feminine' }],
   [21, 'veintiuna', { gender: 'feminine' }],
@@ -89,7 +106,9 @@ export const currency = [
   [1, 'un dólar'],
   [2, 'dos dólares'],
   [10, 'diez dólares'],
-  [21, 'veintiuno dólares'],
+  [21, 'veintiún dólares'],
+  [31, 'treinta y un dólares'],
+  [101, 'ciento un dólares'],
   [100, 'cien dólares'],
   [1000, 'mil dólares'],
   [1000000, 'un millón dólares'],
@@ -98,7 +117,7 @@ export const currency = [
   [0.01, 'un centavo'],
   [0.02, 'dos centavos'],
   [0.10, 'diez centavos'],
-  [0.21, 'veintiuno centavos'],
+  [0.21, 'veintiún centavos'],
   [0.99, 'noventa y nueve centavos'],
 
   // Dollars and centavos
@@ -108,6 +127,7 @@ export const currency = [
   [42.50, 'cuarenta y dos dólares con cincuenta centavos'],
   [100.99, 'cien dólares con noventa y nueve centavos'],
   [1234.56, 'mil doscientos treinta y cuatro dólares con cincuenta y seis centavos'],
+  [21.21, 'veintiún dólares con veintiún centavos'],
 
   // Without connector
   [42.50, 'cuarenta y dos dólares cincuenta centavos', { and: false }],


### PR DESCRIPTION
Fixes #446.

Spanish shortens `uno` → `un` (and `veintiuno` → `veintiún`, `treinta y uno` → `treinta y un`) whenever the numeral immediately precedes a masculine noun. Every scale word and every currency name sits in exactly that position, but both Spanish implementations only special-cased a **bare** segment of 1 (`un millón`), so any segment merely **ending** in 1 kept the full form.

## Before → after

| input | 6.1.1 | this PR |
| --- | --- | --- |
| `toCardinal(21_000)` | `veintiuno mil` | `veintiún mil` |
| `toCardinal(31_000)` | `treinta y uno mil` | `treinta y un mil` |
| `toCardinal(21_000_000)` | `veintiuno millones` | `veintiún millones` |
| `toCardinal(101_000_000)` | `ciento uno millones` | `ciento un millones` |
| `toCardinal(21e9)` | `veintiuno mil millones` | `veintiún mil millones` |
| `toCurrency(21)` | `veintiuno euros` | `veintiún euros` |
| `toCurrency(0.21)` | `veintiuno céntimos` | `veintiún céntimos` |

## Approach

`buildSegment` takes an `apocopate` flag, set for every segment that multiplies a scale word; `integerToWords` takes `beforeNoun`, which carries it to the trailing segment when a currency name follows. Two vocabulary arrays (`ONES_MASC_APOC`, `TWENTIES_MASC_APOC`) hold the shortened forms, alongside the existing masculine/feminine pairs.

Deliberately unchanged:

- **Standalone numerals** keep the full form — `toCardinal(21)` is still `veintiuno`, and so is the tail of `veintiuno punto veintiuno`. Only the segments with a noun after them move.
- **Feminine never apocopates** — `veintiuna casas`, `treinta y una casas`. The flag is ignored when `gender: 'feminine'`.
- **A multiplier of exactly 1** is still dropped before `mil` (`mil`, not `un mil`) and before the compound tiers (`mil millones`), and still kept before `millón`.

`es-MX` and `es` inherit the fix as a locale profile and a bare-tag alias of `es-ES`.

## Verification

- `npm test` — 845 passing; stale fixtures in `es-ES` / `es-US` / `es-MX` corrected and 20 regression cases added.
- Differential run over 28k values across both variants and both genders: **all 5076 changed outputs differ from 6.1.1 only by that exact substitution** — no other word moved — and injectivity over `0..200k` still holds.
- Lint and `build:types` clean.